### PR TITLE
Fix install.sh: skip _shared directory in all skill loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,19 @@ install.ps1                         One-command setup (Windows PowerShell)
 
 ### One-liner (no clone needed)
 
+**macOS / Linux:**
+
 ```bash
 curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash -s -- --tool claude-code ~/my-project
 ```
 
-This downloads the repo to a temp directory, runs the installer, and cleans up. All `install.sh` flags work (`--tool`, `--symlink`, `--global`, `--force`).
+**Windows (PowerShell):**
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1))) -Tool claude-code -TargetDir .\my-project
+```
+
+Downloads the repo to a temp directory, runs the installer, and cleans up. All flags work (`--tool`, `--symlink`, `--global`, `--force`).
 
 ### Install script (from local clone)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,15 @@ install.ps1                         One-command setup (Windows PowerShell)
 
 ## 🚀 Quick start
 
-### Install script (recommended)
+### One-liner (no clone needed)
+
+```bash
+curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash -s -- --tool claude-code ~/my-project
+```
+
+This downloads the repo to a temp directory, runs the installer, and cleans up. All `install.sh` flags work (`--tool`, `--symlink`, `--global`, `--force`).
+
+### Install script (from local clone)
 
 ```bash
 # Install for a specific tool

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,45 @@
+# One-liner remote installer for Well-Architected Skills & Steering (Windows)
+# Usage: irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1 | iex
+# Then run: Install-WellArchitected -Tool claude-code -TargetDir C:\Projects\my-app
+#
+# Or as a true one-liner:
+# & ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1))) -Tool claude-code -TargetDir .\my-project
+
+param(
+    [string[]]$Tool = @("all"),
+    [string]$TargetDir = ".",
+    [switch]$Force,
+    [switch]$Global,
+    [switch]$Symlink
+)
+
+$ErrorActionPreference = "Stop"
+$repoUrl = "https://github.com/aws-samples/sample-well-architected-skills-and-steering/archive/refs/heads/main.zip"
+$tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "wa-skills-install-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+
+try {
+    Write-Host "Downloading Well-Architected Skills & Steering..."
+    $zipPath = "$tmpDir.zip"
+    Invoke-WebRequest -Uri $repoUrl -OutFile $zipPath -UseBasicParsing
+
+    Write-Host "Extracting..."
+    Expand-Archive -Path $zipPath -DestinationPath $tmpDir -Force
+    Remove-Item $zipPath
+
+    $extractedDir = Get-ChildItem $tmpDir -Directory | Select-Object -First 1
+
+    Write-Host "Running installer..."
+    $installArgs = @{
+        Tool      = $Tool
+        TargetDir = $TargetDir
+    }
+    if ($Force) { $installArgs.Force = $true }
+    if ($Global) { $installArgs.Global = $true }
+    if ($Symlink) { $installArgs.Symlink = $true }
+
+    & "$($extractedDir.FullName)\install.ps1" @installArgs
+}
+finally {
+    if (Test-Path $tmpDir) { Remove-Item $tmpDir -Recurse -Force }
+    if (Test-Path "$tmpDir.zip") { Remove-Item "$tmpDir.zip" -Force }
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# One-liner remote installer for Well-Architected Skills & Steering
+# Usage: curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash -s -- --tool claude-code ~/my-project
+set -euo pipefail
+
+REPO_URL="https://github.com/aws-samples/sample-well-architected-skills-and-steering/tarball/main"
+TMPDIR_PREFIX="wa-skills-install"
+
+cleanup() {
+  [[ -n "${TMPDIR:-}" ]] && rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+TMPDIR="$(mktemp -d -t "$TMPDIR_PREFIX.XXXXXX")"
+
+echo "Downloading Well-Architected Skills & Steering..."
+curl -sL "$REPO_URL" | tar xz -C "$TMPDIR" --strip-components=1
+
+echo "Running installer..."
+bash "$TMPDIR/install.sh" "$@"

--- a/install.ps1
+++ b/install.ps1
@@ -268,7 +268,8 @@ Write-Host "Scope:   $(if ($Global) { 'global' } else { 'project' })"
 Write-Host "Tools:   $($Tool -join ', ')"
 Write-Host ""
 
-$TargetDir = (Resolve-Path $TargetDir -ErrorAction SilentlyContinue)?.Path ?? $TargetDir
+$resolved = Resolve-Path $TargetDir -ErrorAction SilentlyContinue
+if ($resolved) { $TargetDir = $resolved.Path }
 
 $validTools = @("kiro", "claude-code", "cursor", "codex", "windsurf", "github-copilot", "cline", "gemini-cli", "antigravity", "junie", "amp", "devops-agent", "all")
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET_DIR="${1:-.}"
+TARGET_DIR="."
 
 usage() {
   cat <<EOF
@@ -74,7 +74,7 @@ copy_or_link() {
   local src="$1"
   local dest="$2"
 
-  mkdir -p "$(dirname "$dest")"
+  mkdir -p "$(dirname -- "$dest")"
 
   if [[ -e "$dest" || -L "$dest" ]] && [[ "$FORCE" != true ]]; then
     echo "  WARNING: $dest already exists."
@@ -111,6 +111,7 @@ install_kiro() {
   for skill_dir in "$SCRIPT_DIR/skills"/*/; do
     local skill_name
     skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
     copy_or_link "$skill_dir/SKILL.md" "$base/.kiro/skills/$skill_name/SKILL.md"
   done
   echo "  Done. Kiro will load steering automatically and skills on demand."
@@ -154,6 +155,7 @@ install_cursor() {
   for skill_dir in "$SCRIPT_DIR/skills"/*/; do
     local skill_name
     skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
     copy_or_link "$skill_dir/SKILL.md" "$base/.cursor/skills/$skill_name/SKILL.md"
   done
   echo "  Done. The well-architected rule is always-on; wa-review activates on demand."
@@ -173,6 +175,7 @@ install_codex() {
   for skill_dir in "$SCRIPT_DIR/skills"/*/; do
     local skill_name
     skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
     copy_or_link "$skill_dir/SKILL.md" "$base/skills/$skill_name/SKILL.md"
   done
   echo "  Done. Codex will read AGENTS.md and reference skills/ on demand."
@@ -192,6 +195,7 @@ install_windsurf() {
   for skill_dir in "$SCRIPT_DIR/skills"/*/; do
     local skill_name
     skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
     copy_or_link "$skill_dir/SKILL.md" "$base/skills/$skill_name/SKILL.md"
   done
   echo "  Done. Windsurf will load .windsurfrules automatically."
@@ -224,6 +228,7 @@ install_cline() {
   for skill_dir in "$SCRIPT_DIR/skills"/*/; do
     local skill_name
     skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
     copy_or_link "$skill_dir/SKILL.md" "$base/skills/$skill_name/SKILL.md"
   done
   echo "  Done. Cline will load .clinerules automatically."
@@ -243,6 +248,7 @@ install_gemini_cli() {
   for skill_dir in "$SCRIPT_DIR/skills"/*/; do
     local skill_name
     skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
     copy_or_link "$skill_dir/SKILL.md" "$base/skills/$skill_name/SKILL.md"
   done
   echo "  Done. Gemini CLI will load GEMINI.md automatically and reference skills/ on demand."
@@ -260,6 +266,7 @@ install_antigravity() {
     for skill_dir in "$SCRIPT_DIR/skills"/*/; do
       local skill_name
       skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
       copy_or_link "$skill_dir/SKILL.md" "$HOME/.gemini/skills/$skill_name/SKILL.md"
     done
     echo "  Done. Global rules installed to ~/.gemini/GEMINI.md."
@@ -276,6 +283,7 @@ install_antigravity() {
     for skill_dir in "$SCRIPT_DIR/skills"/*/; do
       local skill_name
       skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
       copy_or_link "$skill_dir/SKILL.md" "$base/.agents/skills/$skill_name/SKILL.md"
     done
     echo "  Done. Workspace rules in .agents/rules/ and skills in .agents/skills/."


### PR DESCRIPTION
## Summary
The `skills/_shared/` directory has no `SKILL.md` file, causing `cp: No such file or directory` errors when running `--tool all`. Only 3 of 11 loops had the `_shared` skip — now all do.

## Test plan
- [x] `./install.sh /tmp/test --tool all --force` completes with no errors