### PR TITLE
Default one-liner to auto-detect tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,16 +76,24 @@ install.ps1                         One-command setup (Windows PowerShell)
 **macOS / Linux:**
 
 ```bash
-curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash -s -- --tool claude-code ~/my-project
+# Auto-detects your AI tools and installs for all of them
+curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash
+
+# Or specify a tool explicitly
+curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash -s -- --tool claude-code
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1))) -Tool claude-code -TargetDir .\my-project
+# Auto-detects your AI tools and installs for all of them
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1)))
+
+# Or specify a tool explicitly
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1))) -Tool claude-code
 ```
 
-Downloads the repo to a temp directory, runs the installer, and cleans up. All flags work (`--tool`, `--symlink`, `--global`, `--force`).
+Downloads the repo to a temp directory, auto-detects your AI tools (`.cursor/`, `.claude/`, `.kiro/`, etc.), installs, and cleans up. Pass flags to override: `--tool`, `--symlink`, `--global`, `--force`.
 
 ### Install script (from local clone)
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -6,11 +6,12 @@
 #
 # Or as a true one-liner:
 # & ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1))) -Tool claude-code -TargetDir .\my-project
+# Defaults to --tool auto with --force in current directory (auto-detects installed AI tools)
 
 param(
-    [string[]]$Tool = @("all"),
+    [string[]]$Tool = @("auto"),
     [string]$TargetDir = ".",
-    [switch]$Force,
+    [switch]$Force = $true,
     [switch]$Global,
     [switch]$Symlink
 )

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,7 +2,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 # One-liner remote installer for Well-Architected Skills & Steering
-# Usage: curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash -s -- --tool claude-code ~/my-project
+# Usage: curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash
+# Defaults to --tool auto in current directory (auto-detects installed AI tools)
 set -euo pipefail
 
 REPO_URL="https://github.com/aws-samples/sample-well-architected-skills-and-steering/tarball/main"
@@ -19,4 +20,8 @@ echo "Downloading Well-Architected Skills & Steering..."
 curl -sL "$REPO_URL" | tar xz -C "$TMPDIR" --strip-components=1
 
 echo "Running installer..."
-bash "$TMPDIR/install.sh" "$@"
+if [[ $# -eq 0 ]]; then
+  bash "$TMPDIR/install.sh" --tool auto --force
+else
+  bash "$TMPDIR/install.sh" "$@"
+fi


### PR DESCRIPTION
## Summary
The bootstrap one-liner now defaults to `--tool auto --force` when run with no arguments. It auto-detects which AI tools are present in the current directory and installs for all of them.

**Before:**
```bash
curl -sL .../bootstrap.sh | bash -s -- --tool claude-code ~/my-project
```

**After:**
```bash
curl -sL .../bootstrap.sh | bash
```

You can still pass explicit flags to override the defaults.

## Test plan
- [ ] `curl ... | bash` with no args in a project with `.cursor/` and `.claude/` installs for both
- [ ] `curl ... | bash -s -- --tool kiro` still works as explicit override

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*