### PR TITLE
Add platform labels to one-liner code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ install.ps1                         One-command setup (Windows PowerShell)
 
 ### One-liner (no clone needed)
 
+**macOS / Linux:**
+
 ```bash
 curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash
 ```
+
+**Windows (PowerShell):**
 
 ```powershell
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1)))
@@ -89,7 +93,7 @@ To install for a specific tool instead:
 # macOS / Linux
 curl -sL .../bootstrap.sh | bash -s -- --tool kiro
 
-# Windows
+# Windows (PowerShell)
 & ([scriptblock]::Create((irm .../bootstrap.ps1))) -Tool kiro
 ```
 


### PR DESCRIPTION
## Summary
Add **macOS / Linux:** and **Windows (PowerShell):** labels above each code block in the one-liner section so readers know which command is for their platform.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*