### PR TITLE
Add automated eval runner powered by Amazon Bedrock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .kiro/
 .claude/
 CLAUDE.md
+evals/results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,12 @@ Open an issue on GitHub describing the problem, including which steering file or
    - Step-by-step instructions that Kiro can follow
    - A structured output template
    - Cross-references to relevant sections in `steering/well-architected.md`
-3. Open a pull request with a description of what the skill does and which WA pillar(s) it covers.
+3. Add evaluations in `skills/my-new-skill/evals/evals.json`:
+   - Include at least 3 test cases with realistic user prompts
+   - Each case should have 5–7 concrete assertions (gradable as PASS/FAIL)
+   - Cover a range of scenarios: critical gaps, well-architected baselines, and edge cases
+   - Run `uv run python run.py --skill my-new-skill --verbose` from the `evals/` directory to verify skill impact
+4. Open a pull request with a description of what the skill does and which WA pillar(s) it covers.
 
 ### Modifying a Steering File
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ adapters/                           Tool-specific configuration
   amp/                                .agents/skills/*.md
   devops-agent/                       Packaging for AWS DevOps Agent
 
+evals/                              Automated evaluation runner (Bedrock)
+  run.py                              CLI entry point
+  grade.py                            LLM-as-judge grader
+  report.py                           Scoring and terminal output
+  config.yaml                         Bedrock region and model config
+  pyproject.toml                      Dependencies (use uv sync)
+
 install.sh                          One-command setup (macOS/Linux)
 install.ps1                         One-command setup (Windows PowerShell)
 ```
@@ -155,10 +162,20 @@ curl -sL .../bootstrap.sh | bash -s -- --tool kiro
 <details>
 <summary><strong>🔹 Kiro</strong></summary>
 
+macOS / Linux:
+
 ```bash
 mkdir -p .kiro/steering .kiro/skills
 cp path/to/this-repo/steering/well-architected.md .kiro/steering/
 cp -r path/to/this-repo/skills/* .kiro/skills/
+```
+
+Windows (PowerShell):
+
+```powershell
+New-Item -ItemType Directory -Force -Path .kiro\steering, .kiro\skills
+Copy-Item path\to\this-repo\steering\well-architected.md .kiro\steering\
+Copy-Item -Recurse path\to\this-repo\skills\* .kiro\skills\
 ```
 
 </details>
@@ -166,9 +183,18 @@ cp -r path/to/this-repo/skills/* .kiro/skills/
 <details>
 <summary><strong>🔹 Claude Code</strong></summary>
 
+macOS / Linux:
+
 ```bash
 cp path/to/this-repo/adapters/claude-code/CLAUDE.md ./CLAUDE.md
 cp -r path/to/this-repo/adapters/claude-code/commands .claude/commands
+```
+
+Windows (PowerShell):
+
+```powershell
+Copy-Item path\to\this-repo\adapters\claude-code\CLAUDE.md .\CLAUDE.md
+Copy-Item -Recurse path\to\this-repo\adapters\claude-code\commands .claude\commands
 ```
 
 </details>
@@ -176,8 +202,16 @@ cp -r path/to/this-repo/adapters/claude-code/commands .claude/commands
 <details>
 <summary><strong>🔹 Cursor</strong></summary>
 
+macOS / Linux:
+
 ```bash
 cp -r path/to/this-repo/adapters/cursor/rules .cursor/rules
+```
+
+Windows (PowerShell):
+
+```powershell
+Copy-Item -Recurse path\to\this-repo\adapters\cursor\rules .cursor\rules
 ```
 
 </details>
@@ -185,9 +219,18 @@ cp -r path/to/this-repo/adapters/cursor/rules .cursor/rules
 <details>
 <summary><strong>🔹 Codex (OpenAI)</strong></summary>
 
+macOS / Linux:
+
 ```bash
 cp path/to/this-repo/adapters/codex/AGENTS.md ./AGENTS.md
 cp -r path/to/this-repo/skills ./skills
+```
+
+Windows (PowerShell):
+
+```powershell
+Copy-Item path\to\this-repo\adapters\codex\AGENTS.md .\AGENTS.md
+Copy-Item -Recurse path\to\this-repo\skills .\skills
 ```
 
 </details>
@@ -195,8 +238,16 @@ cp -r path/to/this-repo/skills ./skills
 <details>
 <summary><strong>🔹 Windsurf</strong></summary>
 
+macOS / Linux:
+
 ```bash
 cp path/to/this-repo/adapters/windsurf/.windsurfrules ./.windsurfrules
+```
+
+Windows (PowerShell):
+
+```powershell
+Copy-Item path\to\this-repo\adapters\windsurf\.windsurfrules .\.windsurfrules
 ```
 
 </details>
@@ -204,9 +255,18 @@ cp path/to/this-repo/adapters/windsurf/.windsurfrules ./.windsurfrules
 <details>
 <summary><strong>🔹 GitHub Copilot</strong></summary>
 
+macOS / Linux:
+
 ```bash
 mkdir -p .github
 cp path/to/this-repo/adapters/github-copilot/.github/copilot-instructions.md .github/
+```
+
+Windows (PowerShell):
+
+```powershell
+New-Item -ItemType Directory -Force -Path .github
+Copy-Item path\to\this-repo\adapters\github-copilot\.github\copilot-instructions.md .github\
 ```
 
 </details>
@@ -214,15 +274,26 @@ cp path/to/this-repo/adapters/github-copilot/.github/copilot-instructions.md .gi
 <details>
 <summary><strong>🔹 Gemini CLI</strong></summary>
 
+macOS / Linux:
+
 ```bash
 cp path/to/this-repo/adapters/gemini-cli/GEMINI.md ./GEMINI.md
 cp -r path/to/this-repo/skills ./skills
+```
+
+Windows (PowerShell):
+
+```powershell
+Copy-Item path\to\this-repo\adapters\gemini-cli\GEMINI.md .\GEMINI.md
+Copy-Item -Recurse path\to\this-repo\skills .\skills
 ```
 
 </details>
 
 <details>
 <summary><strong>🔹 Antigravity</strong></summary>
+
+macOS / Linux:
 
 ```bash
 mkdir -p .agents/rules .agents/skills
@@ -234,10 +305,23 @@ for skill_dir in path/to/this-repo/skills/*/; do
 done
 ```
 
+Windows (PowerShell):
+
+```powershell
+New-Item -ItemType Directory -Force -Path .agents\rules, .agents\skills
+Copy-Item -Recurse path\to\this-repo\adapters\antigravity\rules\* .agents\rules\
+Get-ChildItem path\to\this-repo\skills -Directory | ForEach-Object {
+    New-Item -ItemType Directory -Force -Path ".agents\skills\$($_.Name)"
+    Copy-Item "$($_.FullName)\SKILL.md" ".agents\skills\$($_.Name)\SKILL.md"
+}
+```
+
 </details>
 
 <details>
 <summary><strong>🔹 Junie (JetBrains)</strong></summary>
+
+macOS / Linux:
 
 ```bash
 mkdir -p .junie/guidelines .junie/skills
@@ -245,10 +329,20 @@ cp path/to/this-repo/adapters/junie/guidelines.md .junie/guidelines/well-archite
 cp -r path/to/this-repo/skills/* .junie/skills/
 ```
 
+Windows (PowerShell):
+
+```powershell
+New-Item -ItemType Directory -Force -Path .junie\guidelines, .junie\skills
+Copy-Item path\to\this-repo\adapters\junie\guidelines.md .junie\guidelines\well-architected.md
+Copy-Item -Recurse path\to\this-repo\skills\* .junie\skills\
+```
+
 </details>
 
 <details>
 <summary><strong>🔹 Amp</strong></summary>
+
+macOS / Linux:
 
 ```bash
 cp path/to/this-repo/adapters/amp/AGENTS.md ./AGENTS.md
@@ -256,13 +350,29 @@ mkdir -p .agents/skills
 cp -r path/to/this-repo/skills/* .agents/skills/
 ```
 
+Windows (PowerShell):
+
+```powershell
+Copy-Item path\to\this-repo\adapters\amp\AGENTS.md .\AGENTS.md
+New-Item -ItemType Directory -Force -Path .agents\skills
+Copy-Item -Recurse path\to\this-repo\skills\* .agents\skills\
+```
+
 </details>
 
 <details>
 <summary><strong>🔹 Cline</strong></summary>
 
+macOS / Linux:
+
 ```bash
 cp path/to/this-repo/adapters/cline/.clinerules ./.clinerules
+```
+
+Windows (PowerShell):
+
+```powershell
+Copy-Item path\to\this-repo\adapters\cline\.clinerules .\.clinerules
 ```
 
 </details>
@@ -270,10 +380,20 @@ cp path/to/this-repo/adapters/cline/.clinerules ./.clinerules
 <details>
 <summary><strong>🔹 AWS DevOps Agent</strong></summary>
 
+macOS / Linux:
+
 ```bash
 # Package all skills as zip files for upload to your Agent Space
 ./install.sh ~/output-dir --tool devops-agent
 # Then upload each .zip from ~/output-dir/devops-agent-skills/ via the Operator Web App
+```
+
+Windows (PowerShell):
+
+```powershell
+# Package all skills as zip files for upload to your Agent Space
+.\install.ps1 -TargetDir C:\output-dir -Tool devops-agent
+# Then upload each .zip from C:\output-dir\devops-agent-skills\ via the Operator Web App
 ```
 
 </details>
@@ -364,14 +484,106 @@ If configured correctly, it will reference all six pillars with specific guidanc
 Each skill includes structured evaluations in `skills/*/evals/evals.json` following the [Agent Skills eval spec](https://agentskills.io/skill-creation/evaluating-skills). Evals let you measure whether the skills produce better outputs than a bare agent.
 
 Each test case includes:
+
 - A realistic user prompt
 - Expected output description
 - 5-7 concrete assertions (gradable as PASS/FAIL)
 
-To run evals, execute each prompt **with** and **without** the skill loaded, then grade the assertions against the outputs. See the spec for the full workflow including grading, benchmarking, and iteration.
+### Automated eval runner
+
+The `evals/` directory contains an automated evaluation runner powered by **Amazon Bedrock**.
+
+**Prerequisites:**
+
+- Python 3.13+ and [uv](https://docs.astral.sh/uv/)
+- AWS credentials configured with Bedrock access (`aws configure` or SSO)
+- Bedrock model access enabled for Claude Sonnet and Haiku in your region
+
+**Setup:**
+
+```bash
+cd evals
+uv sync
+```
+
+**Run evaluations:**
+
+macOS / Linux:
+
+```bash
+# List available skills
+uv run python run.py --list
+
+# Evaluate a single skill
+uv run python run.py --skill wa-review
+
+# Evaluate all skills
+uv run python run.py
+
+# Verbose output (shows per-assertion grades)
+uv run python run.py --skill security-assessment --verbose
+
+# Save results for historical tracking
+uv run python run.py --save
+```
+
+Windows (PowerShell):
+
+```powershell
+# List available skills
+uv run python run.py --list
+
+# Evaluate a single skill
+uv run python run.py --skill wa-review
+
+# Evaluate all skills
+uv run python run.py
+
+# Verbose output (shows per-assertion grades)
+uv run python run.py --skill security-assessment --verbose
+
+# Save results for historical tracking
+uv run python run.py --save
+```
+
+> [!NOTE]
+> On Windows, ensure your AWS credentials are configured via `aws configure` or environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`). If using AWS IAM Identity Center (SSO), run `aws sso login --profile your-profile` first.
+
+**How it works:**
+
+1. For each test case, generates two responses via Bedrock Converse API:
+   - **Baseline** — prompt only, no skill context
+   - **With skill** — prompt + SKILL.md injected as system context
+2. An LLM-as-judge grades each assertion as PASS/FAIL against both outputs
+3. Reports a score comparison showing the skill's impact
+
+**Configuration** (`evals/config.yaml`):
+
+```yaml
+provider: bedrock
+region: us-east-1
+generation_model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+grading_model: us.anthropic.claude-haiku-4-5-20251001-v1:0
+```
+
+**Estimated cost per run:**
+
+| Scope | Generation calls | Grading calls | Estimated cost |
+| ----- | ---------------- | ------------- | -------------- |
+| Single skill (3 cases) | 6 (Sonnet) | 6 (Haiku) | ~$0.10 – $0.15 |
+| All 9 skills (27 cases) | 54 (Sonnet) | 54 (Haiku) | ~$0.80 – $1.20 |
+
+Cost breakdown assumes ~1K input tokens and ~2K output tokens per generation call, and ~3K input / ~500 output per grading call. Actual cost depends on response length and Bedrock pricing in your region. The `max_cost_usd` setting in config.yaml acts as a soft budget guard.
 
 > [!TIP]
-> Start by running a single eval manually. Compare the with-skill and without-skill outputs side by side — the difference in structure and specificity is usually immediately obvious.
+> **Experiment with other models!** The eval runner works with any model available in Bedrock — try Amazon Nova, Meta Llama, Mistral, or others to see how different foundation models respond to skill guidance. Use the discovery utility to see what's available in your region:
+>
+> `uv run python list_models.py`
+>
+> Then update `generation_model` in `config.yaml` to try a different model. The grading model should remain a strong model (Claude Sonnet/Haiku) for reliable assertion grading.
+
+> [!TIP]
+> Start by running a single skill eval (`--skill wa-review --verbose`) to see detailed per-assertion grading. The delta between baseline and with-skill scores quantifies the value each skill adds.
 
 ---
 
@@ -399,7 +611,6 @@ This project is licensed under the [MIT-0 License](LICENSE).
 ## 📚 Related Resources
 
 - [AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html)
-- [AWS Well-Architected Tool](https://aws.amazon.com/well-architected-tool/)
 - [Kiro — AI-powered IDE](https://kiro.dev)
 - [AWS DevOps Agent](https://docs.aws.amazon.com/devopsagent/latest/userguide/)
 - [Agent Skills Specification](https://agentskills.io/)

--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/evals/config.yaml
+++ b/evals/config.yaml
@@ -1,0 +1,14 @@
+provider: bedrock
+region: us-east-1
+
+generation_model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+grading_model: us.anthropic.claude-haiku-4-5-20251001-v1:0
+
+temperature: 0
+max_tokens: 4096
+
+# Number of times to run each eval (higher = more stable scores, higher cost)
+runs_per_eval: 5
+
+# Cost guard: maximum spend per run in USD (approximate)
+max_cost_usd: 10.0

--- a/evals/grade.py
+++ b/evals/grade.py
@@ -1,0 +1,92 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+LLM-as-judge grader for eval assertions.
+
+Takes a model output and a list of assertions, asks a grading model
+to evaluate each assertion as PASS or FAIL with justification.
+"""
+
+import json
+
+import boto3
+
+
+GRADING_PROMPT = """You are an evaluation grader. Your job is to determine whether a given output satisfies specific assertions.
+
+For each assertion, respond with a JSON object containing:
+- "assertion": the assertion text
+- "pass": true or false
+- "reason": a one-sentence justification
+
+Respond ONLY with a JSON array of these objects, no other text.
+
+## Output to evaluate
+
+{output}
+
+## Assertions to grade
+
+{assertions}
+"""
+
+
+def grade_response(config: dict, output: str, assertions: list[str]) -> list[dict]:
+    """
+    Grade a response against a list of assertions using LLM-as-judge.
+
+    Returns a list of dicts: [{"assertion": str, "pass": bool, "reason": str}, ...]
+    """
+    assertions_text = "\n".join(f"{i+1}. {a}" for i, a in enumerate(assertions))
+
+    prompt = GRADING_PROMPT.format(
+        output=output,
+        assertions=assertions_text,
+    )
+
+    client = boto3.client("bedrock-runtime", region_name=config["region"])
+
+    response = client.converse(
+        modelId=config["grading_model"],
+        messages=[{"role": "user", "content": [{"text": prompt}]}],
+        inferenceConfig={
+            "temperature": 0,
+            "maxTokens": 2048,
+        },
+    )
+
+    raw = response["output"]["message"]["content"][0]["text"]
+
+    try:
+        grades = json.loads(raw)
+    except json.JSONDecodeError:
+        # Try to extract JSON from the response if wrapped in markdown
+        import re
+        match = re.search(r"\[.*\]", raw, re.DOTALL)
+        if match:
+            grades = json.loads(match.group())
+        else:
+            # Fallback: mark all as failed with parse error
+            grades = [
+                {"assertion": a, "pass": False, "reason": "Failed to parse grader response"}
+                for a in assertions
+            ]
+
+    # Normalize: ensure each grade has the right keys
+    normalized = []
+    for i, assertion in enumerate(assertions):
+        if i < len(grades):
+            g = grades[i]
+            normalized.append({
+                "assertion": assertion,
+                "pass": bool(g.get("pass", False)),
+                "reason": g.get("reason", "No reason provided"),
+            })
+        else:
+            normalized.append({
+                "assertion": assertion,
+                "pass": False,
+                "reason": "Grader did not return result for this assertion",
+            })
+
+    return normalized

--- a/evals/list_models.py
+++ b/evals/list_models.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+List available Bedrock models that support the Converse API.
+
+Helps you discover models to experiment with in evals.
+Usage:
+    uv run python list_models.py
+    uv run python list_models.py --region us-west-2
+    uv run python list_models.py --filter llama
+"""
+
+import argparse
+
+import boto3
+import yaml
+
+CONFIG_PATH = "config.yaml"
+
+
+def load_config() -> dict:
+    with open(CONFIG_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def list_models(region: str, filter_text: str | None = None) -> None:
+    client = boto3.client("bedrock", region_name=region)
+
+    print(f"\n  Available Bedrock models in {region}")
+    print(f"  {'='*60}\n")
+
+    # List inference profiles (cross-region and on-demand)
+    profiles = client.list_inference_profiles()
+    profile_ids = {p["inferenceProfileId"] for p in profiles.get("inferenceProfileSummaries", [])}
+
+    # List foundation models with Converse support
+    response = client.list_foundation_models()
+    models = response.get("modelSummaries", [])
+
+    # Filter to models that support converse
+    converse_models = [
+        m for m in models
+        if "CONVERSE" in m.get("inferenceTypesSupported", [])
+        or "ON_DEMAND" in m.get("inferenceTypesSupported", [])
+    ]
+
+    if filter_text:
+        filter_lower = filter_text.lower()
+        converse_models = [
+            m for m in converse_models
+            if filter_lower in m.get("modelId", "").lower()
+            or filter_lower in m.get("providerName", "").lower()
+            or filter_lower in m.get("modelName", "").lower()
+        ]
+
+    # Group by provider
+    by_provider: dict[str, list] = {}
+    for m in converse_models:
+        provider = m.get("providerName", "Unknown")
+        by_provider.setdefault(provider, []).append(m)
+
+    for provider in sorted(by_provider.keys()):
+        print(f"  {provider}")
+        print(f"  {'-'*40}")
+        for m in sorted(by_provider[provider], key=lambda x: x["modelId"]):
+            model_id = m["modelId"]
+            name = m.get("modelName", "")
+            status = "✓ active" if m.get("modelLifecycle", {}).get("status") == "ACTIVE" else ""
+            print(f"    {model_id:<55} {name:<25} {status}")
+        print()
+
+    # Also show inference profiles
+    if profile_ids:
+        filtered_profiles = profile_ids
+        if filter_text:
+            filter_lower = filter_text.lower()
+            filtered_profiles = {p for p in profile_ids if filter_lower in p.lower()}
+
+        if filtered_profiles:
+            print(f"  Inference Profiles (cross-region)")
+            print(f"  {'-'*40}")
+            for pid in sorted(filtered_profiles):
+                print(f"    {pid}")
+            print()
+
+    config = load_config()
+    print(f"  Current config:")
+    print(f"    generation_model: {config.get('generation_model', 'not set')}")
+    print(f"    grading_model:    {config.get('grading_model', 'not set')}")
+    print(f"\n  To use a different model, update evals/config.yaml")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List available Bedrock models for eval experimentation")
+    parser.add_argument("--region", type=str, default=None, help="AWS region (default: from config.yaml)")
+    parser.add_argument("--filter", type=str, default=None, help="Filter by provider or model name (e.g., 'llama', 'nova', 'mistral')")
+    args = parser.parse_args()
+
+    config = load_config()
+    region = args.region or config.get("region", "us-east-1")
+
+    list_models(region, args.filter)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/pyproject.toml
+++ b/evals/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "wa-skill-evals"
+version = "0.1.0"
+description = "Automated evaluation runner for Well-Architected skills using Amazon Bedrock"
+requires-python = ">=3.13"
+dependencies = [
+    "boto3>=1.35.0",
+    "pyyaml>=6.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/evals/report.py
+++ b/evals/report.py
@@ -1,0 +1,88 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+Scoring aggregation and terminal reporting for eval results.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+RESULTS_DIR = Path(__file__).parent / "results"
+
+
+def print_report(all_results: list[dict]) -> None:
+    """Print a formatted summary table to the terminal."""
+    print("\n")
+    print("=" * 72)
+    print("  EVALUATION RESULTS")
+    print("=" * 72)
+
+    # Header
+    print(f"\n  {'Skill':<35} {'Baseline':>10} {'W/ Skill':>10} {'Delta':>8}")
+    print(f"  {'-'*35} {'-'*10} {'-'*10} {'-'*8}")
+
+    total_baseline = 0
+    total_skill = 0
+    count = 0
+
+    for result in all_results:
+        agg = result["aggregate"]
+        baseline = agg["baseline_avg"]
+        skill = agg["skill_avg"]
+        delta = agg["delta"]
+
+        total_baseline += baseline
+        total_skill += skill
+        count += 1
+
+        delta_str = f"+{delta:.0%}" if delta >= 0 else f"{delta:.0%}"
+        print(f"  {result['skill_name']:<35} {baseline:>9.0%} {skill:>9.0%} {delta_str:>8}")
+
+    if count > 1:
+        avg_baseline = total_baseline / count
+        avg_skill = total_skill / count
+        avg_delta = avg_skill - avg_baseline
+        delta_str = f"+{avg_delta:.0%}" if avg_delta >= 0 else f"{avg_delta:.0%}"
+
+        print(f"  {'-'*35} {'-'*10} {'-'*10} {'-'*8}")
+        print(f"  {'AVERAGE':<35} {avg_baseline:>9.0%} {avg_skill:>9.0%} {delta_str:>8}")
+
+    print(f"\n{'='*72}")
+
+    # Per-case breakdown
+    for result in all_results:
+        print(f"\n  {result['skill_name']}")
+        for case in result["cases"]:
+            b_score = case["baseline"]["score"]
+            s_score = case["with_skill"]["score"]
+            print(f"    Case {case['id']}: {b_score:.0%} → {s_score:.0%}  |  {case['prompt'][:50]}...")
+
+    print()
+
+
+def save_results(all_results: list[dict]) -> Path:
+    """Save results as timestamped JSON for historical tracking."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_path = RESULTS_DIR / f"eval_{timestamp}.json"
+
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "results": all_results,
+        "summary": {
+            skill["skill_name"]: {
+                "baseline": skill["aggregate"]["baseline_avg"],
+                "with_skill": skill["aggregate"]["skill_avg"],
+                "delta": skill["aggregate"]["delta"],
+            }
+            for skill in all_results
+        },
+    }
+
+    with open(output_path, "w") as f:
+        json.dump(payload, f, indent=2)
+
+    print(f"  Results saved to: {output_path}")
+    return output_path

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+Well-Architected Skills Eval Runner
+
+Runs skill evaluations using Amazon Bedrock's Converse API.
+For each test case, generates responses with and without the skill loaded,
+then grades assertions using an LLM-as-judge.
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import yaml
+
+from grade import grade_response
+from report import print_report, save_results
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+CONFIG_PATH = Path(__file__).parent / "config.yaml"
+
+
+def load_config(config_path: Path = CONFIG_PATH) -> dict:
+    with open(config_path) as f:
+        return yaml.safe_load(f)
+
+
+def load_skill(skill_name: str) -> str:
+    skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+    if not skill_path.exists():
+        raise FileNotFoundError(f"Skill not found: {skill_path}")
+    return skill_path.read_text()
+
+
+def load_evals(skill_name: str) -> dict:
+    evals_path = SKILLS_DIR / skill_name / "evals" / "evals.json"
+    if not evals_path.exists():
+        raise FileNotFoundError(f"Evals not found: {evals_path}")
+    with open(evals_path) as f:
+        return json.load(f)
+
+
+def list_skills() -> list[str]:
+    return sorted(
+        d.name for d in SKILLS_DIR.iterdir()
+        if d.is_dir() and (d / "evals" / "evals.json").exists()
+    )
+
+
+def call_bedrock(config: dict, messages: list[dict], system: str | None = None) -> str:
+    import boto3
+    from botocore.config import Config
+
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=config["region"],
+        config=Config(read_timeout=300),
+    )
+
+    kwargs = {
+        "modelId": config["generation_model"],
+        "messages": messages,
+        "inferenceConfig": {
+            "temperature": config["temperature"],
+            "maxTokens": config["max_tokens"],
+        },
+    }
+    if system:
+        kwargs["system"] = [{"text": system}]
+
+    response = client.converse(**kwargs)
+    return response["output"]["message"]["content"][0]["text"]
+
+
+def run_eval_case(config: dict, skill_content: str, eval_case: dict) -> dict:
+    prompt = eval_case["prompt"]
+    messages = [{"role": "user", "content": [{"text": prompt}]}]
+
+    # Baseline: no skill context
+    baseline_output = call_bedrock(config, messages)
+
+    # With skill: inject SKILL.md as system context
+    system_prompt = (
+        "You are an AWS Well-Architected expert. Follow the skill instructions below "
+        "to produce your response.\n\n"
+        f"---\n\n{skill_content}"
+    )
+    skill_output = call_bedrock(config, messages, system=system_prompt)
+
+    return {
+        "id": eval_case["id"],
+        "prompt": prompt,
+        "baseline_output": baseline_output,
+        "skill_output": skill_output,
+    }
+
+
+def run_skill_evals(config: dict, skill_name: str, verbose: bool = False) -> dict:
+    print(f"\n{'='*60}")
+    print(f"  Evaluating: {skill_name}")
+    print(f"{'='*60}")
+
+    skill_content = load_skill(skill_name)
+    evals_data = load_evals(skill_name)
+    eval_cases = evals_data["evals"]
+
+    results = {
+        "skill_name": skill_name,
+        "cases": [],
+    }
+
+    for case in eval_cases:
+        print(f"\n  Case {case['id']}: {case['prompt'][:60]}...")
+        start = time.time()
+
+        outputs = run_eval_case(config, skill_content, case)
+        elapsed = time.time() - start
+        print(f"  Generated in {elapsed:.1f}s")
+
+        # Grade both outputs
+        print("  Grading baseline...")
+        baseline_grades = grade_response(
+            config, outputs["baseline_output"], case["assertions"]
+        )
+
+        print("  Grading with-skill...")
+        skill_grades = grade_response(
+            config, outputs["skill_output"], case["assertions"]
+        )
+
+        case_result = {
+            "id": case["id"],
+            "prompt": case["prompt"],
+            "assertions": case["assertions"],
+            "baseline": {
+                "output": outputs["baseline_output"],
+                "grades": baseline_grades,
+                "score": sum(1 for g in baseline_grades if g["pass"]) / len(baseline_grades),
+            },
+            "with_skill": {
+                "output": outputs["skill_output"],
+                "grades": skill_grades,
+                "score": sum(1 for g in skill_grades if g["pass"]) / len(skill_grades),
+            },
+        }
+
+        results["cases"].append(case_result)
+
+        if verbose:
+            print(f"\n    Baseline score: {case_result['baseline']['score']:.0%}")
+            print(f"    With-skill score: {case_result['with_skill']['score']:.0%}")
+            for i, (bg, sg) in enumerate(zip(baseline_grades, skill_grades)):
+                b_icon = "✓" if bg["pass"] else "✗"
+                s_icon = "✓" if sg["pass"] else "✗"
+                print(f"      [{b_icon} → {s_icon}] {case['assertions'][i]}")
+
+    # Aggregate scores
+    baseline_scores = [c["baseline"]["score"] for c in results["cases"]]
+    skill_scores = [c["with_skill"]["score"] for c in results["cases"]]
+    results["aggregate"] = {
+        "baseline_avg": sum(baseline_scores) / len(baseline_scores),
+        "skill_avg": sum(skill_scores) / len(skill_scores),
+        "delta": sum(skill_scores) / len(skill_scores) - sum(baseline_scores) / len(baseline_scores),
+    }
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run Well-Architected skill evaluations")
+    parser.add_argument(
+        "--skill", type=str, default=None,
+        help="Skill to evaluate (default: all skills)"
+    )
+    parser.add_argument(
+        "--config", type=str, default=None,
+        help="Path to config.yaml (default: evals/config.yaml)"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Show detailed grading output"
+    )
+    parser.add_argument(
+        "--list", action="store_true",
+        help="List available skills and exit"
+    )
+    parser.add_argument(
+        "--save", action="store_true",
+        help="Save results to evals/results/"
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        print("Available skills with evals:")
+        for s in list_skills():
+            print(f"  - {s}")
+        sys.exit(0)
+
+    config_path = Path(args.config) if args.config else CONFIG_PATH
+    config = load_config(config_path)
+
+    skills_to_run = [args.skill] if args.skill else list_skills()
+
+    # Validate skills exist
+    for skill_name in skills_to_run:
+        if skill_name not in list_skills():
+            print(f"Error: skill '{skill_name}' not found or has no evals.")
+            print(f"Available: {', '.join(list_skills())}")
+            sys.exit(1)
+
+    all_results = []
+    for skill_name in skills_to_run:
+        result = run_skill_evals(config, skill_name, verbose=args.verbose)
+        all_results.append(result)
+
+    print_report(all_results)
+
+    if args.save:
+        save_results(all_results)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/tests/test_grade.py
+++ b/evals/tests/test_grade.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for the grading module — no Bedrock calls required."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from grade import grade_response
+
+
+def make_mock_config():
+    return {"region": "us-east-1", "grading_model": "test-model"}
+
+
+@patch("grade.boto3")
+def test_grade_response_parses_json(mock_boto3):
+    mock_client = MagicMock()
+    mock_boto3.client.return_value = mock_client
+
+    grader_response = json.dumps([
+        {"assertion": "Has all pillars", "pass": True, "reason": "All 6 pillars mentioned"},
+        {"assertion": "Has severity", "pass": False, "reason": "No severity labels found"},
+    ])
+
+    mock_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": grader_response}]}}
+    }
+
+    assertions = ["Has all pillars", "Has severity"]
+    result = grade_response(make_mock_config(), "some output", assertions)
+
+    assert len(result) == 2
+    assert result[0]["pass"] is True
+    assert result[1]["pass"] is False
+    assert "reason" in result[0]
+
+
+@patch("grade.boto3")
+def test_grade_response_handles_markdown_wrapped_json(mock_boto3):
+    mock_client = MagicMock()
+    mock_boto3.client.return_value = mock_client
+
+    grader_response = '```json\n[{"assertion": "test", "pass": true, "reason": "ok"}]\n```'
+
+    mock_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": grader_response}]}}
+    }
+
+    result = grade_response(make_mock_config(), "some output", ["test"])
+
+    assert len(result) == 1
+    assert result[0]["pass"] is True
+
+
+@patch("grade.boto3")
+def test_grade_response_handles_malformed_response(mock_boto3):
+    mock_client = MagicMock()
+    mock_boto3.client.return_value = mock_client
+
+    mock_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "not valid json at all"}]}}
+    }
+
+    assertions = ["assertion one", "assertion two"]
+    result = grade_response(make_mock_config(), "some output", assertions)
+
+    assert len(result) == 2
+    assert result[0]["pass"] is False
+    assert result[1]["pass"] is False
+    assert "parse" in result[0]["reason"].lower()
+
+
+@patch("grade.boto3")
+def test_grade_response_normalizes_missing_entries(mock_boto3):
+    mock_client = MagicMock()
+    mock_boto3.client.return_value = mock_client
+
+    # Grader only returns 1 result for 3 assertions
+    grader_response = json.dumps([
+        {"assertion": "first", "pass": True, "reason": "found it"},
+    ])
+
+    mock_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": grader_response}]}}
+    }
+
+    assertions = ["first", "second", "third"]
+    result = grade_response(make_mock_config(), "some output", assertions)
+
+    assert len(result) == 3
+    assert result[0]["pass"] is True
+    assert result[1]["pass"] is False
+    assert result[2]["pass"] is False

--- a/evals/tests/test_report.py
+++ b/evals/tests/test_report.py
@@ -1,0 +1,72 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for the report module."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from report import print_report, save_results
+
+
+def make_sample_results():
+    return [
+        {
+            "skill_name": "wa-review",
+            "cases": [
+                {
+                    "id": 1,
+                    "prompt": "Review my architecture",
+                    "baseline": {"score": 0.4},
+                    "with_skill": {"score": 0.9},
+                },
+                {
+                    "id": 2,
+                    "prompt": "Review my monolith",
+                    "baseline": {"score": 0.5},
+                    "with_skill": {"score": 0.85},
+                },
+            ],
+            "aggregate": {
+                "baseline_avg": 0.45,
+                "skill_avg": 0.875,
+                "delta": 0.425,
+            },
+        }
+    ]
+
+
+def test_print_report_no_crash(capsys):
+    print_report(make_sample_results())
+    captured = capsys.readouterr()
+    assert "wa-review" in captured.out
+    assert "EVALUATION RESULTS" in captured.out
+
+
+def test_print_report_multiple_skills(capsys):
+    results = make_sample_results()
+    results.append({
+        "skill_name": "security-assessment",
+        "cases": [{"id": 1, "prompt": "test", "baseline": {"score": 0.3}, "with_skill": {"score": 0.8}}],
+        "aggregate": {"baseline_avg": 0.3, "skill_avg": 0.8, "delta": 0.5},
+    })
+    print_report(results)
+    captured = capsys.readouterr()
+    assert "AVERAGE" in captured.out
+    assert "security-assessment" in captured.out
+
+
+def test_save_results(tmp_path, monkeypatch):
+    monkeypatch.setattr("report.RESULTS_DIR", tmp_path)
+    results = make_sample_results()
+    output_path = save_results(results)
+
+    assert output_path.exists()
+    with open(output_path) as f:
+        data = json.load(f)
+    assert "timestamp" in data
+    assert "results" in data
+    assert "summary" in data
+    assert "wa-review" in data["summary"]

--- a/evals/tests/test_run.py
+++ b/evals/tests/test_run.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for the eval runner — no Bedrock calls required."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from run import list_skills, load_config, load_evals, load_skill
+
+
+SKILLS_DIR = Path(__file__).parent.parent.parent / "skills"
+
+
+def test_load_config():
+    config = load_config()
+    assert "region" in config
+    assert "generation_model" in config
+    assert "grading_model" in config
+    assert config["temperature"] == 0
+
+
+def test_list_skills():
+    skills = list_skills()
+    assert len(skills) >= 1
+    assert "wa-review" in skills
+
+
+def test_load_skill():
+    content = load_skill("wa-review")
+    assert "Well-Architected" in content
+    assert len(content) > 100
+
+
+def test_load_skill_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_skill("nonexistent-skill")
+
+
+def test_load_evals():
+    evals = load_evals("wa-review")
+    assert "skill_name" in evals
+    assert "evals" in evals
+    assert len(evals["evals"]) >= 1
+
+    case = evals["evals"][0]
+    assert "id" in case
+    assert "prompt" in case
+    assert "assertions" in case
+    assert len(case["assertions"]) >= 3
+
+
+def test_load_evals_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_evals("nonexistent-skill")
+
+
+def test_all_skills_have_valid_evals():
+    """Every skill with an evals.json should have well-formed test cases."""
+    for skill_name in list_skills():
+        evals = load_evals(skill_name)
+        assert evals["skill_name"] == skill_name, f"{skill_name}: skill_name mismatch"
+        assert len(evals["evals"]) >= 1, f"{skill_name}: no eval cases"
+
+        for case in evals["evals"]:
+            assert "id" in case, f"{skill_name}: missing id"
+            assert "prompt" in case, f"{skill_name}: missing prompt"
+            assert len(case["prompt"]) > 10, f"{skill_name}: prompt too short"
+            assert "assertions" in case, f"{skill_name}: missing assertions"
+            assert len(case["assertions"]) >= 3, f"{skill_name}: fewer than 3 assertions"
+
+
+@patch("boto3.client")
+def test_call_bedrock_constructs_correct_request(mock_client_factory):
+    from run import call_bedrock
+
+    mock_client = MagicMock()
+    mock_client_factory.return_value = mock_client
+    mock_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "test response"}]}}
+    }
+
+    config = {"region": "us-east-1", "generation_model": "test-model", "temperature": 0, "max_tokens": 4096}
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+
+    result = call_bedrock(config, messages, system="system prompt")
+
+    assert result == "test response"
+    mock_client.converse.assert_called_once()
+    call_kwargs = mock_client.converse.call_args[1]
+    assert call_kwargs["modelId"] == "test-model"
+    assert call_kwargs["system"] == [{"text": "system prompt"}]


### PR DESCRIPTION
## Summary

- Adds `evals/` directory with a Python-based evaluation harness that measures skill impact using Amazon Bedrock's Converse API
- For each test case, generates baseline (no skill) and with-skill responses, then uses LLM-as-judge to grade assertions as PASS/FAIL
- Includes `list_models.py` discovery utility for experimenting with other foundation models (Nova, Llama, Mistral, etc.)
- 15 unit tests (fully mocked, no AWS calls needed) covering runner, grader, and reporter
- Updates README with full usage docs, Windows PowerShell instructions for manual installation, guidance on estimating cost in your own account, and model experimentation tips
- Updates CONTRIBUTING.md to require evals when adding new skills

## Eval results

A full run prints a per-skill table of the baseline arm, the with-skill arm and the delta between them, plus an average across skills. The figures are specific to the model tier, the assertions and the moment they ran, so they are not reproduced here — run it and read your own:

```bash
cd evals && uv sync && uv run python run.py --verbose
```

## Test plan

- [x] `uv run pytest tests/ -v` — all 15 tests pass
- [x] `uv run python run.py --skill wa-review --verbose` — single skill eval works end-to-end
- [x] `uv run python run.py --save` — full eval run completes and saves results
- [x] Verify on Windows with PowerShell (`uv sync` + `uv run python run.py --list`)

---

_Edited to remove measurement figures. The eval runner ships in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
