### PR TITLE
Add Kiro Powers scaffold and update llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ adapters/                           Tool-specific configuration
   amp/                                .agents/skills/*.md
   devops-agent/                       Packaging for AWS DevOps Agent
 
+powers/                             Kiro Powers (coming soon)
+
 evals/                              Automated evaluation runner (Bedrock)
   run.py                              CLI entry point
   grade.py                            LLM-as-judge grader
@@ -424,6 +426,7 @@ graph LR
 | --------- | ------------ |
 | **Skills** (`skills/*/SKILL.md`) | Self-contained, tool-agnostic playbooks. Any AI agent can follow them step-by-step. They don't depend on steering or on each other. |
 | **Steering** (`steering/*.md`) | Always-on context loaded into every Kiro conversation. Other tools use equivalent mechanisms via adapters. |
+| **Powers** (`powers/*/`) | Bundled, installable units for Kiro. Package steering + MCP tools + hooks into a single activatable power. |
 | **Adapters** (`adapters/`) | Translate steering into each tool's native config format and wire up skills as commands or rules. |
 | **Assets** (`assets/`) | Shared reference material (v13 best practices, metrics, patterns) bundled with skills for tools that support it. |
 
@@ -443,6 +446,17 @@ graph LR
 | Junie | `.junie/guidelines/*.md` | `.junie/skills/*/SKILL.md` |
 | Amp | `AGENTS.md` | `.agents/skills/*/SKILL.md` |
 | AWS DevOps Agent | N/A (skills are self-contained) | `SKILL.md` zip upload to Agent Space |
+
+### Kiro Powers
+
+[Kiro Powers](https://kiro.dev) are bundled, installable units that activate contextually based on conversation keywords. Unlike always-on steering, Powers load guidance dynamically when relevant topics arise.
+
+| Power | Status | Description |
+| ----- | ------ | ----------- |
+| `well-architected` | 🚧 In progress | Full WA framework — all 6 pillars, activated on architecture discussions |
+
+> [!NOTE]
+> Powers are the recommended way to use WA guidance in Kiro going forward. They provide richer activation (keyword-based), optional MCP tool integration, and one-click installation from the Powers gallery.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Well-Architected Skills & Steering for AI Coding Agents
 
-> Reusable skills and steering that teach AI coding agents how to apply the AWS Well-Architected Framework.
+> Reusable skills and steering that teach AI coding agents how to apply the AWS Well-Architected Framework. One set of playbooks, 12 supported tools.
 
 ## What this repo contains
 
@@ -38,13 +38,15 @@ This repository provides ready-to-use instruction sets that make AI coding agent
 ```
 steering/       → Always-on context (principles, pillars, format guidance)
 skills/         → On-demand playbooks (step-by-step assessment procedures)
+powers/         → Kiro Powers (bundled installable units with contextual activation)
 assets/         → Reference material (best practices, metrics, patterns)
 adapters/       → Tool-specific packaging (Claude Code, Cursor, Kiro, etc.)
+evals/          → Automated evaluation runner (Amazon Bedrock)
 install.sh      → Setup script for macOS/Linux
 install.ps1     → Setup script for Windows
 ```
 
-Skills are tool-agnostic. Adapters translate them into each tool's native format. You do not need to read adapter files — read skills directly.
+Skills are tool-agnostic. Adapters translate them into each tool's native format. Powers bundle steering + MCP tools for Kiro's installable unit system. You do not need to read adapter files — read skills directly.
 
 ## Key principles to apply
 
@@ -55,6 +57,7 @@ When giving Well-Architected guidance:
 - Include "Why it matters" for each finding
 - Provide concrete next steps with AWS service recommendations
 - Acknowledge trade-offs explicitly (security vs latency, availability vs cost, etc.)
+- For well-architected systems, focus on advanced improvements rather than critical findings
 
 ## Design principles to recommend
 
@@ -66,3 +69,7 @@ When giving Well-Architected guidance:
 - Automate everything that can be automated
 - Use infrastructure as code for all environments
 - Design for observability from day one
+
+## Evaluations
+
+Each skill includes test cases in `skills/*/evals/evals.json`. The `evals/` directory contains an automated runner powered by Amazon Bedrock that measures skill impact (baseline vs with-skill) using LLM-as-judge grading. Current benchmark: 86% baseline → 98% with-skill average across all 9 skills.


### PR DESCRIPTION
## Summary

- Adds `powers/` directory scaffold for upcoming Kiro Powers support
- Updates `llms.txt` to reflect current repo state (was missing evals, powers, and calibration guidance)
- Documents Powers in README component table and adds a Kiro Powers section

## What's included

- `powers/.gitkeep` — placeholder directory for upcoming powers
- README updates: directory tree, component table row, Kiro Powers section with status table
- `llms.txt` fully refreshed to match current repo capabilities

## Context

Powers are Kiro's bundled installable units — they package steering, MCP tools, and hooks into a single activatable unit with keyword-based contextual activation. A `well-architected` power and an `eks` power (via `aws-wa-eks-kiro-power-guidance` collaboration) are planned.

## Test plan

- [x] No functional changes — scaffold only
- [x] README renders correctly
- [x] `llms.txt` accurately describes the repo