### PR TITLE
Fix missing encoding parameter in open() calls

### DIFF
--- a/evals/list_models.py
+++ b/evals/list_models.py
@@ -20,7 +20,7 @@ CONFIG_PATH = "config.yaml"
 
 
 def load_config() -> dict:
-    with open(CONFIG_PATH) as f:
+    with open(CONFIG_PATH, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/evals/report.py
+++ b/evals/report.py
@@ -81,7 +81,7 @@ def save_results(all_results: list[dict]) -> Path:
         },
     }
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
 
     print(f"  Results saved to: {output_path}")

--- a/evals/run.py
+++ b/evals/run.py
@@ -25,7 +25,7 @@ CONFIG_PATH = Path(__file__).parent / "config.yaml"
 
 
 def load_config(config_path: Path = CONFIG_PATH) -> dict:
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
@@ -40,7 +40,7 @@ def load_evals(skill_name: str) -> dict:
     evals_path = SKILLS_DIR / skill_name / "evals" / "evals.json"
     if not evals_path.exists():
         raise FileNotFoundError(f"Evals not found: {evals_path}")
-    with open(evals_path) as f:
+    with open(evals_path, encoding="utf-8") as f:
         return json.load(f)
 
 


### PR DESCRIPTION
## Summary
- Add explicit `encoding="utf-8"` to all `open()` calls in evals scripts (`list_models.py`, `report.py`, `run.py`)
- Resolves semgrep `unspecified-open-encoding` warnings
- Ensures consistent cross-platform file handling behavior

## Test plan
- [ ] Verify semgrep no longer reports `unspecified-open-encoding` for these files
- [ ] Run evals scripts to confirm no regressions