### PR TITLE
Add skills.sh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ install.ps1                         One-command setup (Windows PowerShell)
 
 ### One-liner (no clone needed)
 
+#### Via [skills.sh](https://skills.sh)
+
+```bash
+npx skills add aws-samples/sample-well-architected-skills-and-steering
+```
+
+Auto-detects your AI agent and installs skills directly. Use `--list` to preview available skills, or `--skill <name>` to install a specific one:
+
+```bash
+# List available skills
+npx skills add aws-samples/sample-well-architected-skills-and-steering --list
+
+# Install a specific skill
+npx skills add aws-samples/sample-well-architected-skills-and-steering --skill wa-review
+
+# Install globally (user-level, applies to all projects)
+npx skills add aws-samples/sample-well-architected-skills-and-steering -g
+```
+
+#### Via bootstrap script
+
 **macOS / Linux:**
 
 ```bash
@@ -628,3 +649,4 @@ This project is licensed under the [MIT-0 License](LICENSE).
 - [Kiro — AI-powered IDE](https://kiro.dev)
 - [AWS DevOps Agent](https://docs.aws.amazon.com/devopsagent/latest/userguide/)
 - [Agent Skills Specification](https://agentskills.io/)
+- [skills.sh — Skills directory for AI agents](https://skills.sh)

--- a/llms.txt
+++ b/llms.txt
@@ -6,6 +6,20 @@
 
 This repository provides ready-to-use instruction sets that make AI coding agents Well-Architected aware. When loaded, you should apply the six pillars (Operational Excellence, Security, Reliability, Performance Efficiency, Cost Optimization, Sustainability) to architecture discussions, code reviews, and design decisions.
 
+## Installation
+
+Install via [skills.sh](https://skills.sh) (no clone needed):
+
+```
+npx skills add aws-samples/sample-well-architected-skills-and-steering
+```
+
+Or via bootstrap script:
+
+```
+curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.sh | bash
+```
+
 ## How to use this content
 
 ### If you are an AI agent assisting a developer:

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "groupings": [
+    {
+      "title": "Full Reviews",
+      "description": "Comprehensive architecture reviews and decision records.",
+      "skills": ["wa-review", "architecture-decision-record", "migration-readiness"]
+    },
+    {
+      "title": "Pillar Assessments",
+      "description": "Deep-dive assessments for individual Well-Architected pillars.",
+      "skills": [
+        "security-assessment",
+        "reliability-improvement-plan",
+        "cost-optimization-audit",
+        "performance-efficiency",
+        "operational-excellence",
+        "sustainability-optimization"
+      ]
+    }
+  ]
+}

--- a/skills/architecture-decision-record/metadata.json
+++ b/skills/architecture-decision-record/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Generate a Well-Architected-aligned Architecture Decision Record (ADR) that documents a design decision with context, options evaluated, trade-offs, and WA pillar impact.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html"
+  ]
+}

--- a/skills/cost-optimization-audit/metadata.json
+++ b/skills/cost-optimization-audit/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Analyze an AWS architecture for cost waste, right-sizing opportunities, and pricing model improvements aligned with the Well-Architected Cost Optimization pillar.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html"
+  ]
+}

--- a/skills/migration-readiness/metadata.json
+++ b/skills/migration-readiness/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Assess a workload's readiness to migrate to AWS using Well-Architected principles, covering the 7 Rs, dependencies, risks, and a migration plan.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/migration-lens/migration-lens.html"
+  ]
+}

--- a/skills/operational-excellence/metadata.json
+++ b/skills/operational-excellence/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Assess a workload's operational excellence posture against the Well-Architected Operational Excellence pillar, covering organization, preparation, operation, and evolution.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/operational-excellence-pillar/welcome.html"
+  ]
+}

--- a/skills/performance-efficiency/metadata.json
+++ b/skills/performance-efficiency/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Evaluate a workload's performance efficiency against the Well-Architected Performance Efficiency pillar, covering resource selection, scaling, monitoring, and optimization opportunities.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/performance-efficiency-pillar/welcome.html"
+  ]
+}

--- a/skills/reliability-improvement-plan/metadata.json
+++ b/skills/reliability-improvement-plan/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Identify single points of failure, assess recovery capabilities, and produce a prioritized remediation plan aligned with the Well-Architected Reliability pillar.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/welcome.html"
+  ]
+}

--- a/skills/security-assessment/metadata.json
+++ b/skills/security-assessment/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Deep-dive security posture assessment against the Well-Architected Security pillar, covering identity, detection, infrastructure protection, data protection, and incident response.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html"
+  ]
+}

--- a/skills/sustainability-optimization/metadata.json
+++ b/skills/sustainability-optimization/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Assess a workload's environmental sustainability posture against the Well-Architected Sustainability pillar, identifying opportunities to reduce carbon footprint through resource efficiency, managed services, and architectural optimization.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html"
+  ]
+}

--- a/skills/wa-review/metadata.json
+++ b/skills/wa-review/metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.1.0",
+  "organization": "AWS",
+  "date": "May 2026",
+  "abstract": "Perform a full AWS Well-Architected Framework review evaluating all six pillars with prioritized findings and actionable recommendations.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `npx skills add aws-samples/sample-well-architected-skills-and-steering` as the primary one-liner installation method in README
- Add `skills.sh.json` manifest at repo root to group skills into "Full Reviews" and "Pillar Assessments" for better display on [skills.sh](https://skills.sh)
- Add `metadata.json` to each skill directory with version, organization, abstract, and references for improved discoverability
- Update `llms.txt` with skills.sh installation instructions
- Add skills.sh to Related Resources section

Closes #21 — thanks @juancarlosjr97 for the suggestion!

## Test plan

- [x] Verified `npx skills add aws-samples/sample-well-architected-skills-and-steering --list` discovers all 9 skills correctly
- [ ] Confirm skills.sh leaderboard picks up the repo after installs
- [ ] Validate `skills.sh.json` groupings render correctly on skills.sh once indexed