### PR TITLE
Add OpenClaw as 13th supported tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🏗️ Well-Architected Skills & Steering for AI Coding Agents
 
-Reusable skills and steering that teach AI coding agents how to apply the [AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html). One set of playbooks, **12 supported tools**.
+Reusable skills and steering that teach AI coding agents how to apply the [AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html). One set of playbooks, **13 supported tools**.
 
 <div align="center">
 
-**Kiro** · **Claude Code** · **Cursor** · **Codex** · **Windsurf** · **GitHub Copilot** · **Gemini CLI** · **Antigravity** · **Junie** · **Amp** · **Cline** · **AWS DevOps Agent**
+**Kiro** · **Claude Code** · **Cursor** · **Codex** · **Windsurf** · **GitHub Copilot** · **Gemini CLI** · **Antigravity** · **Junie** · **Amp** · **OpenClaw** · **Cline** · **AWS DevOps Agent**
 
 </div>
 
@@ -20,7 +20,7 @@ Developers don't stop to consult documentation — they ask their AI assistant. 
 This project embeds WA best practices **where development actually happens**: in the IDE, at the moment code is being written. Instead of treating architecture reviews as a separate gate, teams get continuous, contextual guidance that:
 
 - ✅ Reduces rework by catching misalignments early
-- ✅ Works across 12 AI coding tools with a single source of truth
+- ✅ Works across 13 AI coding tools with a single source of truth
 - ✅ Requires no AWS credentials, no API calls — everything runs locally
 - ✅ Follows the open [Agent Skills specification](https://agentskills.io/)
 
@@ -61,6 +61,7 @@ adapters/                           Tool-specific configuration
   antigravity/                        .agents/rules/*.md
   junie/                              .junie/guidelines + .junie/skills
   amp/                                .agents/skills/*.md
+  openclaw/                           AGENTS.md + .agents/skills/*.md
   devops-agent/                       Packaging for AWS DevOps Agent
 
 powers/                             Kiro Powers (coming soon)
@@ -115,7 +116,7 @@ curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-s
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/aws-samples/sample-well-architected-skills-and-steering/main/bootstrap.ps1)))
 ```
 
-Auto-detects your AI tools (`.cursor/`, `.claude/`, `.kiro/`, `.junie/`, etc.), installs for all of them, and cleans up.
+Auto-detects your AI tools (`.cursor/`, `.claude/`, `.kiro/`, `.junie/`, `.openclaw/`, etc.), installs for all of them, and cleans up.
 
 To install for a specific tool instead:
 
@@ -384,6 +385,27 @@ Copy-Item -Recurse path\to\this-repo\skills\* .agents\skills\
 </details>
 
 <details>
+<summary><strong>🔹 OpenClaw</strong></summary>
+
+macOS / Linux:
+
+```bash
+cp path/to/this-repo/adapters/openclaw/AGENTS.md ./AGENTS.md
+mkdir -p .agents/skills
+cp -r path/to/this-repo/skills/* .agents/skills/
+```
+
+Windows (PowerShell):
+
+```powershell
+Copy-Item path\to\this-repo\adapters\openclaw\AGENTS.md .\AGENTS.md
+New-Item -ItemType Directory -Force -Path .agents\skills
+Copy-Item -Recurse path\to\this-repo\skills\* .agents\skills\
+```
+
+</details>
+
+<details>
 <summary><strong>🔹 Cline</strong></summary>
 
 macOS / Linux:
@@ -439,6 +461,7 @@ graph LR
     A --> AG[Antigravity]
     A --> J[Junie]
     A --> AM[Amp]
+    A --> OC[OpenClaw]
     A --> CL[Cline]
     A --> DA[DevOps Agent]
 ```
@@ -466,6 +489,7 @@ graph LR
 | Antigravity | `.agents/rules/*.md` | `.agents/skills/*/SKILL.md` |
 | Junie | `.junie/guidelines/*.md` | `.junie/skills/*/SKILL.md` |
 | Amp | `AGENTS.md` | `.agents/skills/*/SKILL.md` |
+| OpenClaw | `AGENTS.md` | `.agents/skills/*/SKILL.md` |
 | AWS DevOps Agent | N/A (skills are self-contained) | `SKILL.md` zip upload to Agent Space |
 
 ### Kiro Powers
@@ -649,4 +673,5 @@ This project is licensed under the [MIT-0 License](LICENSE).
 - [Kiro — AI-powered IDE](https://kiro.dev)
 - [AWS DevOps Agent](https://docs.aws.amazon.com/devopsagent/latest/userguide/)
 - [Agent Skills Specification](https://agentskills.io/)
+- [OpenClaw — Personal AI assistant platform](https://openclaw.ai)
 - [skills.sh — Skills directory for AI agents](https://skills.sh)

--- a/adapters/openclaw/AGENTS.md
+++ b/adapters/openclaw/AGENTS.md
@@ -1,0 +1,63 @@
+# Well-Architected Framework
+
+## When to Apply
+
+Apply this guidance whenever the user:
+- Asks for an architecture review or design feedback
+- Requests help designing a new workload or system
+- Asks about best practices for reliability, security, cost, performance, or sustainability
+- Mentions "Well-Architected" or "WA review"
+
+## Pillars
+
+Always consider all six pillars when evaluating or proposing architectures:
+
+1. **Operational Excellence** — Automate operations, make frequent small reversible changes, refine procedures, anticipate failure, learn from operational events.
+2. **Security** — Implement a strong identity foundation, enable traceability, apply security at all layers, automate security best practices, protect data in transit and at rest, keep people away from data, prepare for security events.
+3. **Reliability** — Automatically recover from failure, test recovery procedures, scale horizontally, stop guessing capacity, manage change through automation.
+4. **Performance Efficiency** — Democratize advanced technologies, go global in minutes, use serverless architectures, experiment more often, consider mechanical sympathy.
+5. **Cost Optimization** — Implement cloud financial management, adopt a consumption model, measure overall efficiency, stop spending money on undifferentiated heavy lifting, analyze and attribute expenditure.
+6. **Sustainability** — Understand your impact, establish sustainability goals, maximize utilization, anticipate and adopt new more efficient offerings, use managed services, reduce downstream impact.
+
+## Design Principles
+
+When proposing solutions:
+- Favor managed services over self-managed infrastructure
+- Design for failure — assume any component can fail at any time
+- Decouple components to reduce blast radius
+- Use multiple Availability Zones for high availability
+- Implement least-privilege access for all identities
+- Automate everything that can be automated
+- Use infrastructure as code for all environments
+- Design for observability from day one
+
+## Trade-off Guidance
+
+Acknowledge trade-offs explicitly:
+- Security controls may add latency — quantify the impact
+- High availability increases cost — present options at different tiers
+- Performance optimization may reduce portability — state the lock-in risk
+- Cost optimization may reduce resilience — make the risk visible
+
+## Response Format
+
+When delivering Well-Architected guidance:
+- Lead with the most critical finding or recommendation
+- Group findings by pillar
+- Use severity labels: 🔴 High Risk, 🟡 Medium Risk, 🟢 Best Practice
+- Include "Why it matters" for each finding
+- Provide a concrete next step for each recommendation
+
+## Available Skills
+
+For structured assessments, load the corresponding skill from `.agents/skills/`:
+
+- `wa-review` — Full 6-pillar review with prioritized findings report
+- `security-assessment` — Deep-dive into IAM, detection, infrastructure, data protection, incident response
+- `reliability-improvement-plan` — Find SPOFs, assess recovery, produce remediation plan
+- `cost-optimization-audit` — Identify waste, right-sizing, pricing model improvements
+- `performance-efficiency` — Resource selection, scaling, caching, optimization
+- `sustainability-optimization` — Utilization, architecture efficiency, carbon reduction
+- `operational-excellence` — CI/CD, observability, incident management, operational maturity
+- `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
+- `architecture-decision-record` — ADR with WA pillar impact analysis

--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,7 @@
 
 .PARAMETER Tool
     Install only for specific tool(s). Can be specified multiple times.
-    Valid: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, devops-agent, all
+    Valid: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, devops-agent, all
 
 .PARAMETER Symlink
     Use symlinks instead of copies (requires elevated permissions on Windows)
@@ -227,6 +227,19 @@ function Install-Amp {
     Write-Host "  Done. Amp will discover skills from .agents/skills/ automatically.`n"
 }
 
+function Install-OpenClaw {
+    $base = if ($Global) { "$env:USERPROFILE\.openclaw\workspace" } else { $TargetDir }
+
+    Write-Host "Installing for OpenClaw..."
+    Copy-OrLink "$ScriptDir\adapters\openclaw\AGENTS.md" "$base\AGENTS.md"
+
+    $skillsDir = if ($Global) { "$base\skills" } else { "$base\.agents\skills" }
+    foreach ($skill in Get-Skills) {
+        Copy-OrLink "$($skill.FullName)\SKILL.md" "$skillsDir\$($skill.Name)\SKILL.md"
+    }
+    Write-Host "  Done. OpenClaw will discover skills from .agents/skills/ automatically.`n"
+}
+
 function Install-DevOpsAgent {
     $base = if ($Global) { "$env:USERPROFILE\.devops-agent-skills" } else { $TargetDir }
 
@@ -273,7 +286,7 @@ Write-Host ""
 $resolved = Resolve-Path $TargetDir -ErrorAction SilentlyContinue
 if ($resolved) { $TargetDir = $resolved.Path }
 
-$validTools = @("kiro", "claude-code", "cursor", "codex", "windsurf", "github-copilot", "cline", "gemini-cli", "antigravity", "junie", "amp", "devops-agent", "all")
+$validTools = @("kiro", "claude-code", "cursor", "codex", "windsurf", "github-copilot", "cline", "gemini-cli", "antigravity", "junie", "amp", "openclaw", "devops-agent", "all")
 
 foreach ($t in $Tool) {
     switch ($t) {
@@ -288,6 +301,7 @@ foreach ($t in $Tool) {
         "antigravity"    { Install-Antigravity }
         "junie"          { Install-Junie }
         "amp"            { Install-Amp }
+        "openclaw"       { Install-OpenClaw }
         "devops-agent"   { Install-DevOpsAgent }
         "all" {
             Install-Kiro
@@ -301,6 +315,7 @@ foreach ($t in $Tool) {
             Install-Antigravity
             Install-Junie
             Install-Amp
+            Install-OpenClaw
             Install-DevOpsAgent
         }
         default {

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ Arguments:
 
 Options:
   --tool TOOL   Install only for a specific tool. Can be repeated.
-                Valid: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, devops-agent, auto, all
+                Valid: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, devops-agent, auto, all
   --uninstall   Remove previously installed WA files from the target directory
   --check-update  Check if a newer version is available on GitHub
   --symlink     Use symlinks instead of copies (auto-updates when this repo changes)
@@ -354,6 +354,31 @@ install_amp() {
   echo ""
 }
 
+install_openclaw() {
+  local base="$TARGET_DIR"
+  if [[ "$GLOBAL" == true ]]; then
+    base="$HOME/.openclaw/workspace"
+  fi
+
+  echo "Installing for OpenClaw..."
+  copy_or_link "$SCRIPT_DIR/adapters/openclaw/AGENTS.md" "$base/AGENTS.md"
+
+  mkdir -p "$base/.agents/skills" 2>/dev/null || mkdir -p "$base/skills"
+  local skills_dir="$base/.agents/skills"
+  if [[ "$GLOBAL" == true ]]; then
+    skills_dir="$base/skills"
+  fi
+
+  for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+    local skill_name
+    skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
+    copy_or_link "$skill_dir/SKILL.md" "$skills_dir/$skill_name/SKILL.md"
+  done
+  echo "  Done. OpenClaw will discover skills from .agents/skills/ automatically."
+  echo ""
+}
+
 install_devops_agent() {
   local base="$TARGET_DIR"
   if [[ "$GLOBAL" == true ]]; then
@@ -413,6 +438,7 @@ detect_tools() {
   [[ -f "$dir/.clinerules" ]] && detected+=("cline")
   [[ -f "$dir/GEMINI.md" || -d "$dir/.gemini" ]] && detected+=("gemini-cli")
   [[ -d "$dir/.agents" ]] && detected+=("antigravity")
+  [[ -d "$dir/.openclaw" || -f "$dir/.openclaw.json" ]] && detected+=("openclaw")
   [[ -d "$dir/.junie" ]] && detected+=("junie")
 
   if [[ ${#detected[@]} -eq 0 ]]; then
@@ -485,6 +511,11 @@ uninstall_tool() {
       rm -rf "$base/.agents/skills"
       echo "  Removed: Amp AGENTS.md and skills"
       ;;
+    openclaw)
+      rm -f "$base/AGENTS.md"
+      rm -rf "$base/.agents/skills"
+      echo "  Removed: OpenClaw AGENTS.md and skills"
+      ;;
     devops-agent)
       rm -rf "$base/devops-agent-skills"
       echo "  Removed: DevOps Agent skill packages"
@@ -539,7 +570,7 @@ if [[ "$UNINSTALL" == true ]]; then
   echo "Uninstalling..."
   for tool in "${TOOLS[@]}"; do
     if [[ "$tool" == "all" ]]; then
-      for t in kiro claude-code cursor codex windsurf github-copilot cline gemini-cli antigravity junie amp devops-agent; do
+      for t in kiro claude-code cursor codex windsurf github-copilot cline gemini-cli antigravity junie amp openclaw devops-agent; do
         uninstall_tool "$t"
       done
     else
@@ -564,6 +595,7 @@ for tool in "${TOOLS[@]}"; do
     antigravity)    install_antigravity ;;
     junie)          install_junie ;;
     amp)            install_amp ;;
+    openclaw)       install_openclaw ;;
     devops-agent)   install_devops_agent ;;
     all)
       install_kiro
@@ -577,11 +609,12 @@ for tool in "${TOOLS[@]}"; do
       install_antigravity
       install_junie
       install_amp
+      install_openclaw
       install_devops_agent
       ;;
     *)
       echo "Unknown tool: $tool"
-      echo "Valid options: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, devops-agent, auto, all"
+      echo "Valid options: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, devops-agent, auto, all"
       exit 1
       ;;
   esac

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Well-Architected Skills & Steering for AI Coding Agents
 
-> Reusable skills and steering that teach AI coding agents how to apply the AWS Well-Architected Framework. One set of playbooks, 12 supported tools.
+> Reusable skills and steering that teach AI coding agents how to apply the AWS Well-Architected Framework. One set of playbooks, 13 supported tools.
 
 ## What this repo contains
 
@@ -54,7 +54,7 @@ steering/       → Always-on context (principles, pillars, format guidance)
 skills/         → On-demand playbooks (step-by-step assessment procedures)
 powers/         → Kiro Powers (bundled installable units with contextual activation)
 assets/         → Reference material (best practices, metrics, patterns)
-adapters/       → Tool-specific packaging (Claude Code, Cursor, Kiro, etc.)
+adapters/       → Tool-specific packaging (Claude Code, Cursor, Kiro, OpenClaw, etc.)
 evals/          → Automated evaluation runner (Amazon Bedrock)
 install.sh      → Setup script for macOS/Linux
 install.ps1     → Setup script for Windows


### PR DESCRIPTION
## Summary

- Adds OpenClaw adapter (`adapters/openclaw/AGENTS.md`) using the same `AGENTS.md` + `.agents/skills/` convention
- Adds `install_openclaw()` / `Install-OpenClaw` to both install scripts with auto-detection (`.openclaw/` or `.openclaw.json`), uninstall, and "all" dispatch
- Updates README (tool count, directory tree, manual install section, mermaid diagram, compatibility matrix, related resources)
- Syncs `llms.txt` to reflect 13 tools

## Test plan

- [ ] Run `./install.sh /tmp/test-openclaw --tool openclaw` and verify files land in correct paths
- [ ] Run `./install.sh /tmp/test-all --tool all` and confirm OpenClaw is included
- [ ] Run `bash -n install.sh` (syntax check passes)
- [ ] Verify README renders correctly (mermaid diagram, table, manual install section)