### PR TITLE
Add eval results section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,22 @@
 
 <!-- Brief description of what this PR does -->
 
+## Eval results (required for skill changes)
+
+<!-- 
+If this PR adds a new skill or modifies an existing skill (SKILL.md or evals.json),
+you MUST include eval numbers. PRs without eval data will not be merged.
+
+Run: uv run python run.py --skill <skill-name> --verbose
+
+Paste the output below showing:
+- Baseline score vs. with-skill score
+- Delta and statistical significance (p-value)
+- Per-assertion breakdown (--verbose)
+
+If adding/changing eval cases, show before-and-after results.
+-->
+
 ## Test plan
 
 <!-- How was this tested? -->


### PR DESCRIPTION
Require eval numbers for any PR that adds or modifies skills, ensuring quality gates before merge.

## Summary

<!-- Brief description of what this PR does -->

## Test plan

<!-- How was this tested? -->

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
