### PR TITLE
Fix installer: add Claude Code skills and safe uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ Arguments:
 
 Options:
   --tool TOOL   Install only for a specific tool. Can be repeated.
-                Valid: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, devops-agent, auto, all
+                Valid: kiro, kiro-cli, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, devops-agent, auto, all
   --uninstall   Remove previously installed WA files from the target directory
   --check-update  Check if a newer version is available on GitHub
   --symlink     Use symlinks instead of copies (auto-updates when this repo changes)
@@ -465,7 +465,7 @@ uninstall_tool() {
   fi
 
   case "$tool" in
-    kiro)
+    kiro|kiro-cli)
       rm -f "$base/.kiro/steering/well-architected.md"
       for skill_dir in "$SCRIPT_DIR/skills"/*/; do
         local skill_name
@@ -648,7 +648,7 @@ fi
 
 for tool in "${TOOLS[@]}"; do
   case "$tool" in
-    kiro)           install_kiro ;;
+    kiro|kiro-cli)  install_kiro ;;
     claude-code)    install_claude_code ;;
     cursor)         install_cursor ;;
     codex)          install_codex ;;
@@ -678,7 +678,7 @@ for tool in "${TOOLS[@]}"; do
       ;;
     *)
       echo "Unknown tool: $tool"
-      echo "Valid options: kiro, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, devops-agent, auto, all"
+      echo "Valid options: kiro, kiro-cli, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, devops-agent, auto, all"
       exit 1
       ;;
   esac

--- a/install.sh
+++ b/install.sh
@@ -152,7 +152,14 @@ install_claude_code() {
     cmd_name="$(basename "$cmd_file")"
     copy_or_link "$cmd_file" "$base/.claude/commands/$cmd_name"
   done
-  echo "  Done. Use /wa-review, /security-assessment, etc. as slash commands."
+
+  for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+    local skill_name
+    skill_name="$(basename "$skill_dir")"
+    [[ "$skill_name" == "_shared" ]] && continue
+    copy_or_link "$skill_dir/SKILL.md" "$base/.claude/skills/$skill_name/SKILL.md"
+  done
+  echo "  Done. Skills installed to .claude/skills/; slash commands also available."
   echo ""
 }
 
@@ -460,27 +467,53 @@ uninstall_tool() {
   case "$tool" in
     kiro)
       rm -f "$base/.kiro/steering/well-architected.md"
-      rm -rf "$base/.kiro/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/.kiro/skills/$skill_name"
+      done
       echo "  Removed: Kiro steering and skills"
       ;;
     claude-code)
       rm -f "$base/CLAUDE.md"
       rm -rf "$base/.claude/commands"
-      echo "  Removed: Claude Code CLAUDE.md and commands"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/.claude/skills/$skill_name"
+      done
+      echo "  Removed: Claude Code CLAUDE.md, commands, and skills"
       ;;
     cursor)
       rm -f "$base/.cursor/rules/well-architected.md" "$base/.cursor/rules/wa-review.md"
-      rm -rf "$base/.cursor/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/.cursor/skills/$skill_name"
+      done
       echo "  Removed: Cursor rules and skills"
       ;;
     codex)
       rm -f "$base/AGENTS.md"
-      rm -rf "$base/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/skills/$skill_name"
+      done
       echo "  Removed: Codex AGENTS.md and skills"
       ;;
     windsurf)
       rm -f "$base/.windsurfrules"
-      rm -rf "$base/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/skills/$skill_name"
+      done
       echo "  Removed: Windsurf .windsurfrules and skills"
       ;;
     github-copilot)
@@ -489,31 +522,62 @@ uninstall_tool() {
       ;;
     cline)
       rm -f "$base/.clinerules"
-      rm -rf "$base/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/skills/$skill_name"
+      done
       echo "  Removed: Cline .clinerules and skills"
       ;;
     gemini-cli)
       rm -f "$base/GEMINI.md"
-      rm -rf "$base/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/skills/$skill_name"
+      done
       echo "  Removed: Gemini CLI GEMINI.md and skills"
       ;;
     antigravity)
-      rm -rf "$base/.agents/rules" "$base/.agents/skills"
+      rm -f "$base/.agents/rules/well-architected.md" "$base/.agents/rules/wa-review.md"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/.agents/skills/$skill_name"
+      done
       echo "  Removed: Antigravity rules and skills"
       ;;
     junie)
       rm -f "$base/.junie/guidelines/well-architected.md"
-      rm -rf "$base/.junie/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/.junie/skills/$skill_name"
+      done
       echo "  Removed: Junie guidelines and skills"
       ;;
     amp)
       rm -f "$base/AGENTS.md"
-      rm -rf "$base/.agents/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/.agents/skills/$skill_name"
+      done
       echo "  Removed: Amp AGENTS.md and skills"
       ;;
     openclaw)
       rm -f "$base/AGENTS.md"
-      rm -rf "$base/.agents/skills"
+      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+        local skill_name
+        skill_name="$(basename "$skill_dir")"
+        [[ "$skill_name" == "_shared" ]] && continue
+        rm -rf "$base/.agents/skills/$skill_name"
+      done
       echo "  Removed: OpenClaw AGENTS.md and skills"
       ;;
     devops-agent)


### PR DESCRIPTION
## Summary
- **Claude Code adapter** now installs skills to `.claude/skills/<name>/SKILL.md` in addition to slash commands, matching Cursor/Codex/Windsurf/Cline/Gemini CLI behavior
- **Uninstall** across all adapters now only removes the specific WA skill directories instead of `rm -rf` on the entire skills folder, preventing accidental deletion of user's other skills

## Test plan
- [ ] `./install.sh /tmp/test --tool claude-code --force` installs both commands and skills
- [ ] `./install.sh /tmp/test --tool claude-code --uninstall` removes only WA skills
- [ ] `./install.sh --global --tool kiro --force` installs steering + skills without nuking personal skills
- [ ] `./install.sh --global --tool kiro --uninstall` removes only WA skills, keeps personal ones
- [ ] `bash -n install.sh` passes syntax check