### PR TITLE
Fix installer and eval bugs (auto-detect, global uninstall, failing tests)

### DIFF
--- a/adapters/amp/AGENTS.md
+++ b/adapters/amp/AGENTS.md
@@ -55,7 +55,7 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `wa-review` — Full 6-pillar review with prioritized findings report
 - `security-assessment` — Deep-dive into IAM, detection, infrastructure, data protection, incident response
 - `reliability-improvement-plan` — Find SPOFs, assess recovery, produce remediation plan
-- `cost-optimization-audit` — Identify waste, right-sizing, pricing model improvements
+- `cost-optimization-review` — Identify waste, right-sizing, pricing model improvements
 - `performance-efficiency` — Resource selection, scaling, caching, optimization
 - `sustainability-optimization` — Utilization, architecture efficiency, carbon reduction
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -50,4 +50,4 @@ When delivering Well-Architected guidance:
 
 ## Skills
 
-Well-Architected skills are available as slash commands. Use `/wa-review`, `/security-assessment`, `/reliability-improvement-plan`, `/cost-optimization-audit`, `/performance-efficiency`, `/sustainability-optimization`, `/operational-excellence`, `/migration-readiness`, or `/architecture-decision-record` to run a structured assessment.
+Well-Architected skills are available as slash commands. Use `/wa-review`, `/security-assessment`, `/reliability-improvement-plan`, `/cost-optimization-review`, `/performance-efficiency`, `/sustainability-optimization`, `/operational-excellence`, `/migration-readiness`, or `/architecture-decision-record` to run a structured assessment.

--- a/adapters/cline/.clinerules
+++ b/adapters/cline/.clinerules
@@ -59,7 +59,7 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `wa-review` — Full 6-pillar review with prioritized findings report
 - `security-assessment` — Deep-dive security posture assessment
 - `reliability-improvement-plan` — Find SPOFs and produce remediation plan
-- `cost-optimization-audit` — Identify waste and right-sizing opportunities
+- `cost-optimization-review` — Identify waste and right-sizing opportunities
 - `performance-efficiency` — Resource selection, scaling, caching assessment
 - `sustainability-optimization` — Utilization and carbon reduction assessment
 - `migration-readiness` — 7 Rs assessment with migration plan

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -51,7 +51,7 @@ When the user asks for a specific assessment, follow the structured approach in 
 - `wa-review` — Full 6-pillar review with prioritized findings report
 - `security-assessment` — Deep-dive into IAM, detection, infrastructure, data protection, incident response
 - `reliability-improvement-plan` — Find SPOFs, assess recovery, produce remediation plan
-- `cost-optimization-audit` — Identify waste, right-sizing, pricing model improvements
+- `cost-optimization-review` — Identify waste, right-sizing, pricing model improvements
 - `performance-efficiency` — Resource selection, scaling, caching, optimization
 - `sustainability-optimization` — Utilization, architecture efficiency, carbon reduction
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan

--- a/adapters/devops-agent/README.md
+++ b/adapters/devops-agent/README.md
@@ -52,7 +52,7 @@ This creates zip files ready for upload in the target directory.
 | `wa-review` | On-demand, Evaluation |
 | `security-assessment` | On-demand, Evaluation |
 | `reliability-improvement-plan` | On-demand, Incident RCA |
-| `cost-optimization-audit` | On-demand, Evaluation |
+| `cost-optimization-review` | On-demand, Evaluation |
 | `performance-efficiency` | On-demand, Incident RCA |
 | `sustainability-optimization` | On-demand, Evaluation |
 | `migration-readiness` | On-demand |

--- a/adapters/gemini-cli/GEMINI.md
+++ b/adapters/gemini-cli/GEMINI.md
@@ -54,7 +54,7 @@ Well-Architected skills are available as reusable playbooks in the `skills/` dir
 - [wa-review](file:///skills/wa-review/SKILL.md) (Full Well-Architected review)
 - [security-assessment](file:///skills/security-assessment/SKILL.md) (Security posture assessment)
 - [reliability-improvement-plan](file:///skills/reliability-improvement-plan/SKILL.md) (Reliability remediation plan)
-- [cost-optimization-audit](file:///skills/cost-optimization-audit/SKILL.md) (Cost optimization audit)
+- [cost-optimization-review](file:///skills/cost-optimization-review/SKILL.md) (Cost optimization audit)
 - [performance-efficiency](file:///skills/performance-efficiency/SKILL.md) (Performance efficiency review)
 - [sustainability-optimization](file:///skills/sustainability-optimization/SKILL.md) (Sustainability optimization review)
 - [migration-readiness](file:///skills/migration-readiness/SKILL.md) (Migration readiness assessment)

--- a/adapters/junie/guidelines.md
+++ b/adapters/junie/guidelines.md
@@ -50,4 +50,4 @@ When delivering Well-Architected guidance:
 
 ## Skills
 
-For structured assessments, invoke the corresponding skill by name: `wa-review`, `security-assessment`, `reliability-improvement-plan`, `cost-optimization-audit`, `performance-efficiency`, `sustainability-optimization`, `operational-excellence`, `migration-readiness`, or `architecture-decision-record`.
+For structured assessments, invoke the corresponding skill by name: `wa-review`, `security-assessment`, `reliability-improvement-plan`, `cost-optimization-review`, `performance-efficiency`, `sustainability-optimization`, `operational-excellence`, `migration-readiness`, or `architecture-decision-record`.

--- a/adapters/openclaw/AGENTS.md
+++ b/adapters/openclaw/AGENTS.md
@@ -55,7 +55,7 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `wa-review` — Full 6-pillar review with prioritized findings report
 - `security-assessment` — Deep-dive into IAM, detection, infrastructure, data protection, incident response
 - `reliability-improvement-plan` — Find SPOFs, assess recovery, produce remediation plan
-- `cost-optimization-audit` — Identify waste, right-sizing, pricing model improvements
+- `cost-optimization-review` — Identify waste, right-sizing, pricing model improvements
 - `performance-efficiency` — Resource selection, scaling, caching, optimization
 - `sustainability-optimization` — Utilization, architecture efficiency, carbon reduction
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity

--- a/adapters/windsurf/.windsurfrules
+++ b/adapters/windsurf/.windsurfrules
@@ -59,7 +59,7 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `wa-review` — Full 6-pillar review with prioritized findings report
 - `security-assessment` — Deep-dive security posture assessment
 - `reliability-improvement-plan` — Find SPOFs and produce remediation plan
-- `cost-optimization-audit` — Identify waste and right-sizing opportunities
+- `cost-optimization-review` — Identify waste and right-sizing opportunities
 - `performance-efficiency` — Resource selection, scaling, caching assessment
 - `sustainability-optimization` — Utilization and carbon reduction assessment
 - `migration-readiness` — 7 Rs assessment with migration plan

--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,2 +1,5 @@
 results/*
 !results/baseline.json
+
+__pycache__/
+*.pyc

--- a/evals/config.yaml
+++ b/evals/config.yaml
@@ -6,6 +6,9 @@ grading_model: us.anthropic.claude-opus-4-8
 
 max_tokens: 16384
 
+# Sampling temperature for generation. 0 = deterministic (recommended for evals).
+temperature: 0
+
 # Number of times to run each eval (higher = more stable scores, higher cost)
 runs_per_eval: 1
 

--- a/install.sh
+++ b/install.sh
@@ -461,7 +461,16 @@ uninstall_tool() {
   local tool="$1"
   local base="$TARGET_DIR"
   if [[ "$GLOBAL" == true ]]; then
-    base="$HOME"
+    # Mirror the per-tool global base used by each install_* function so
+    # uninstall removes files from where they were actually installed.
+    case "$tool" in
+      gemini-cli)   base="$HOME/.gemini" ;;
+      amp)          base="$HOME/.config/agents" ;;
+      openclaw)     base="$HOME/.openclaw/workspace" ;;
+      devops-agent) base="$HOME/.devops-agent-skills" ;;
+      antigravity)  base="$HOME/.gemini" ;;
+      *)            base="$HOME" ;;
+    esac
   fi
 
   case "$tool" in
@@ -541,13 +550,24 @@ uninstall_tool() {
       echo "  Removed: Gemini CLI GEMINI.md and skills"
       ;;
     antigravity)
-      rm -f "$base/.agents/rules/well-architected.md" "$base/.agents/rules/wa-review.md"
-      for skill_dir in "$SCRIPT_DIR/skills"/*/; do
-        local skill_name
-        skill_name="$(basename "$skill_dir")"
-        [[ "$skill_name" == "_shared" ]] && continue
-        rm -rf "$base/.agents/skills/$skill_name"
-      done
+      if [[ "$GLOBAL" == true ]]; then
+        # Global install reuses the Gemini layout (~/.gemini/GEMINI.md + skills/).
+        rm -f "$base/GEMINI.md"
+        for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+          local skill_name
+          skill_name="$(basename "$skill_dir")"
+          [[ "$skill_name" == "_shared" ]] && continue
+          rm -rf "$base/skills/$skill_name"
+        done
+      else
+        rm -f "$base/.agents/rules/well-architected.md" "$base/.agents/rules/wa-review.md"
+        for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+          local skill_name
+          skill_name="$(basename "$skill_dir")"
+          [[ "$skill_name" == "_shared" ]] && continue
+          rm -rf "$base/.agents/skills/$skill_name"
+        done
+      fi
       echo "  Removed: Antigravity rules and skills"
       ;;
     junie)
@@ -562,21 +582,25 @@ uninstall_tool() {
       ;;
     amp)
       rm -f "$base/AGENTS.md"
+      local amp_skills_dir="$base/.agents/skills"
+      [[ "$GLOBAL" == true ]] && amp_skills_dir="$base/skills"
       for skill_dir in "$SCRIPT_DIR/skills"/*/; do
         local skill_name
         skill_name="$(basename "$skill_dir")"
         [[ "$skill_name" == "_shared" ]] && continue
-        rm -rf "$base/.agents/skills/$skill_name"
+        rm -rf "$amp_skills_dir/$skill_name"
       done
       echo "  Removed: Amp AGENTS.md and skills"
       ;;
     openclaw)
       rm -f "$base/AGENTS.md"
+      local openclaw_skills_dir="$base/.agents/skills"
+      [[ "$GLOBAL" == true ]] && openclaw_skills_dir="$base/skills"
       for skill_dir in "$SCRIPT_DIR/skills"/*/; do
         local skill_name
         skill_name="$(basename "$skill_dir")"
         [[ "$skill_name" == "_shared" ]] && continue
-        rm -rf "$base/.agents/skills/$skill_name"
+        rm -rf "$openclaw_skills_dir/$skill_name"
       done
       echo "  Removed: OpenClaw AGENTS.md and skills"
       ;;

--- a/install.sh
+++ b/install.sh
@@ -449,7 +449,7 @@ detect_tools() {
   [[ -d "$dir/.junie" ]] && detected+=("junie")
 
   if [[ ${#detected[@]} -eq 0 ]]; then
-    echo "  No AI tools detected in $dir. Installing for all tools."
+    echo "  No AI tools detected in $dir. Installing for all tools." >&2
     echo "all"
   else
     echo "  Detected: ${detected[*]}" >&2

--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,7 @@ curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-s
 - `skills/wa-review/SKILL.md` — Full Well-Architected review across all 6 pillars
 - `skills/security-assessment/SKILL.md` — Deep-dive security posture assessment
 - `skills/reliability-improvement-plan/SKILL.md` — Identify SPOFs, assess recovery, produce remediation plan
-- `skills/cost-optimization-audit/SKILL.md` — Find waste, right-sizing, pricing model improvements
+- `skills/cost-optimization-review/SKILL.md` — Find waste, right-sizing, pricing model improvements
 - `skills/performance-efficiency/SKILL.md` — Resource selection, scaling, caching assessment
 - `skills/sustainability-optimization/SKILL.md` — Utilization, managed services, data lifecycle
 - `skills/operational-excellence/SKILL.md` — CI/CD, observability, incident management, automation

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -12,7 +12,7 @@
       "skills": [
         "security-assessment",
         "reliability-improvement-plan",
-        "cost-optimization-audit",
+        "cost-optimization-review",
         "performance-efficiency",
         "operational-excellence",
         "sustainability-optimization"

--- a/skills/cost-optimization-review/evals/evals.json
+++ b/skills/cost-optimization-review/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "cost-optimization-audit",
+  "skill_name": "cost-optimization-review",
   "evals": [
     {
       "id": 1,


### PR DESCRIPTION
## Summary

Fixes three bugs found while reviewing the installer and eval harness:

1. **`install.sh --tool auto` aborts the entire install when no AI tools are detected** (breaks the default `bootstrap.sh` one-liner)
2. **Two unit tests in `evals/tests/test_run.py` fail against the shipped repo** (missing config key + an inconsistent skill name)
3. **`install.sh --global --uninstall` leaves files behind for 5 tools** (uninstall looked in the wrong directories)

All changes are limited to the installer, the eval config, and metadata — no skill *content* or steering guidance was modified. Test suite goes from 13/15 → **15/15 passing**.

---

## 1. `--tool auto` aborts install when no tools are detected

**File:** `install.sh`

`detect_tools()` printed its "No AI tools detected" diagnostic message to **stdout**. The caller captures stdout line-by-line into the `TOOLS` array, so the array became `("  No AI tools detected..." "all")`. The message string was then matched against the tool `case`, hit the unknown-tool branch, and exited 1.

This breaks the documented default path — `bootstrap.sh` runs `install.sh --tool auto --force`, so the curl one-liner fails on any project without pre-existing AI-tool config.

**Fix:** redirect the diagnostic to stderr (`>&2`), matching the non-empty detection branch which already does this. Only `all` is then captured, and the install proceeds correctly.

**Verified:** running `install.sh <empty-dir> --tool auto` now installs all tools instead of exiting 1.

---

## 2. Failing eval tests

**Files:** `evals/config.yaml`, `evals/.gitignore`, and 12 metadata files

Two independent failures in `evals/tests/test_run.py`:

**(a) Missing `temperature` key.** `test_load_config` asserts `config["temperature"] == 0`, but `config.yaml` had no `temperature` key → `KeyError`. `run.py` reads it via `.get()`, so generation was unaffected, but evals ran non-deterministically. Added `temperature: 0` (the recommended deterministic setting for evals).

**(b) Skill name mismatch.** `test_all_skills_have_valid_evals` failed because the cost-optimization skill was named inconsistently across the repo. The **canonical name is `cost-optimization-review`**, as declared by the skill itself:
- `SKILL.md` frontmatter: `name: cost-optimization-review`
- the directory on disk: `skills/cost-optimization-review/`
- `metadata.json`, the README, and the Claude Code slash command

But 11 secondary references still used the old `cost-optimization-audit` (the `evals.json` `skill_name` field, `skills.sh.json`, `llms.txt`, and 8 adapter docs). Beyond failing the test, the stale adapter docs pointed agents at a skill directory that does not exist on disk.

**Fix:** normalized all source references to the canonical `cost-optimization-review`. `evals/results/baseline.json` is intentionally left unchanged — it is a generated historical eval artifact, not hand-maintained source.

Also added `__pycache__/` and `*.pyc` to `evals/.gitignore` (they were untracked and easy to commit by accident).

**Verified:** `python -m pytest evals/tests/` → 15 passed (was 2 failed, 13 passed).

---

## 3. `--global --uninstall` leaves files behind for 5 tools

**File:** `install.sh`

`uninstall_tool()` hardcoded `base="$HOME"` in global mode, but several `install_*` functions use tool-specific global bases — and a couple also use a different skills subdirectory in global vs. project mode. As a result `--global --uninstall` for these tools removed nothing (or the wrong path), orphaning the installed files:

| Tool | Global install location | Old uninstall looked in |
|---|---|---|
| `gemini-cli` | `~/.gemini/` | `~/` |
| `amp` | `~/.config/agents/` (skills in `skills/`) | `~/` (skills in `.agents/skills/`) |
| `openclaw` | `~/.openclaw/workspace/` (skills in `skills/`) | `~/` (skills in `.agents/skills/`) |
| `devops-agent` | `~/.devops-agent-skills/` | `~/` |
| `antigravity` | Gemini layout: `~/.gemini/GEMINI.md` + `skills/` | `.agents/rules` + `.agents/skills` (project layout only) |

**Fix:** set the global base per-tool to mirror each install function. Also fixed `amp`/`openclaw` (whose skills dir flips from `.agents/skills` in project mode to `skills` in global mode) and gave `antigravity` a dedicated global uninstall branch matching its Gemini-style global install.

**Verified:** ran an install → uninstall round-trip against a sandboxed `$HOME` for all five tools in global mode (all files removed cleanly) and confirmed project-mode uninstall still works (no regression).

---

## Testing

- `python -m pytest evals/tests/` — **15 passed** (previously 2 failed)
- `bash -n install.sh` — syntax clean
- Manual install/uninstall round-trips (global + project) for the affected tools, verified with `find` against a sandboxed `$HOME`

## Pillars

N/A — these are installer/tooling and test fixes; no Well-Architected skill content or steering guidance was changed.
