### PR TITLE
Fix eval runtime: strip temperature for models that reject it (Opus 4.8)

### DIFF
--- a/evals/run.py
+++ b/evals/run.py
@@ -76,7 +76,17 @@ def call_bedrock(config: dict, messages: list[dict], system: str | None = None) 
     if system:
         kwargs["system"] = [{"text": system}]
 
-    response = client.converse(**kwargs)
+    try:
+        response = client.converse(**kwargs)
+    except client.exceptions.ValidationException as e:
+        # Some models (e.g. Claude Opus 4.8) reject the temperature parameter.
+        # Rather than guessing from the model id, drop it and retry once when
+        # Bedrock tells us the parameter is unsupported.
+        if "temperature" in inference_config and "temperature" in str(e).lower():
+            del inference_config["temperature"]
+            response = client.converse(**kwargs)
+        else:
+            raise
     return response["output"]["message"]["content"][0]["text"]
 
 

--- a/evals/tests/test_run.py
+++ b/evals/tests/test_run.py
@@ -95,3 +95,54 @@ def test_call_bedrock_constructs_correct_request(mock_client_factory):
     call_kwargs = mock_client.converse.call_args[1]
     assert call_kwargs["modelId"] == "test-model"
     assert call_kwargs["system"] == [{"text": "system prompt"}]
+
+
+@patch("boto3.client")
+def test_call_bedrock_retries_without_temperature_when_unsupported(mock_client_factory):
+    """Models like Opus 4.8 reject temperature; the call should drop it and retry."""
+    from run import call_bedrock
+
+    class ValidationException(Exception):
+        pass
+
+    mock_client = MagicMock()
+    mock_client_factory.return_value = mock_client
+    mock_client.exceptions.ValidationException = ValidationException
+
+    # First call raises a temperature ValidationException, second succeeds.
+    mock_client.converse.side_effect = [
+        ValidationException("The model returned the following errors: temperature ... not supported"),
+        {"output": {"message": {"content": [{"text": "ok"}]}}},
+    ]
+
+    config = {"region": "us-east-1", "generation_model": "us.anthropic.claude-opus-4-8", "temperature": 0, "max_tokens": 4096}
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+
+    result = call_bedrock(config, messages)
+
+    assert result == "ok"
+    assert mock_client.converse.call_count == 2
+    # The retry must not include temperature in inferenceConfig.
+    retry_kwargs = mock_client.converse.call_args_list[1][1]
+    assert "temperature" not in retry_kwargs["inferenceConfig"]
+
+
+@patch("boto3.client")
+def test_call_bedrock_reraises_unrelated_validation_errors(mock_client_factory):
+    """A ValidationException not about temperature must propagate, not retry."""
+    from run import call_bedrock
+
+    class ValidationException(Exception):
+        pass
+
+    mock_client = MagicMock()
+    mock_client_factory.return_value = mock_client
+    mock_client.exceptions.ValidationException = ValidationException
+    mock_client.converse.side_effect = ValidationException("malformed input: messages is empty")
+
+    config = {"region": "us-east-1", "generation_model": "us.anthropic.claude-opus-4-8", "temperature": 0, "max_tokens": 4096}
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+
+    with pytest.raises(ValidationException):
+        call_bedrock(config, messages)
+    mock_client.converse.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes a runtime regression in the eval harness: with the default generation model (`us.anthropic.claude-opus-4-8`), a real eval run now fails because the harness sends the `temperature` parameter, which Opus 4.8 rejects.

This is a follow-up to #30, which added `temperature: 0` to `evals/config.yaml`.

## Background

PR #30 added `temperature: 0` to `evals/config.yaml` to satisfy `test_load_config` (which asserts `config["temperature"] == 0`). That made the test pass, but introduced a runtime problem:

- `run.py`'s `call_bedrock` forwards `temperature` to the generation `Converse` call **whenever it is non-`None`**, with no model guard.
- The default `generation_model` is `us.anthropic.claude-opus-4-8`, which **does not support `temperature`** (as the README itself notes: *"Opus 4.8 does not support the `temperature` parameter — the runner handles this automatically"*).
- Before #30 the key was absent, so `config.get("temperature")` returned `None` and the parameter was skipped. After #30 it is always sent → `ValidationException` on a real run.

The README promises the runner "handles this automatically," but that guard only exists in `grade.py` (for the grading model), not in `run.py` (for the generation model).

## Fix

`evals/run.py` — wrap the generation `converse()` call so that, when Bedrock raises a `ValidationException` reporting the `temperature` parameter is unsupported, the parameter is dropped and the call is retried once:

```python
try:
    response = client.converse(**kwargs)
except client.exceptions.ValidationException as e:
    if "temperature" in inference_config and "temperature" in str(e).lower():
        del inference_config["temperature"]
        response = client.converse(**kwargs)
    else:
        raise
```

### Why catch-and-retry instead of a model-name check

`grade.py` guards with `if "opus" not in config["grading_model"]`. I deliberately did **not** copy that approach, because name-based detection is brittle:

- It breaks on inference-profile or ARN model id forms that don't contain the literal `"opus"`.
- It over-generalizes — the limitation is specific to **Opus 4.8**; older Opus models (4.1, 3.x) *do* accept `temperature`, and a substring check wrongly strips it from them.
- The README explicitly encourages experimenting with other Bedrock models (Nova, Llama, Mistral, …). A name heuristic only knows about Opus; the catch-and-retry handles whatever model is in `config.yaml`, including future ones.

Asking Bedrock (via the `ValidationException`) is the only authoritative signal for whether a given model accepts the parameter.

## Tests

`evals/tests/test_run.py` — two new tests (the pre-existing happy-path test never exercises the retry branch):

- `test_call_bedrock_retries_without_temperature_when_unsupported` — simulates Opus rejecting `temperature`; asserts the call retries and the retry omits `temperature`.
- `test_call_bedrock_reraises_unrelated_validation_errors` — asserts a `ValidationException` **not** about temperature propagates (no silent swallowing of auth/throttling/malformed-input errors).

```
$ python -m pytest evals/tests/ -q
17 passed
```

(was 15 before this change.)

I also verified that `ValidationException` is a declared error shape on the `Converse` operation in the `bedrock-runtime` service model, so `client.exceptions.ValidationException` is the correct exception to catch.

## Known limitation

The retry triggers on the exception **message** text (`"temperature" in str(e).lower()`). If AWS reworded the Bedrock error so it no longer contains the word "temperature," the retry would not fire and the original `ValidationException` would surface — i.e. it degrades to the current (pre-fix) behavior, never worse. A fully message-independent approach would require a capability lookup that the Bedrock API does not currently expose. Noted here as a possible future follow-up.

## Scope

Only `evals/run.py` and its tests. `grade.py` is intentionally left unchanged — its existing guard is not broken for the default config, and refactoring it would expand this PR beyond the regression being fixed. (Aligning `grade.py` to the same catch-and-retry pattern would be a reasonable separate cleanup.)

## Pillars

N/A — eval-harness/tooling fix; no Well-Architected skill content or steering guidance changed.
