### PR TITLE
Wire wa-builder skill into adapters, slash command, and registry

### DIFF
--- a/adapters/amp/AGENTS.md
+++ b/adapters/amp/AGENTS.md
@@ -61,3 +61,4 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
 - `architecture-decision-record` — ADR with WA pillar impact analysis
+- `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -50,4 +50,4 @@ When delivering Well-Architected guidance:
 
 ## Skills
 
-Well-Architected skills are available as slash commands. Use `/wa-review`, `/security-assessment`, `/reliability-improvement-plan`, `/cost-optimization-review`, `/performance-efficiency`, `/sustainability-optimization`, `/operational-excellence`, `/migration-readiness`, or `/architecture-decision-record` to run a structured assessment.
+Well-Architected skills are available as slash commands. Use `/wa-review`, `/security-assessment`, `/reliability-improvement-plan`, `/cost-optimization-review`, `/performance-efficiency`, `/sustainability-optimization`, `/operational-excellence`, `/migration-readiness`, `/architecture-decision-record`, or `/wa-builder` to run a structured assessment.

--- a/adapters/claude-code/commands/wa-builder.md
+++ b/adapters/claude-code/commands/wa-builder.md
@@ -1,0 +1,63 @@
+"Learn then Build" — help the user understand AWS Well-Architected best practices for their specific workload, then produce actionable visual artifacts (architecture diagrams with WA annotations, decision trees, improvement roadmaps) they can commit and use.
+
+Unlike `/wa-review` (which assesses and scores), wa-builder teaches and enables. Adapt explanations for beginners and generate artifacts faster for experienced builders.
+
+## Step 1: Context and calibration
+
+Ask the user:
+
+> I can help you understand Well-Architected for your project and produce visual artifacts. Let me know:
+> - **Workload name** and brief description (or point me at your code)
+> - **Your WA familiarity**: New to WA / Familiar / Practitioner
+> - **What you want**: Architecture diagram, decision tree, roadmap, or all three
+> - **Existing review** (optional): If you have a `/wa-review` output, share it for richer artifacts
+
+If context is already provided or you are in a codebase, proceed directly.
+
+**Detect experience** if not stated:
+- Uses "pillar", "HRI", "RTO/RPO", "blast radius" naturally → **Practitioner** (skip learning, go straight to artifacts)
+- Asks "what is WA" or "how does this apply" → **Beginner** (full explanations with analogies)
+- Default → **Familiar** (concise pillar relevance)
+
+## Step 2: Workload discovery
+
+**Path A — Standalone (no prior review):** lightweight discovery — scan IaC for resource types, identify compute pattern (serverless/containers/VMs/mixed), data stores, network topology, deployment patterns. Produce a workload profile: architecture pattern, AWS services in use, per-pillar health signals, top 3 risk hotspots.
+
+**Path B — Post-review (consumes a `/wa-review` output):** parse the report for pillar scores, findings by severity, evidence locations, remediation items, and any PlantUML diagram. Use directly — skip discovery, do NOT re-assess.
+
+## Step 3: Learning phase
+
+**Skip entirely for Practitioners.** For Beginners and Familiar, personalize WA to their workload, prioritized by gap severity.
+
+- **Beginner**: for each relevant pillar, explain "Why it matters for YOU" (reference their actual services), top 3 concepts with WA Question IDs, and one developer-friendly analogy.
+- **Familiar**: terse per-pillar key-gap list with Question/BP IDs.
+
+Select concepts by mapping the workload's gaps to WA questions (OPS 1–11, SEC 1–11, REL 1–13, PERF 1–5, COST 1–11, SUS 1–6), clustering related questions, and ordering by risk severity then relevance.
+
+## Step 4: Artifact generation
+
+Generate ALL requested artifacts. Each MUST include BP ID references, color/severity indicators, and context specific to THEIR workload (never generic).
+
+**Artifact 1 — Architecture diagram with WA annotations:** PlantUML (primary) + Mermaid alternative. Color-coded component borders — 🟢 key BPs implemented, 🟡 partial gaps, 🔴 critical/high gaps — plus risk-hotspot callouts citing BP IDs and a legend.
+
+**Artifact 2 — Decision trees:** 2–3 Mermaid flowcharts for the most impactful architectural choices (e.g. serverless vs containers, single vs multi-region, canary vs blue/green). Start from their workload context, branch on WA-relevant criteria (availability target, cost tolerance, compliance), end with recommendations citing BP IDs and effort/cost indicators. Present OPTIONS, not mandates.
+
+**Artifact 3 — Improvement roadmap:** Mermaid Gantt chart (Quick Wins → Foundation → Strategic) plus an ASCII dependency graph showing what blocks what. Order by prerequisite relationships, then effort phase, then severity. Keep it REALISTIC — do not pack everything into "Quick Wins".
+
+## Step 5: Commit guidance
+
+Suggest where to save the artifacts, e.g.:
+- `docs/architecture/wa-annotated.puml` — architecture with pillar health
+- `docs/decisions/{topic}-decision.md` — decision tree(s)
+- `docs/roadmap/wa-improvement-roadmap.md` — Gantt + dependency graph
+
+Then offer to refine an artifact, deep-dive a decision, generate IaC for a roadmap item, create an ADR (`/architecture-decision-record`), or run a full `/wa-review` for precise per-BP scoring.
+
+## Calibration
+
+- This skill is about ENABLEMENT, not JUDGMENT — tone is encouraging, not critical
+- Beginners: analogies, avoid jargon, explain why before what. Practitioners: concise, artifacts fast
+- Decision trees present options; the builder decides
+- Always tie back to WA Framework Question IDs (OPS 4, SEC 3, REL 9, etc.) so builders can look up details
+- When generating from a `/wa-review`, USE its findings — don't re-assess
+- PlantUML is primary (broadest support); Mermaid is the alternative (renders in GitHub/VS Code); ASCII fallbacks work everywhere

--- a/adapters/cline/.clinerules
+++ b/adapters/cline/.clinerules
@@ -65,3 +65,4 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `migration-readiness` — 7 Rs assessment with migration plan
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
+- `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -57,5 +57,6 @@ When the user asks for a specific assessment, follow the structured approach in 
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
+- `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
 
 Read the corresponding `skills/{skill-name}/SKILL.md` file and follow its steps.

--- a/adapters/devops-agent/README.md
+++ b/adapters/devops-agent/README.md
@@ -57,6 +57,7 @@ This creates zip files ready for upload in the target directory.
 | `sustainability-optimization` | On-demand, Evaluation |
 | `migration-readiness` | On-demand |
 | `architecture-decision-record` | On-demand |
+| `wa-builder` | On-demand, Evaluation |
 
 ## Shared assets
 

--- a/adapters/gemini-cli/GEMINI.md
+++ b/adapters/gemini-cli/GEMINI.md
@@ -59,3 +59,4 @@ Well-Architected skills are available as reusable playbooks in the `skills/` dir
 - [sustainability-optimization](file:///skills/sustainability-optimization/SKILL.md) (Sustainability optimization review)
 - [migration-readiness](file:///skills/migration-readiness/SKILL.md) (Migration readiness assessment)
 - [architecture-decision-record](file:///skills/architecture-decision-record/SKILL.md) (Architecture decision record template)
+- [wa-builder](file:///skills/wa-builder/SKILL.md) (Understand Well-Architected for your workload and generate visual artifacts: annotated diagrams, decision trees, roadmaps)

--- a/adapters/junie/guidelines.md
+++ b/adapters/junie/guidelines.md
@@ -50,4 +50,4 @@ When delivering Well-Architected guidance:
 
 ## Skills
 
-For structured assessments, invoke the corresponding skill by name: `wa-review`, `security-assessment`, `reliability-improvement-plan`, `cost-optimization-review`, `performance-efficiency`, `sustainability-optimization`, `operational-excellence`, `migration-readiness`, or `architecture-decision-record`.
+For structured assessments, invoke the corresponding skill by name: `wa-review`, `security-assessment`, `reliability-improvement-plan`, `cost-optimization-review`, `performance-efficiency`, `sustainability-optimization`, `operational-excellence`, `migration-readiness`, `architecture-decision-record`, or `wa-builder`.

--- a/adapters/openclaw/AGENTS.md
+++ b/adapters/openclaw/AGENTS.md
@@ -61,3 +61,4 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
 - `architecture-decision-record` — ADR with WA pillar impact analysis
+- `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)

--- a/adapters/windsurf/.windsurfrules
+++ b/adapters/windsurf/.windsurfrules
@@ -65,3 +65,4 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `migration-readiness` — 7 Rs assessment with migration plan
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
+- `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -4,7 +4,7 @@
     {
       "title": "Full Reviews",
       "description": "Comprehensive architecture reviews and decision records.",
-      "skills": ["wa-review", "architecture-decision-record", "migration-readiness"]
+      "skills": ["wa-review", "architecture-decision-record", "migration-readiness", "wa-builder"]
     },
     {
       "title": "Pillar Assessments",


### PR DESCRIPTION
Fixes #32.

## Problem

The `wa-builder` skill (added in #28) ships and is documented in the README, but was never wired into the **adapter layer** or the **skills.sh registry**. No tool was actually told the skill exists — discovery relied on the model spontaneously noticing the `skills/wa-builder/` directory. It was the only one of the 10 skills with no Claude Code slash command.

See #32 for the full evidence.

## Changes

- **8 enumerating adapters** — added `wa-builder` to `codex`, `amp`, `openclaw`, `cline`, `windsurf`, `gemini-cli`, `junie`, and `devops-agent`, matching each adapter's existing format (bullet / link / inline list / table row).
- **Claude Code** — added `/wa-builder` to `CLAUDE.md` and created `adapters/claude-code/commands/wa-builder.md` (abridged from `SKILL.md`, following the same pattern as the other 9 commands).
- **skills.sh.json** — added `wa-builder` to the "Full Reviews" grouping (it's cross-pillar, like `wa-review` and `architecture-decision-record`).

### Description wording

Used a consistent, value-led description that spells out "Well-Architected" instead of the bare "WA" abbreviation, so first-time readers aren't left guessing:

> Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)

## Intentionally not touched

`cursor`, `github-copilot`, and `antigravity` are always-on steering only and do **not** enumerate skills by name:
- **cursor** already receives the skill via the installer's `skills/` → `.cursor/skills/` copy; its rule file lists no skills, so there's nothing to add.
- **github-copilot** has no skill mechanism at all (single always-on instructions file; the installer copies no skills for it).
- **antigravity** rules are steering-only.

## Testing

- **Installer round-trip** (`install.sh --tool all` then `--uninstall --tool all` against a temp target): `wa-builder` installs to every tool's skills dir, the `/wa-builder` command is created, all adapter docs name it, and uninstall removes everything cleanly with no leftovers.
- **Evals** (Bedrock, Opus 4.8): `wa-builder` improved over baseline with the skill loaded, confirming the wiring doesn't disturb the skill. Every case improved; the largest gain was case 2 (generate artifacts from a prior wa-review), where the baseline omitted the visual artifacts entirely and the skill produced an annotated architecture diagram with risk colouring, gap annotations and a dependency-ordered roadmap. Case 1 (beginner, Lambda/DynamoDB/S3) gained by grounding recommendations in WA Question IDs; case 3 (SaaS multi-region decision) gained a Mermaid decision tree branching on SLA/revenue/team size with review triggers. Reproduce with:

  ```bash
  cd evals && uv run python run.py --skill wa-builder --verbose
  ```

- **Unit tests**: `pytest` → 17 passed. `skills.sh.json` validates as JSON.

## Pillars

N/A — adapter/registry wiring for an existing all-6-pillar skill; no skill content or steering guidance changed.

---

_Edited to remove measurement figures. The eval runner ships in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
