### PR TITLE
Fix wa-review question count (58->57) and version mismatch

### DIFF
--- a/skills/wa-review/SKILL.md
+++ b/skills/wa-review/SKILL.md
@@ -62,7 +62,7 @@ Analyze application code for architectural patterns:
 
 ## Step 4: Evaluate EVERY WA Framework question with code evidence
 
-Assess the workload against ALL 58 questions in the Well-Architected Framework. For each question, provide:
+Assess the workload against ALL 57 questions in the Well-Architected Framework. For each question, provide:
 - **Status**: "Implemented", "Partially Implemented", "Not Implemented", "Cannot Determine"
 - **Evidence**: specific file paths and line numbers
 - **Gaps**: what's missing or could be improved

--- a/skills/wa-review/metadata.json
+++ b/skills/wa-review/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "organization": "AWS",
   "date": "June 2026",
   "abstract": "Perform a full AWS Well-Architected Framework review by analyzing code, IaC, and configurations to produce evidence-backed findings with risk assessment and prioritized remediation.",


### PR DESCRIPTION
Fixes #34

## What
Two one-line metadata fixes in the `wa-review` skill:

1. **Question count typo** — `skills/wa-review/SKILL.md:65` said "ALL 58 questions" while lines 3, 220, and 246 say 57. The framework has 57 questions (OPS 11 + SEC 11 + REL 13 + PERF 5 + COST 11 + SUS 6 = 57). Corrected 58 -> 57.

2. **Version mismatch** — `metadata.json` declared `2.0.0` while `SKILL.md` declared `2.1.0`. Aligned `metadata.json` up to `2.1.0`.

## Testing
- `evals/` test suite: 17 passed.
- No eval assertion or other file references the changed values (verified repo-wide); no downstream docs needed updating.