### PR TITLE
Fix failing eval test: unify temperature handling on catch-and-retry

### DIFF
--- a/evals/grade.py
+++ b/evals/grade.py
@@ -12,6 +12,35 @@ import json
 import boto3
 
 
+def _grader_converse(config: dict, prompt: str) -> str:
+    """
+    Call the grading model with temperature=0, dropping temperature and retrying
+    once if Bedrock reports the parameter is unsupported (e.g. Claude Opus 4.8).
+
+    This is model-agnostic: it reacts to Bedrock's own ValidationException rather
+    than guessing from the model id, so it works for ARNs and inference-profile
+    ids and does not wrongly strip temperature from models that support it.
+    """
+    client = boto3.client("bedrock-runtime", region_name=config["region"])
+
+    inference_config = {"maxTokens": 2048, "temperature": 0}
+    kwargs = {
+        "modelId": config["grading_model"],
+        "messages": [{"role": "user", "content": [{"text": prompt}]}],
+        "inferenceConfig": inference_config,
+    }
+
+    try:
+        response = client.converse(**kwargs)
+    except client.exceptions.ValidationException as e:
+        if "temperature" in inference_config and "temperature" in str(e).lower():
+            del inference_config["temperature"]
+            response = client.converse(**kwargs)
+        else:
+            raise
+    return response["output"]["message"]["content"][0]["text"]
+
+
 GRADING_PROMPT = """You are an evaluation grader. Your job is to determine whether a given output satisfies specific assertions.
 
 For each assertion, respond with a JSON object containing:
@@ -44,19 +73,7 @@ def grade_response(config: dict, output: str, assertions: list[str]) -> list[dic
         assertions=assertions_text,
     )
 
-    client = boto3.client("bedrock-runtime", region_name=config["region"])
-
-    inference_config = {"maxTokens": 2048}
-    if "opus" not in config["grading_model"]:
-        inference_config["temperature"] = 0
-
-    response = client.converse(
-        modelId=config["grading_model"],
-        messages=[{"role": "user", "content": [{"text": prompt}]}],
-        inferenceConfig=inference_config,
-    )
-
-    raw = response["output"]["message"]["content"][0]["text"]
+    raw = _grader_converse(config, prompt)
 
     try:
         grades = json.loads(raw)
@@ -113,19 +130,7 @@ def grade_process(config: dict, output: str, process_assertions: list[str]) -> l
     for i, assertion in enumerate(process_assertions, 1):
         prompt += f"{i}. {assertion}\n"
 
-    client = boto3.client("bedrock-runtime", region_name=config["region"])
-
-    inference_config = {"maxTokens": 2048}
-    if "opus" not in config["grading_model"]:
-        inference_config["temperature"] = 0
-
-    response = client.converse(
-        modelId=config["grading_model"],
-        messages=[{"role": "user", "content": [{"text": prompt}]}],
-        inferenceConfig=inference_config,
-    )
-
-    raw = response["output"]["message"]["content"][0]["text"]
+    raw = _grader_converse(config, prompt)
 
     try:
         grades = json.loads(raw)
@@ -182,19 +187,7 @@ def grade_knowledge(config: dict, output: str, knowledge_assertions: list[dict])
     for i, ka in enumerate(knowledge_assertions, 1):
         prompt += f'{i}. Claim: {ka["claim"]}\n   Source: {ka["source"]}\n   Rationale: {ka["rationale"]}\n'
 
-    client = boto3.client("bedrock-runtime", region_name=config["region"])
-
-    inference_config = {"maxTokens": 2048}
-    if "opus" not in config["grading_model"]:
-        inference_config["temperature"] = 0
-
-    response = client.converse(
-        modelId=config["grading_model"],
-        messages=[{"role": "user", "content": [{"text": prompt}]}],
-        inferenceConfig=inference_config,
-    )
-
-    raw = response["output"]["message"]["content"][0]["text"]
+    raw = _grader_converse(config, prompt)
 
     try:
         grades = json.loads(raw)

--- a/evals/run.py
+++ b/evals/run.py
@@ -81,10 +81,7 @@ def call_bedrock(config: dict, messages: list[dict], system: str | None = None) 
 
     inference_config = {"maxTokens": config["max_tokens"]}
     if config.get("temperature") is not None:
-        model_id = config["generation_model"]
-        # Opus 4.x models do not support temperature
-        if "opus-4" not in model_id:
-            inference_config["temperature"] = config["temperature"]
+        inference_config["temperature"] = config["temperature"]
 
     kwargs = {
         "modelId": config["generation_model"],


### PR DESCRIPTION
Fixes #41.

## Problem

`evals/tests/test_run.py::test_call_bedrock_retries_without_temperature_when_unsupported` fails on a clean `main` (`1 failed, 22 passed`).

The eval code works, but the test contradicts the code because two PRs layered two different strategies for the same problem — models like Claude Opus 4.8 rejecting the Converse `temperature` parameter:

- **#31** made `call_bedrock` resilient: send `temperature`, and if Bedrock raises a `ValidationException` naming the parameter, drop it and retry once (model-agnostic). The failing test encodes this — it expects the first call to include `temperature` and a second call to retry without it (`converse.call_count == 2`).
- **#37** later added a model-name short-circuit *above* that logic: `if "opus-4" not in model_id`. For the default `opus-4-8`, this strips `temperature` before the call, so the `ValidationException` never fires, the retry never runs, and `converse` is called only once → the test fails.

So `run.py` ended up with two mechanisms for the same job, and the test described one while the code did the other.

## Fix

Keep the model-agnostic catch-and-retry (#31) as the single source of truth and remove the name-based guards.

- **`evals/run.py`** — remove the `"opus-4" not in model_id` guard so `temperature` is always attempted; the existing `ValidationException` catch-and-retry handles models that reject it. Makes the failing test pass with **no test changes**.
- **`evals/grade.py`** — replace the brittle `"opus" not in grading_model` check (3 copies) with a shared `_grader_converse()` helper using the same catch-and-retry. This was the exact name-guessing approach #31 set out to avoid; the helper is model-agnostic (works for ARNs / inference-profile ids and does not wrongly strip `temperature` from models that support it).

Net change is a simplification: **2 files, +33 / −43**.

## Why this is behavior-neutral

For the default `opus-4-8`, the final Bedrock call is byte-identical before and after — both send `{"maxTokens": N}` with no `temperature` (the old code never added it; the new code adds it, gets the `ValidationException`, drops it, and retries). Only the *path* to that call changed.

## Testing

- **Unit suite**: `cd evals && python -m pytest tests/` → **23 passed** (was 22 passed, 1 failed). No test files were modified.
- **Edge cases verified** for both `run.py` and `grade.py`: (a) temperature unsupported → retries once without it and succeeds; (b) model accepts temperature → single call, temperature kept; (c) an *unrelated* `ValidationException` re-raises and does **not** retry; (d) case-insensitive match on "temperature" in the error message.
- **Live Bedrock smoke test** (Opus 4.8): ran a full skill eval end-to-end (generation via `run.py` + grading via `grade.py`) with no errors, confirming the retry path works against the real model.

## Scope

Found while building the `wa-guardrails` skill (#40) but unrelated to it — kept as a standalone fix so the `wa-guardrails` PR can land on a green test suite. No skill content or steering guidance changed.
