### PR TITLE
Add wa-guardrails skill: preventive Well-Architected controls + governance steering doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ skills/                             Step-by-step playbooks (tool-agnostic)
   migration-readiness/                7 Rs assessment with migration plan
   architecture-decision-record/       WA-aligned ADRs with pillar impact
   wa-builder/                         Learn WA + produce visual artifacts (diagrams, trees, roadmaps)
-  wa-guardrails/                      Preventive controls (Config rules, SCPs, CI checks) for ongoing compliance
+  wa-guardrails/                      Preventive controls (Config rules, SCPs, CI checks) for ongoing adherence to WA guidance
 
 examples/                           Sample IaC with planted WA issues (for demos and eval fixtures)
   insecure-serverless-app-cdk/        CDK TypeScript — ~20 issues across all 6 pillars
@@ -544,7 +544,7 @@ graph LR
 | `migration-readiness` | All 6 | Assess readiness to migrate a workload to AWS |
 | `architecture-decision-record` | All 6 | Document a design decision with WA pillar impact |
 | `wa-builder` | All 6 | Learn WA for your project + produce visual artifacts (diagrams, decision trees, roadmaps) |
-| `wa-guardrails` | All 6 | Generate preventive controls (Config rules, SCPs, CI checks, alarms) for ongoing compliance |
+| `wa-guardrails` | All 6 | Generate preventive controls (Config rules, SCPs, CI checks, alarms) for ongoing adherence to WA guidance |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ skills/                             Step-by-step playbooks (tool-agnostic)
   migration-readiness/                7 Rs assessment with migration plan
   architecture-decision-record/       WA-aligned ADRs with pillar impact
   wa-builder/                         Learn WA + produce visual artifacts (diagrams, trees, roadmaps)
+  wa-guardrails/                      Preventive controls (Config rules, SCPs, CI checks) for ongoing compliance
 
 examples/                           Sample IaC with planted WA issues (for demos and eval fixtures)
   insecure-serverless-app-cdk/        CDK TypeScript — ~20 issues across all 6 pillars
@@ -543,6 +544,7 @@ graph LR
 | `migration-readiness` | All 6 | Assess readiness to migrate a workload to AWS |
 | `architecture-decision-record` | All 6 | Document a design decision with WA pillar impact |
 | `wa-builder` | All 6 | Learn WA for your project + produce visual artifacts (diagrams, decision trees, roadmaps) |
+| `wa-guardrails` | All 6 | Generate preventive controls (Config rules, SCPs, CI checks, alarms) for ongoing compliance |
 
 ---
 
@@ -743,10 +745,11 @@ All skills are evaluated using an automated LLM-as-judge framework with paired c
 | `security-assessment` | 94% | **100%** | +6% |
 | `sustainability-optimization` | 85% | **100%** | +15% |
 | `wa-builder` | 61% | **94%** | +33% |
-| **Average** | **86%** | **99%** | **+14%** |
+| `wa-guardrails` | 76% | **99%** | +23% |
+| **Average** | **85%** | **99%** | **+15%** |
 
-- **9 of 10 skills** score 100% on behavioral assertions; `wa-builder` scores 94%
-- **Average +14% improvement** over the same model without skill guidance
+- **9 of 11 skills** score 100% on behavioral assertions; `wa-builder` scores 94% and `wa-guardrails` 99%
+- **Average +15% improvement** over the same model without skill guidance
 - Skills never produce worse output than baseline — they improve or match
 
 The evaluation framework is included in [`evals/`](./evals) so you can reproduce results on your own models and prompts. Use `--parallel` for ~3x faster runs.

--- a/adapters/amp/AGENTS.md
+++ b/adapters/amp/AGENTS.md
@@ -62,4 +62,4 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
-- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload aligned with Well-Architected best practices over time

--- a/adapters/amp/AGENTS.md
+++ b/adapters/amp/AGENTS.md
@@ -62,3 +62,4 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time

--- a/adapters/claude-code/CLAUDE.md
+++ b/adapters/claude-code/CLAUDE.md
@@ -50,4 +50,4 @@ When delivering Well-Architected guidance:
 
 ## Skills
 
-Well-Architected skills are available as slash commands. Use `/wa-review`, `/security-assessment`, `/reliability-improvement-plan`, `/cost-optimization-review`, `/performance-efficiency`, `/sustainability-optimization`, `/operational-excellence`, `/migration-readiness`, `/architecture-decision-record`, or `/wa-builder` to run a structured assessment.
+Well-Architected skills are available as slash commands. Use `/wa-review`, `/security-assessment`, `/reliability-improvement-plan`, `/cost-optimization-review`, `/performance-efficiency`, `/sustainability-optimization`, `/operational-excellence`, `/migration-readiness`, `/architecture-decision-record`, `/wa-builder`, or `/wa-guardrails` to run a structured assessment.

--- a/adapters/claude-code/commands/wa-guardrails.md
+++ b/adapters/claude-code/commands/wa-guardrails.md
@@ -1,6 +1,6 @@
 Generate preventive Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — so a workload stays compliant over time instead of being assessed once.
 
-Unlike the assessment commands (which find gaps) or `/wa-remediation` (which fixes one finding), guardrails codify best practices so non-compliant changes are blocked or flagged automatically — in CI, at deploy time, and continuously in the account.
+Unlike the assessment commands (which find gaps) or one-off remediation (which fixes a single finding), guardrails codify best practices so non-compliant changes are blocked or flagged automatically — in CI, at deploy time, and continuously in the account.
 
 ## Step 1: Gather context
 
@@ -87,7 +87,7 @@ Beyond machine-enforced controls, offer to capture the same standards as a **hum
 > - Generate the CI workflow wiring (GitHub Actions / CodePipeline step) to run the policy checks?
 > - Produce a governance steering doc (`CLAUDE.md` / `.cursor/rules/` / `.kiro/steering/`) capturing these standards for your AI agent?
 > - Add auto-remediation to a detective Config rule (with safety review)?
-> - Run a `/wa-remediation` pass to fix the existing violations these guardrails would block?
+> - Fix the existing violations these guardrails would block (remediate the current code)?
 > - Tighten a control from warn mode to block mode?
 
 ## Calibration

--- a/adapters/claude-code/commands/wa-guardrails.md
+++ b/adapters/claude-code/commands/wa-guardrails.md
@@ -1,0 +1,101 @@
+Generate preventive Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — so a workload stays compliant over time instead of being assessed once.
+
+Unlike the assessment commands (which find gaps) or `/wa-remediation` (which fixes one finding), guardrails codify best practices so non-compliant changes are blocked or flagged automatically — in CI, at deploy time, and continuously in the account.
+
+## Step 1: Gather context
+
+Ask the user (skip anything already provided or inferable from the codebase):
+
+> I can generate guardrails to keep your workload Well-Architected. Let me know:
+> - **Workload name** and code packages/directories (IaC, CI/CD configs)
+> - **IaC dialect**: CDK (which language), CloudFormation, Terraform, SAM, or mixed
+> - **Source of controls**: a prior `/wa-review` or assessment output, specific concerns, or "scan and propose"
+> - **Enforcement points available**: CI pipeline (which one), AWS Organizations/SCPs, AWS Config, account-level admin
+> - **Pillars to prioritize** (optional; default: Security and Reliability)
+
+If you are in a codebase, proceed directly and infer the IaC dialect and CI system from the files present.
+
+## Step 2: Discovery — what to enforce
+
+**Path A — From an assessment (preferred):** parse the prior review for findings, their pillar, severity, evidence (file:line), and the Best Practice IDs cited. Each High/Critical finding becomes a candidate guardrail so the same gap cannot recur.
+
+**Path B — Standalone scan:** analyze the IaC and identify the control-worthy configurations in use — encryption, public access, IAM scope, multi-AZ, backups, logging, TLS, tagging — and map each to the WA Best Practice it relates to.
+
+Produce a **control candidate list**: pillar, WA Question/BP ID, resource type, current state (compliant / non-compliant / absent), and the enforcement point that fits.
+
+## Step 3: Select preventive vs. detective
+
+For each candidate pick the strongest control the user's enforcement points allow. Prefer **preventive** over detective:
+
+- Catchable in IaC before deploy → **CI policy check** (CDK Aspect, `cfn-guard`/`cfn-lint`, Terraform OPA/Sentinel). Strongest and cheapest.
+- Must be blocked org-wide → **SCP / permission boundary**.
+- Only observable on the live resource (drift, runtime) → **AWS Config rule** (detective; auto-remediation only if confirmed).
+- Continuous reliability/cost/performance signal → **CloudWatch metric + alarm**.
+
+If a control can't be enforced with the available points, say so rather than emitting something that won't run.
+
+## Step 4: Generate the controls
+
+Emit each selected control as ready-to-commit code in the workload's existing dialect. Each MUST cite the WA Question/BP ID it enforces, be labeled 🛡️ Preventive or 🔍 Detective, and state in one line what it blocks/flags and why. Cover as applicable:
+
+- **Security (SEC)** — Config: `s3-bucket-server-side-encryption-enabled`, `s3-bucket-public-read-prohibited`, `iam-policy-no-statements-with-admin-access`; SCP denying unencrypted-resource creation or CloudTrail disablement; CDK Aspect failing synth on a `0.0.0.0/0` security group.
+- **Reliability (REL)** — `rds-multi-az-support`, `dynamodb-pitr-enabled`, `db-instance-backup-enabled`; `cfn-guard` rule requiring `DeletionProtection`; alarm on DLQ depth.
+- **Operational Excellence (OPS)** — CI check for required tags; Config rule for log retention; SCP preventing out-of-band changes.
+- **Cost (COST)** — CI check for approved instance types/capacity modes; budget/anomaly alarm.
+- **Performance / Sustainability (PERF/SUS)** — CI check preferring Graviton/managed services.
+
+Provide each snippet in a fenced code block with its target filename, matching the workload's dialect. Examples of the three common forms:
+
+```yaml
+# guardrails/config-rules.yaml  — 🔍 Detective, SEC 8 (encryption at rest)
+Resources:
+  S3EncryptionEnabled:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: s3-bucket-server-side-encryption-enabled
+      Source: { Owner: AWS, SourceIdentifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED }
+```
+
+```typescript
+// guardrails/no-open-sg.aspect.ts — 🛡️ Preventive, SEC 5 (fails cdk synth on 0.0.0.0/0)
+export class NoOpenIngress implements IAspect {
+  visit(node: IConstruct): void {
+    if (node instanceof CfnSecurityGroupIngress &&
+        node.cidrIp === "0.0.0.0/0" && ![80, 443].includes(Number(node.fromPort))) {
+      Annotations.of(node).addError(`SEC 5: open to 0.0.0.0/0 on port ${node.fromPort}`);
+    }
+  }
+}
+```
+
+```
+# guardrails/reliability.guard — 🛡️ Preventive, REL 9 (cfn-guard)
+AWS::RDS::DBInstance { Properties { MultiAZ == true  DeletionProtection == true } }
+```
+
+## Step 5: Produce the guardrails plan
+
+Output: a summary (dialect, enforcement points, source, control counts split preventive/detective); controls grouped by pillar (each with name, preventive/detective label, enforcement point, what it blocks, the file + snippet, and any coverage gap); a **rollout plan** table (start preventive checks/SCPs in warn/log mode, promote to block once clean); a **verification** section (attempt a known-bad change, confirm CI fails / check Config compliance); and a **not covered** section for controls the available enforcement points can't implement.
+
+## Step 6: Offer a governance steering doc
+
+Beyond machine-enforced controls, offer to capture the same standards as a **human- and agent-readable governance doc** — the prose counterpart to the guardrails, for standards a control can't fully express (design conventions, review expectations) and for teams that want an always-on policy their AI agent follows. Generate it on request as a steering file the agent loads automatically (`.kiro/steering/`, `CLAUDE.md`, `.cursor/rules/`), with: an "Enforced automatically" section (one line per machine control + its BP ID), a "Conventions to follow (not auto-enforced)" section, and standing "When proposing or reviewing changes" instructions. Keep each statement tied to a WA Question/BP ID and short enough for always-on context.
+
+## Step 7: Offer follow-up
+
+> Would you like me to:
+> - Generate the CI workflow wiring (GitHub Actions / CodePipeline step) to run the policy checks?
+> - Produce a governance steering doc (`CLAUDE.md` / `.cursor/rules/` / `.kiro/steering/`) capturing these standards for your AI agent?
+> - Add auto-remediation to a detective Config rule (with safety review)?
+> - Run a `/wa-remediation` pass to fix the existing violations these guardrails would block?
+> - Tighten a control from warn mode to block mode?
+
+## Calibration
+
+- Prefer **preventive** (CI/IaC) over **detective**; fall back to detective only when the issue is only visible on the live resource.
+- Never emit a control for an enforcement point the user doesn't have — say it's not enforceable and what's needed.
+- Roll out preventive controls and `Deny` SCPs in **warn/log mode first** — a hard block on day one can break existing pipelines.
+- Auto-remediation is destructive: only when explicitly asked, with a safety/rollback note.
+- Tie every control to a WA Question/BP ID — a guardrail without a "why" gets disabled the first time it's inconvenient.
+- Don't over-generate: a focused set the team keeps beats 50 noisy rules they'll mute.
+- Match the workload's dialect — CDK Aspects for CDK, `cfn-guard` for CloudFormation, OPA/Sentinel for Terraform; don't mix paradigms.

--- a/adapters/claude-code/commands/wa-guardrails.md
+++ b/adapters/claude-code/commands/wa-guardrails.md
@@ -1,4 +1,4 @@
-Generate preventive Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — so a workload stays compliant over time instead of being assessed once.
+Generate preventive Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — so a workload stays aligned with Well-Architected best practices over time instead of being assessed once.
 
 Unlike the assessment commands (which find gaps) or one-off remediation (which fixes a single finding), guardrails codify best practices so non-compliant changes are blocked or flagged automatically — in CI, at deploy time, and continuously in the account.
 

--- a/adapters/cline/.clinerules
+++ b/adapters/cline/.clinerules
@@ -66,3 +66,4 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time

--- a/adapters/cline/.clinerules
+++ b/adapters/cline/.clinerules
@@ -66,4 +66,4 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
-- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload aligned with Well-Architected best practices over time

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -58,6 +58,6 @@ When the user asks for a specific assessment, follow the structured approach in 
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
-- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload aligned with Well-Architected best practices over time
 
 Read the corresponding `skills/{skill-name}/SKILL.md` file and follow its steps.

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -58,5 +58,6 @@ When the user asks for a specific assessment, follow the structured approach in 
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time
 
 Read the corresponding `skills/{skill-name}/SKILL.md` file and follow its steps.

--- a/adapters/devops-agent/README.md
+++ b/adapters/devops-agent/README.md
@@ -58,6 +58,7 @@ This creates zip files ready for upload in the target directory.
 | `migration-readiness` | On-demand |
 | `architecture-decision-record` | On-demand |
 | `wa-builder` | On-demand, Evaluation |
+| `wa-guardrails` | On-demand, Evaluation |
 
 ## Shared assets
 

--- a/adapters/gemini-cli/GEMINI.md
+++ b/adapters/gemini-cli/GEMINI.md
@@ -60,4 +60,4 @@ Well-Architected skills are available as reusable playbooks in the `skills/` dir
 - [migration-readiness](file:///skills/migration-readiness/SKILL.md) (Migration readiness assessment)
 - [architecture-decision-record](file:///skills/architecture-decision-record/SKILL.md) (Architecture decision record template)
 - [wa-builder](file:///skills/wa-builder/SKILL.md) (Understand Well-Architected for your workload and generate visual artifacts: annotated diagrams, decision trees, roadmaps)
-- [wa-guardrails](file:///skills/wa-guardrails/SKILL.md) (Generate preventive guardrails: Config rules, SCPs, CI policy checks, alarms to keep a workload compliant over time)
+- [wa-guardrails](file:///skills/wa-guardrails/SKILL.md) (Generate preventive guardrails: Config rules, SCPs, CI policy checks, alarms to keep a workload aligned with Well-Architected best practices over time)

--- a/adapters/gemini-cli/GEMINI.md
+++ b/adapters/gemini-cli/GEMINI.md
@@ -60,3 +60,4 @@ Well-Architected skills are available as reusable playbooks in the `skills/` dir
 - [migration-readiness](file:///skills/migration-readiness/SKILL.md) (Migration readiness assessment)
 - [architecture-decision-record](file:///skills/architecture-decision-record/SKILL.md) (Architecture decision record template)
 - [wa-builder](file:///skills/wa-builder/SKILL.md) (Understand Well-Architected for your workload and generate visual artifacts: annotated diagrams, decision trees, roadmaps)
+- [wa-guardrails](file:///skills/wa-guardrails/SKILL.md) (Generate preventive guardrails: Config rules, SCPs, CI policy checks, alarms to keep a workload compliant over time)

--- a/adapters/junie/guidelines.md
+++ b/adapters/junie/guidelines.md
@@ -50,4 +50,4 @@ When delivering Well-Architected guidance:
 
 ## Skills
 
-For structured assessments, invoke the corresponding skill by name: `wa-review`, `security-assessment`, `reliability-improvement-plan`, `cost-optimization-review`, `performance-efficiency`, `sustainability-optimization`, `operational-excellence`, `migration-readiness`, `architecture-decision-record`, or `wa-builder`.
+For structured assessments, invoke the corresponding skill by name: `wa-review`, `security-assessment`, `reliability-improvement-plan`, `cost-optimization-review`, `performance-efficiency`, `sustainability-optimization`, `operational-excellence`, `migration-readiness`, `architecture-decision-record`, `wa-builder`, or `wa-guardrails`.

--- a/adapters/openclaw/AGENTS.md
+++ b/adapters/openclaw/AGENTS.md
@@ -62,4 +62,4 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
-- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload aligned with Well-Architected best practices over time

--- a/adapters/openclaw/AGENTS.md
+++ b/adapters/openclaw/AGENTS.md
@@ -62,3 +62,4 @@ For structured assessments, load the corresponding skill from `.agents/skills/`:
 - `migration-readiness` — 7 Rs assessment, dependency analysis, migration plan
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time

--- a/adapters/windsurf/.windsurfrules
+++ b/adapters/windsurf/.windsurfrules
@@ -66,3 +66,4 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time

--- a/adapters/windsurf/.windsurfrules
+++ b/adapters/windsurf/.windsurfrules
@@ -66,4 +66,4 @@ For structured assessments, read and follow the step-by-step instructions in the
 - `operational-excellence` — CI/CD, observability, incident management, operational maturity
 - `architecture-decision-record` — ADR with WA pillar impact analysis
 - `wa-builder` — Understand Well-Architected for your workload and generate visual artifacts (annotated diagrams, decision trees, roadmaps)
-- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload compliant over time
+- `wa-guardrails` — Generate preventive guardrails (Config rules, SCPs, CI policy checks, alarms) to keep a workload aligned with Well-Architected best practices over time

--- a/llms.txt
+++ b/llms.txt
@@ -39,6 +39,8 @@ curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-s
 - `skills/operational-excellence/SKILL.md` — CI/CD, observability, incident management, automation
 - `skills/migration-readiness/SKILL.md` — 7 Rs assessment with migration plan
 - `skills/architecture-decision-record/SKILL.md` — WA-aligned ADR with pillar impact analysis
+- `skills/wa-builder/SKILL.md` — Learn WA for your workload and produce visual artifacts (diagrams, decision trees, roadmaps)
+- `skills/wa-guardrails/SKILL.md` — Generate preventive controls (Config rules, SCPs, CI checks, alarms) for ongoing compliance
 
 ### Reference material:
 

--- a/llms.txt
+++ b/llms.txt
@@ -40,7 +40,7 @@ curl -sL https://raw.githubusercontent.com/aws-samples/sample-well-architected-s
 - `skills/migration-readiness/SKILL.md` — 7 Rs assessment with migration plan
 - `skills/architecture-decision-record/SKILL.md` — WA-aligned ADR with pillar impact analysis
 - `skills/wa-builder/SKILL.md` — Learn WA for your workload and produce visual artifacts (diagrams, decision trees, roadmaps)
-- `skills/wa-guardrails/SKILL.md` — Generate preventive controls (Config rules, SCPs, CI checks, alarms) for ongoing compliance
+- `skills/wa-guardrails/SKILL.md` — Generate preventive controls (Config rules, SCPs, CI checks, alarms) for ongoing adherence to WA guidance
 
 ### Reference material:
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -19,8 +19,8 @@
       ]
     },
     {
-      "title": "Enforcement & Compliance",
-      "description": "Codify best practices as ongoing controls that keep a workload compliant over time.",
+      "title": "Enforcement & Governance",
+      "description": "Codify best practices as ongoing controls that keep a workload aligned with Well-Architected guidance over time.",
       "skills": ["wa-guardrails"]
     }
   ]

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -17,6 +17,11 @@
         "operational-excellence",
         "sustainability-optimization"
       ]
+    },
+    {
+      "title": "Enforcement & Compliance",
+      "description": "Codify best practices as ongoing controls that keep a workload compliant over time.",
+      "skills": ["wa-guardrails"]
     }
   ]
 }

--- a/skills/wa-guardrails/SKILL.md
+++ b/skills/wa-guardrails/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: wa-guardrails
+description: Generate preventive Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — plus an optional governance steering doc, so a workload stays compliant over time instead of being assessed once. Use when the user wants to enforce best practices in CI, prevent insecure or non-compliant configurations from shipping, detect configuration drift, codify the fixes from a Well-Architected review as ongoing controls, or capture standards as an always-on steering file for their AI coding agent.
+version: 1.0.0
+---
+
+# Well-Architected Guardrails
+
+This skill generates **preventive and detective controls** that keep a workload Well-Architected over time. Unlike the assessment skills (which find gaps) or remediation (which fixes a specific finding once), guardrails codify best practices so non-compliant changes are blocked or flagged automatically — in CI, at deploy time, and continuously in the account.
+
+**What you'll produce:** ready-to-commit control files (Config rules, SCPs, CI policy checks, alarms), each tied to the WA Question/Best Practice ID it enforces, with a note on whether the control is **preventive** (blocks the bad change) or **detective** (flags it after the fact).
+
+## Step 1: Gather context
+
+Ask the user (skip any already provided or inferable from the codebase):
+
+> I can generate guardrails to keep your workload Well-Architected. Let me know:
+> - **Workload name** and code packages/directories (IaC, CI/CD configs)
+> - **IaC dialect**: CDK (which language), CloudFormation, Terraform, SAM, or mixed
+> - **Source of controls**: a prior `/wa-review` or assessment output, specific concerns, or "scan and propose"
+> - **Enforcement points available**: CI pipeline (which one), AWS Organizations/SCPs, AWS Config, account-level admin — so controls target what you can actually deploy
+> - **Pillars to prioritize** (optional; default: Security and Reliability)
+
+If you are in a codebase, proceed directly and infer the IaC dialect and CI system from the files present.
+
+## Step 2: Discovery — what to enforce
+
+Determine the controls to generate from one of two inputs:
+
+**Path A — From an assessment (preferred):** parse the prior review for findings, their pillar, severity, evidence (file:line), and the Best Practice IDs cited. Each High/Critical finding becomes a candidate guardrail so the same gap cannot recur.
+
+**Path B — Standalone scan:** analyze the IaC and identify the control-worthy configurations actually in use — storage encryption, public access, IAM scope, multi-AZ, backups, logging, TLS, tagging. Map each to the WA Best Practice it relates to.
+
+Produce a **control candidate list**: for each, record the pillar, the WA Question/BP ID, the resource type it applies to, the current state (compliant / non-compliant / absent), and the **enforcement point** that fits (CI check, Config rule, SCP, alarm).
+
+## Step 3: Select preventive vs. detective for each control
+
+For every candidate, choose the strongest control the user's enforcement points allow. Prefer **preventive** (stops the bad change before it ships) over **detective** (catches it afterward). Use this decision guidance:
+
+- Can the misconfiguration be caught in IaC before deploy? → **CI policy check** (CDK Aspect, `cfn-guard`/`cfn-lint`, Terraform OPA/Sentinel). Strongest and cheapest.
+- Must it be blocked org-wide regardless of who deploys? → **SCP or permission boundary**.
+- Is it only observable on the live resource (e.g. drift, runtime state)? → **AWS Config rule** (detective; add auto-remediation only if the user confirms).
+- Is it a continuous reliability/cost/performance signal? → **CloudWatch metric + alarm**.
+
+If a control cannot be enforced with the available points, say so explicitly rather than emitting a control that won't run.
+
+## Step 4: Generate the controls
+
+Generate every selected control as ready-to-commit code in the workload's existing dialect and conventions. Each control MUST:
+
+- Cite the WA Question/BP ID it enforces (e.g. `SEC 8`, `REL 9`)
+- Be labeled 🛡️ Preventive or 🔍 Detective
+- Include a one-line statement of what it blocks/flags and why it matters
+
+Cover, as applicable to the workload:
+
+**Security (SEC)** — examples: `s3-bucket-server-side-encryption-enabled`, `s3-bucket-public-read-prohibited`, `iam-policy-no-statements-with-admin-access` (Config); SCP denying creation of unencrypted resources or disabling CloudTrail; a CDK Aspect failing synth on a security group open to `0.0.0.0/0` on non-web ports.
+
+**Reliability (REL)** — `rds-multi-az-support`, `dynamodb-pitr-enabled`, `db-instance-backup-enabled` (Config); a `cfn-guard` rule requiring `DeletionProtection` on stateful resources; an alarm on DLQ depth.
+
+**Operational Excellence (OPS)** — a CI check requiring tags (owner, cost-center, environment); a Config rule for required CloudWatch log retention; an SCP preventing manual changes outside IaC.
+
+**Cost (COST)** — a CI check flagging instance types or capacity modes outside an approved list; a budget/anomaly alarm.
+
+**Performance / Sustainability (PERF/SUS)** — a CI check preferring Graviton/managed services where applicable.
+
+Provide each control's snippet in a fenced code block with the target filename, so the user can commit it directly. Match the workload's dialect — examples of the three most common forms:
+
+**Detective — AWS Config managed rule (SEC 8, encryption at rest), CloudFormation:**
+
+```yaml
+# guardrails/config-rules.yaml
+Resources:
+  S3EncryptionEnabled:                      # 🔍 Detective — flags any S3 bucket without SSE
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: s3-bucket-server-side-encryption-enabled
+      Source: { Owner: AWS, SourceIdentifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED }
+```
+
+**Preventive — CDK Aspect (SEC 5, no open security groups), TypeScript:**
+
+```typescript
+// guardrails/no-open-sg.aspect.ts
+import { IAspect, Annotations } from "aws-cdk-lib";
+import { CfnSecurityGroupIngress } from "aws-cdk-lib/aws-ec2";
+import { IConstruct } from "constructs";
+
+// 🛡️ Preventive — fails `cdk synth` on 0.0.0.0/0 ingress to non-web ports
+export class NoOpenIngress implements IAspect {
+  visit(node: IConstruct): void {
+    if (node instanceof CfnSecurityGroupIngress &&
+        node.cidrIp === "0.0.0.0/0" && ![80, 443].includes(Number(node.fromPort))) {
+      Annotations.of(node).addError(`SEC 5: security group open to 0.0.0.0/0 on port ${node.fromPort}`);
+    }
+  }
+}
+```
+
+**Preventive — cfn-guard rule (REL 9, stateful resources need deletion protection):**
+
+```
+# guardrails/reliability.guard
+# 🛡️ Preventive — blocks RDS instances without Multi-AZ + deletion protection
+AWS::RDS::DBInstance {
+  Properties { MultiAZ == true  DeletionProtection == true }
+}
+```
+
+## Step 5: Produce the guardrails plan
+
+Output a structured deliverable:
+
+```markdown
+# Well-Architected Guardrails: {Workload Name}
+
+## Summary
+- **IaC dialect**: {CDK/CloudFormation/Terraform/SAM}
+- **Enforcement points used**: {CI / Config / SCP / alarms}
+- **Source**: {prior review / standalone scan}
+- **Controls generated**: {N} ({P} preventive, {D} detective) across {pillars}
+
+## Controls by pillar
+
+### {Pillar} — {WA Question/BP ID}
+- **Control**: {name}  |  🛡️ Preventive / 🔍 Detective  |  Enforcement: {CI / Config / SCP / alarm}
+- **Blocks/flags**: {what, and why it matters}
+- **File**: `{path}`
+  ```{lang}
+  {ready-to-commit snippet}
+  ```
+- **Coverage gap** (if any): {what this control does NOT catch}
+
+## Rollout plan
+| Order | Control | Enforcement | Risk of false-positive | Notes |
+|-------|---------|-------------|------------------------|-------|
+{Start in warn/log mode for preventive CI checks and SCPs, then promote to block once clean.}
+
+## Verification
+{How to confirm each control works — e.g. attempt a known-bad change in a branch and confirm CI fails; check Config rule compliance status.}
+
+## Not covered
+{Controls the available enforcement points cannot implement, and what would be needed.}
+```
+
+## Step 6: Offer a governance steering doc
+
+Beyond machine-enforced controls, offer to capture the same standards as a **human- and agent-readable governance doc** — the prose counterpart to the guardrails. This is useful for the standards a control can't fully express (design conventions, review expectations) and for teams that want an always-on policy their AI coding agent will follow.
+
+Generate it on request as a steering file the agent loads automatically (e.g. `.kiro/steering/`, `CLAUDE.md`, `.cursor/rules/`), structured as:
+
+```markdown
+# {Workload} — Well-Architected Guardrails (Governance)
+
+## Enforced automatically
+{One line per machine control, linking the rule file and its WA BP ID — so readers know what is already gated in CI/Config.}
+
+## Conventions to follow (not auto-enforced)
+- {Pillar} — {convention}, because {WA BP ID rationale}. {How a reviewer/agent checks it.}
+
+## When proposing or reviewing changes to this workload
+- {Standing instruction, e.g. "new data stores MUST set encryption + backups before merge (SEC 8 / REL 9)"}
+```
+
+Keep each statement tied to a WA Question/BP ID, and keep the doc short enough to live in always-on context without bloat.
+
+## Step 7: Offer follow-up
+
+> Would you like me to:
+> - Generate the CI workflow wiring (GitHub Actions / CodePipeline step) to run the policy checks?
+> - Produce a governance steering doc (`CLAUDE.md` / `.cursor/rules/` / `.kiro/steering/`) capturing these standards for your AI agent?
+> - Add auto-remediation to a detective Config rule (with safety review)?
+> - Run a `/wa-remediation` pass to fix the existing violations these guardrails would block?
+> - Tighten a control from warn mode to block mode?
+
+## Calibration Guidance
+
+- Prefer **preventive** controls (catch in CI/IaC) over **detective** — they're cheaper and stop the problem before it ships; only fall back to detective when the issue is only visible on the live resource.
+- Never emit a control for an enforcement point the user doesn't have — say it's not enforceable and what's needed instead.
+- **Roll out preventive controls in warn/log mode first.** Recommending a hard `block` or `Deny` SCP on day one risks breaking existing pipelines — flag this and stage it.
+- Auto-remediation is **destructive**: only generate it when the user explicitly asks, and include a safety/rollback note.
+- Tie every control to a WA Question/BP ID so the builder can trace the rationale — a guardrail without a "why" gets disabled the first time it's inconvenient.
+- Don't over-generate: a focused set of high-value controls that the team will keep beats 50 noisy rules they'll mute.
+- Respect the workload's existing dialect and conventions — emit CDK Aspects for a CDK app, `cfn-guard` for CloudFormation, OPA/Sentinel for Terraform; don't mix paradigms.
+- The governance steering doc complements controls, it doesn't replace them — prefer a machine-enforced control whenever one exists, and use the doc for what code can't express. Keep it concise enough for always-on context.

--- a/skills/wa-guardrails/SKILL.md
+++ b/skills/wa-guardrails/SKILL.md
@@ -170,7 +170,7 @@ Keep each statement tied to a WA Question/BP ID, and keep the doc short enough t
 > - Generate the CI workflow wiring (GitHub Actions / CodePipeline step) to run the policy checks?
 > - Produce a governance steering doc (`CLAUDE.md` / `.cursor/rules/` / `.kiro/steering/`) capturing these standards for your AI agent?
 > - Add auto-remediation to a detective Config rule (with safety review)?
-> - Run a `/wa-remediation` pass to fix the existing violations these guardrails would block?
+> - Fix the existing violations these guardrails would block (remediate the current code)?
 > - Tighten a control from warn mode to block mode?
 
 ## Calibration Guidance

--- a/skills/wa-guardrails/SKILL.md
+++ b/skills/wa-guardrails/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wa-guardrails
-description: Generate preventive Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — plus an optional governance steering doc, so a workload stays compliant over time instead of being assessed once. Use when the user wants to enforce best practices in CI, prevent insecure or non-compliant configurations from shipping, detect configuration drift, codify the fixes from a Well-Architected review as ongoing controls, or capture standards as an always-on steering file for their AI coding agent.
+description: Generate preventive Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — plus an optional governance steering doc, so a workload stays aligned with Well-Architected best practices over time instead of being assessed once. Use when the user wants to enforce best practices in CI, prevent insecure or non-compliant configurations from shipping, detect configuration drift, codify the fixes from a Well-Architected review as ongoing controls, or capture standards as an always-on steering file for their AI coding agent.
 version: 1.0.0
 ---
 

--- a/skills/wa-guardrails/evals/evals.json
+++ b/skills/wa-guardrails/evals/evals.json
@@ -1,0 +1,58 @@
+{
+  "skill_name": "wa-guardrails",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We keep shipping S3 buckets without encryption and security groups open to 0.0.0.0/0 — it gets caught in review but only after merge. We use AWS CDK (TypeScript) and GitHub Actions. Can you set up guardrails so these are blocked before they ship?",
+      "expected_output": "Preventive CI/IaC controls (CDK Aspects and/or cfn-guard) that fail the build on unencrypted S3 and open security groups, tied to WA Security best practices, with rollout guidance.",
+      "assertions": [
+        "Generates preventive controls that run in CI/IaC (e.g. CDK Aspect or cfn-guard) rather than only detective AWS Config rules",
+        "Produces a control that fails on S3 buckets without server-side encryption",
+        "Produces a control that fails on security groups open to 0.0.0.0/0 on non-web ports",
+        "Emits CDK-based controls (TypeScript) consistent with the stated CDK stack, not Terraform or a mismatched dialect",
+        "Ties each control to a Well-Architected Security question or best-practice ID (e.g. SEC 5, SEC 8)",
+        "Recommends rolling out in warn/log mode before hard-blocking to avoid breaking existing pipelines",
+        "Provides a way to verify the control works (e.g. attempt a known-bad change and confirm CI fails)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I just ran a wa-review. Lowest scores were Reliability (no RDS Multi-AZ, no DynamoDB PITR, no backups on several stores) and Security (IAM roles with Action: '*'). We're on CloudFormation. I want controls so these gaps can't come back. We have AWS Config and AWS Organizations available.",
+      "expected_output": "Guardrails derived from the review findings: Config rules and/or SCPs enforcing Multi-AZ, PITR, backups, and least-privilege, each labeled preventive vs detective and mapped to BP IDs.",
+      "assertions": [
+        "Derives the controls from the review's findings (Reliability and Security gaps) rather than starting from scratch",
+        "Generates controls for RDS Multi-AZ, DynamoDB PITR, and backup enablement",
+        "Generates a control addressing IAM policies with admin/wildcard actions",
+        "Labels each control as preventive or detective and uses the available enforcement points (AWS Config and/or SCPs)",
+        "Maps controls to Reliability and Security best-practice IDs (e.g. REL 9, SEC 3)",
+        "Notes that auto-remediation on Config rules is destructive and only includes it with a safety caveat or on explicit request"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Set up guardrails for our Lambda + DynamoDB + API Gateway app on Terraform. We want required tagging (owner, cost-center, environment) enforced and to catch any resource that isn't Graviton/ARM where it could be. We run Terraform Cloud. We do NOT have AWS Organizations or SCP access.",
+      "expected_output": "Terraform-native policy controls (OPA/Sentinel) for tagging and architecture preferences, correctly avoiding SCP-based controls since the user lacks Organizations access.",
+      "assertions": [
+        "Generates Terraform-native policy controls (OPA/Sentinel for Terraform Cloud) rather than CDK Aspects or CloudFormation tooling",
+        "Produces a control enforcing required tags (owner, cost-center, environment)",
+        "Produces a control flagging non-Graviton/ARM compute where applicable",
+        "Does NOT propose SCPs or Organizations-level controls, since the user stated they lack that access",
+        "Ties the tagging and architecture controls to Well-Architected best practices (e.g. OPS, SUS/PERF, COST)",
+        "Recommends warn mode before hard enforcement for the new policy checks"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "We use Claude Code and Kiro across the team. Beyond CI checks, I want our AI coding agents to follow our Well-Architected standards automatically — things like 'new data stores must have encryption and backups' and our review expectations. Can you capture our guardrails as something the agents always read?",
+      "expected_output": "A governance steering document (CLAUDE.md / .kiro/steering) that captures the standards in agent-readable prose, tied to WA best practices, distinguishing auto-enforced controls from conventions.",
+      "assertions": [
+        "Produces a governance/steering document intended for always-on agent context (e.g. CLAUDE.md or .kiro/steering), not only machine controls",
+        "Includes standing instructions for proposing or reviewing changes (e.g. new data stores require encryption and backups)",
+        "Distinguishes standards that are auto-enforced by controls from conventions that are not machine-enforced",
+        "Ties the standards to Well-Architected Question/best-practice IDs (e.g. SEC 8, REL 9)",
+        "Keeps the document concise enough to live in always-on context rather than an exhaustive dump",
+        "Recommends a machine-enforced control where one exists rather than relying on the prose doc alone"
+      ]
+    }
+  ]
+}

--- a/skills/wa-guardrails/evals/triggering.json
+++ b/skills/wa-guardrails/evals/triggering.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "wa-guardrails",
+  "prompts": [
+    { "text": "set up guardrails so unencrypted S3 buckets can't be merged", "should_trigger": true },
+    { "text": "generate AWS Config rules to enforce our security baseline", "should_trigger": true },
+    { "text": "I want CI to block security groups open to 0.0.0.0/0 before deploy", "should_trigger": true },
+    { "text": "create SCPs to prevent anyone from disabling CloudTrail", "should_trigger": true },
+    { "text": "add cfn-guard rules so non-compliant CloudFormation fails the build", "should_trigger": true },
+    { "text": "enforce required tags (owner, cost-center, environment) on every resource", "should_trigger": true },
+    { "text": "codify the fixes from our wa-review as ongoing controls so they can't regress", "should_trigger": true },
+    { "text": "write a CDK Aspect that fails synth when RDS isn't Multi-AZ", "should_trigger": true },
+    { "text": "detect configuration drift on encryption and public access continuously", "should_trigger": true },
+    { "text": "give me OPA/Sentinel policies for Terraform to keep us compliant", "should_trigger": true },
+    { "text": "capture our Well-Architected standards as a steering doc our AI agents always follow", "should_trigger": true },
+    { "text": "turn our review findings into a governance policy in CLAUDE.md so the team's agents enforce them", "should_trigger": true },
+    { "text": "review our AWS costs and find savings opportunities", "should_trigger": false },
+    { "text": "write a CLAUDE.md describing our build commands and how to run tests", "should_trigger": false },
+    { "text": "draft team onboarding docs for our new engineers", "should_trigger": false },
+    { "text": "audit our security groups and IAM roles for vulnerabilities", "should_trigger": false },
+    { "text": "identify single points of failure and produce a remediation plan", "should_trigger": false },
+    { "text": "fix the unencrypted S3 bucket in our CDK code", "should_trigger": false },
+    { "text": "improve API Gateway response times", "should_trigger": false },
+    { "text": "plan our data center migration to AWS", "should_trigger": false },
+    { "text": "reduce our carbon footprint and resource waste", "should_trigger": false },
+    { "text": "do a full Well-Architected review of our workload", "should_trigger": false },
+    { "text": "help me understand Well-Architected and draw an architecture diagram", "should_trigger": false },
+    { "text": "document our decision to switch from SQS to EventBridge", "should_trigger": false }
+  ]
+}

--- a/skills/wa-guardrails/metadata.json
+++ b/skills/wa-guardrails/metadata.json
@@ -22,7 +22,7 @@
   ],
   "not_for": [
     "one-time gap assessment (use wa-review or a pillar assessment instead)",
-    "fixing a specific existing finding in code (use wa-remediation instead)",
+    "fixing a specific existing finding in code (remediate the code directly instead)",
     "learning Well-Architected or producing diagrams (use wa-builder instead)",
     "documenting a design decision (use architecture-decision-record instead)"
   ],

--- a/skills/wa-guardrails/metadata.json
+++ b/skills/wa-guardrails/metadata.json
@@ -1,0 +1,53 @@
+{
+  "version": "1.0.0",
+  "organization": "AWS",
+  "date": "June 2026",
+  "abstract": "Generate preventive and detective Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — so a workload stays compliant over time instead of being assessed once.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html",
+    "https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html",
+    "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html"
+  ],
+  "triggers": [
+    "enforce Well-Architected best practices",
+    "generate AWS Config rules",
+    "prevent insecure configurations",
+    "continuous compliance controls",
+    "configuration drift detection",
+    "service control policies",
+    "CI policy checks for IaC",
+    "guardrails for my workload",
+    "cfn-guard or CDK Aspect rules",
+    "codify review findings as controls"
+  ],
+  "not_for": [
+    "one-time gap assessment (use wa-review or a pillar assessment instead)",
+    "fixing a specific existing finding in code (use wa-remediation instead)",
+    "learning Well-Architected or producing diagrams (use wa-builder instead)",
+    "documenting a design decision (use architecture-decision-record instead)"
+  ],
+  "metadata": {
+    "service": [
+      "config",
+      "organizations",
+      "iam",
+      "cloudwatch",
+      "cloudformation",
+      "cdk"
+    ],
+    "task": [
+      "enforce",
+      "prevent",
+      "monitor"
+    ],
+    "persona": [
+      "platform-engineer",
+      "security-engineer",
+      "solutions-architect",
+      "developer"
+    ],
+    "workload": [
+      "any"
+    ]
+  }
+}

--- a/skills/wa-guardrails/metadata.json
+++ b/skills/wa-guardrails/metadata.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "organization": "AWS",
   "date": "June 2026",
-  "abstract": "Generate preventive and detective Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — so a workload stays compliant over time instead of being assessed once.",
+  "abstract": "Generate preventive and detective Well-Architected guardrails — AWS Config rules, Service Control Policies, permission boundaries, CloudWatch alarms, and IaC policy checks (CDK Aspects, cfn-guard, OPA/Sentinel) — so a workload stays aligned with Well-Architected best practices over time instead of being assessed once.",
   "references": [
     "https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html",
     "https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html",
@@ -12,7 +12,7 @@
     "enforce Well-Architected best practices",
     "generate AWS Config rules",
     "prevent insecure configurations",
-    "continuous compliance controls",
+    "continuous alignment with best practices",
     "configuration drift detection",
     "service control policies",
     "CI policy checks for IaC",


### PR DESCRIPTION
Fixes #40.

## What this adds

A new skill, **`wa-guardrails`**, that codifies Well-Architected best practices as **ongoing controls** so a workload stays aligned with best practices over time — rather than being assessed once. Where the existing skills *find* gaps, this one *prevents* them from recurring.

Given a prior `/wa-review` (or a fresh scan), the skill generates — matched to the workload's IaC dialect:

- **Preventive CI/IaC checks** — CDK Aspects, `cfn-guard`/`cfn-lint`, Terraform OPA/Sentinel
- **Detective AWS Config rules** — with optional, safety-gated auto-remediation
- **Service Control Policies / permission boundaries**
- **CloudWatch metrics + alarms**
- **An optional governance steering doc** — `CLAUDE.md` / `.kiro/steering/` / `.cursor/rules/` capturing standards an always-on agent will follow, the prose counterpart to machine controls (added from review feedback that the skill "can even help generate steering files")

Every control is tied to a WA Question/BP ID, labeled 🛡️ preventive or 🔍 detective, and rolled out in warn/log mode first to avoid breaking existing pipelines.

## Files

- `skills/wa-guardrails/SKILL.md` — 7-step playbook with a decision tree for control selection, **worked code examples** for each dialect (Config rule, CDK Aspect, cfn-guard), and a calibration section.
- `skills/wa-guardrails/metadata.json`, `evals/evals.json` (4 cases, 6–7 assertions each, incl. the steering-doc scenario), `evals/triggering.json` (12 positive + 12 negative prompts).
- Wired into the 8 enumerating adapters, `CLAUDE.md`, a `/wa-guardrails` Claude Code command, `README.md` (file tree + skills table), `llms.txt`, and `skills.sh.json` (new "Enforcement & Compliance" grouping).

## Effectiveness

Measured on Amazon Bedrock (Claude Opus 4.8), **averaged over 5 runs** (not a single sample, to avoid noise/cherry-picking). The with-skill arm improved over baseline and was never below it; every run but one passed every assertion, and that run flaked on a single assertion (eval non-determinism — Opus 4.8 runs at default temperature since it rejects `temperature: 0`). Run the arms yourself:

```bash
cd evals && uv run python run.py --skill wa-guardrails --runs 5 --verbose
```

## Testing

- **Installer round-trip** (`install.sh --tool all` then `--uninstall --tool all`): installs to every tool's skills dir, creates the `/wa-guardrails` command, all adapter docs name it, uninstall removes everything cleanly.
- **pytest**: structure + triggering tests pass; all JSON validates.
- **Live Bedrock evals**: as above.

## Note

Also adds the `wa-builder` entry to `llms.txt`, which was missed when `wa-builder` was wired up in #33.

## Intentionally not touched

`cursor`, `github-copilot`, and `antigravity` adapters are always-on steering only and do not enumerate skills by name (cursor still receives the skill via the installer's `skills/` copy; copilot has no skill mechanism), so they need no change — consistent with how `wa-builder` was wired in #33.

---

_Edited to remove measurement figures. The eval runner ships in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
