### PR TITLE
Fix crawler pillar-as-leaf drop; restore serverless Sustainability pillar

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Then in Kiro: Powers panel → **Add Custom Power** → **Import power from a fo
 
 - Auto-activates when you mention "well-architected", "architecture review", "security review", "reliability", etc.
 - Loads only relevant steering based on your current task
-- Progressive BP-level reference loading (57 question files + 8 lens packs) — managed automatically
+- Progressive BP-level reference loading (57 question files + 9 lens packs) — managed automatically
 
 > [!NOTE]
 > Kiro's "Import from GitHub" expects `POWER.md` at the repository root. Since this repo contains multiple skills and adapters, the Power lives under `powers/wa-review/` and must be imported from a local folder. If you want GitHub-based import, you can fork just the `powers/wa-review/` directory into its own repo.
@@ -550,7 +550,7 @@ graph LR
 
 ## 📊 Reference data and token consumption
 
-The `wa-review` skill includes **307 best practices** across **57 framework questions** plus **8 lens extensions** — sourced directly from the [AWS Well-Architected public documentation](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html). This reference data lives in `skills/wa-review/references/` and is loaded progressively (one question at a time), not all at once.
+The `wa-review` skill includes **307 best practices** across **57 framework questions** plus **9 lens extensions** — sourced directly from the [AWS Well-Architected public documentation](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html). This reference data lives in `skills/wa-review/references/` and is loaded progressively (one question at a time), not all at once.
 
 ### Reference data summary
 
@@ -565,6 +565,7 @@ The `wa-review` skill includes **307 best practices** across **57 framework ques
 | Migration Lens | 6 | 76 KB | Migration planning |
 | DevOps Guidance Lens | 196 | 820 KB | CI/CD, automated governance, dev lifecycle, observability |
 | Machine Learning Lens | 35 | 852 KB | ML lifecycle (MLOPS), training/deployment, data engineering, responsible ML |
+| Data Analytics Lens | 6 | 180 KB | Data pipelines, governance, catalogs, lineage, analytics perf & cost |
 
 ### Token strategies
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The `wa-review` skill includes **307 best practices** across **57 framework ques
 | Content | Files | Size | Loaded when |
 |---------|-------|------|-------------|
 | Framework questions | 57 | 2.2 MB | Full review — one file per question evaluated |
-| Serverless Lens | 5 | 116 KB | Workload uses Lambda/API Gateway/Step Functions |
+| Serverless Lens | 6 | 120 KB | Workload uses Lambda/API Gateway/Step Functions |
 | Generative AI Lens | 29 | 368 KB | LLM, RAG, or fine-tuning workloads |
 | Agentic AI Lens | 41 | 1.2 MB | AI agent workloads |
 | Responsible AI Lens | 28 | 780 KB | AI governance and fairness requirements |

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Then in Kiro: Powers panel → **Add Custom Power** → **Import power from a fo
 
 - Auto-activates when you mention "well-architected", "architecture review", "security review", "reliability", etc.
 - Loads only relevant steering based on your current task
-- Progressive BP-level reference loading (57 question files + 7 lens packs) — managed automatically
+- Progressive BP-level reference loading (57 question files + 8 lens packs) — managed automatically
 
 > [!NOTE]
 > Kiro's "Import from GitHub" expects `POWER.md` at the repository root. Since this repo contains multiple skills and adapters, the Power lives under `powers/wa-review/` and must be imported from a local folder. If you want GitHub-based import, you can fork just the `powers/wa-review/` directory into its own repo.
@@ -550,7 +550,7 @@ graph LR
 
 ## 📊 Reference data and token consumption
 
-The `wa-review` skill includes **307 best practices** across **57 framework questions** plus **7 lens extensions** — sourced directly from the [AWS Well-Architected public documentation](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html). This reference data lives in `skills/wa-review/references/` and is loaded progressively (one question at a time), not all at once.
+The `wa-review` skill includes **307 best practices** across **57 framework questions** plus **8 lens extensions** — sourced directly from the [AWS Well-Architected public documentation](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html). This reference data lives in `skills/wa-review/references/` and is loaded progressively (one question at a time), not all at once.
 
 ### Reference data summary
 
@@ -564,6 +564,7 @@ The `wa-review` skill includes **307 best practices** across **57 framework ques
 | Hybrid Networking Lens | 30 | 480 KB | Direct Connect, VPN, Transit Gateway |
 | Migration Lens | 6 | 76 KB | Migration planning |
 | DevOps Guidance Lens | 196 | 820 KB | CI/CD, automated governance, dev lifecycle, observability |
+| Machine Learning Lens | 35 | 852 KB | ML lifecycle (MLOPS), training/deployment, data engineering, responsible ML |
 
 ### Token strategies
 

--- a/powers/wa-review/POWER.md
+++ b/powers/wa-review/POWER.md
@@ -32,7 +32,7 @@ This power uses multiple steering files for different workflows. Kiro loads only
 The power includes detailed best-practice reference files that are loaded progressively during a review (one question at a time to manage context):
 
 - `steering/references/questions/` — 57 files, one per WA Framework question, containing all best practices with implementation guidance
-- `steering/references/lenses/` — Additional lens-specific best practices (serverless, generative-ai, agentic-ai, responsible-ai, hybrid-networking, migration, devops-guidance, machine-learning)
+- `steering/references/lenses/` — Additional lens-specific best practices (serverless, generative-ai, agentic-ai, responsible-ai, hybrid-networking, migration, devops-guidance, machine-learning, data-analytics)
 
 The agent loads these on demand — you don't need to do anything. During a full review, it works through questions sequentially: quick-scan first, then deep-dives only on questions where gaps are found.
 

--- a/powers/wa-review/POWER.md
+++ b/powers/wa-review/POWER.md
@@ -32,7 +32,7 @@ This power uses multiple steering files for different workflows. Kiro loads only
 The power includes detailed best-practice reference files that are loaded progressively during a review (one question at a time to manage context):
 
 - `steering/references/questions/` — 57 files, one per WA Framework question, containing all best practices with implementation guidance
-- `steering/references/lenses/` — Additional lens-specific best practices (serverless, generative-ai, agentic-ai, responsible-ai, hybrid-networking, migration, devops-guidance)
+- `steering/references/lenses/` — Additional lens-specific best practices (serverless, generative-ai, agentic-ai, responsible-ai, hybrid-networking, migration, devops-guidance, machine-learning)
 
 The agent loads these on demand — you don't need to do anything. During a full review, it works through questions sequentially: quick-scan first, then deep-dives only on questions where gaps are found.
 

--- a/powers/wa-review/steering/references/lenses/data-analytics/cost-optimization.md
+++ b/powers/wa-review/steering/references/lenses/data-analytics/cost-optimization.md
@@ -1,0 +1,420 @@
+# Cost optimization
+
+**Pages**: 11
+
+---
+
+# Best practice 11.1 – Decouple storage from compute
+
+It’s common for data assets to grow exponentially year over
+year. However, your compute needs might not grow at the same
+rate. Decoupling storage from compute allows you to manage
+the cost of storage and compute separately, and implement
+different cost optimization features to minimize cost.
+
+## Suggestion 11.1.1 – Use services that decouple compute from storage
+
+Services that allow independent scaling of storage and compute allow for greater flexibility when handling workloads. This means when your workload is compute intensive you do not need to deploy a large storage array to meet the compute power for running your workload.
+
+## Suggestion 11.1.2 – Use Amazon Redshift RA3 instances types
+
+Amazon Redshift RA3 instance types support the ability to
+decouple the compute and storage. This allows your Amazon Redshift storage to scale independently from your compute
+resources, which improves cost efficiencies for your data
+warehousing workloads.
+
+## Suggestion 11.1.3 – Use a decoupled ﬁle system for Big Data workloads
+
+The EMR file system (EMRFS) is an implementation of HDFS
+that all Amazon EMR clusters use for reading and writing
+regular files from Amazon EMR directly to Amazon S3. By
+using EMRFS, your organization is only charged for the
+storage used, rather than paying for overprovisioned and
+underutilized HDFS EBS storage.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.1---decouple-storage-from-compute..html*
+
+---
+
+# Best practice 11.2 – Plan and provision capacity for predictable workload usage
+
+For well-defined workloads, planning capacity ahead based on
+average usage pattern helps improve resource utilization and
+avoid over provisioning. For a spiky workload, set up
+automatic scaling to meet user and workload demand.
+
+## Suggestion 11.2.1 – Choose the right instance type based on workload pattern and growth ratio
+
+Consider resource needs, such as CPU, memory, and
+networking that meet the performance requirements of your
+workload. Choose the right instance type and avoid
+overprovisioning. An optimized EC2 instance runs your
+workloads with optimal performance and infrastructure
+cost. For example, choose the smaller instance if your
+growth ratio is low as this allows more granular
+incremental change.
+
+## Suggestion 11.2.2 – Choose the right sizing based on average or medium workload usage
+
+Right sizing is the process of matching instance types and
+sizes to your workload performance and capacity
+requirements at the lowest possible cost. It’s also the
+process of looking at deployed instances and identifying
+opportunities to downsize without compromising capacity or
+other requirements that will result in lower costs.
+
+## Suggestion 11.2.3 – Use automatic scaling capability to meet the peak demand instead of over provisioning
+
+Analytics services can scale dynamically to meet demand. Then, after the demand has dropped below a certain threshold, the service will remove the resources that are no longer needed. The automatic scaling of serverless services enables applications to handle sudden traffic spikes without capacity planning, reducing costs and improving availability.
+
+There are a number of services that can automatically scale, and other services that you need to configure the scaling for. For example, AWS services like Amazon EMR, AWS Glue, and Amazon Kinesis can auto-scale seamlessly in response to usage spikes and remove resources without any configuration.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.2---plan-and-provision-capacity-for-predictable-workload-usage..html*
+
+---
+
+# Best practice 11.3 – Use on-demand instances or serverless capacity for unpredictable workload usage
+
+Serverless services typically only charge for the compute used, or the use of other measures like data processed, but only when there is a workload actively using the service. In contrast, allocating infrastructure yourself often means paying for idle resources.
+
+## Suggestion 11.3.1 – Use Amazon Athena for ad hoc SQL workloads
+
+Amazon Athena is a serverless query service that makes it
+easy to analyze data directly in Amazon S3 using standard
+SQL. With Amazon Athena, you only pay for the queries that
+you run. You are charged based on the amount of data
+scanned per query.
+
+## Suggestion 11.3.2 – Use AWS Glue or Amazon EMR Serverless instead of Amazon EMR on EC2 for infrequent ETL jobs
+
+AWS Glue is a fully managed ETL (extract, transform, and
+load) service that makes it simple and cost-effective to
+categorize your data, clean it, enrich it, and move it
+reliably between various data stores and data streams.
+With AWS Glue jobs, you pay only for the resources used
+during the ETL process. In contrast, Amazon EMR on EC2 is
+typically used for frequently running jobs requiring
+semipersistent data storage.
+
+Amazon EMR Serverless provides a highly cost-effective way to run EMR clusters and data pipelines on an infrequent or intermittent basis. Unlike provisioned clusters that incur hourly charges even when idle, Serverless allows you to spin up a cluster on-demand when a job is submitted, and tear it down automatically once the job completes. This means you only pay for the actual time the cluster is running to process your workload, optimizing costs for infrequent ETL, data processing, or when-necessary analysis jobs.
+
+## Suggestion 11.3.3 – Use serverless resources for unpredictable or spiky workloads
+
+Use serverless analytics services, such as Amazon Redshift Serverless, Amazon EMR, Amazon Athena, Amazon Quick Serverless, and Amazon Managed Streaming for Apache Kafka (Amazon MSK) Serverless, to perform analytical queries, processing and streaming, with pay-as-you-go pricing. This helps remove the cost associated with idle resources.
+
+You can also use serverless resources for development and testing needs.
+
+For more details, see [AWS serverless data analytics pipeline reference architecture](https://aws.amazon.com/blogs/big-data/aws-serverless-data-analytics-pipeline-reference-architecture/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.3---use-on-demand-instance-capacity-for-unpredictable-workload-usage..html*
+
+---
+
+# Best practice 12.1 – Measure data storage and processing costs per user of the workload
+
+Data analytics workloads have recurring stable costs and
+per-use costs, for example, a weekly reporting job with
+relatively static data storage fees or periodic
+unpredictable processing runtime fees. Your organization
+should establish a financial attribution mechanism that
+captures data storage and workload usage when analytics
+systems are run. Using this approach, your end users
+(business unit, team, or individual) can be notified of their
+consumption at regular intervals.
+
+## Suggestion 12.1.1 – Use tagging or other attribution methods to identify workload and data storage ownership
+
+Collaboration between business, IT, and finance team to
+agree on cost allocation, cost ownership, cost charging,
+and budget management. Create budget tracking policy for
+storage and workload using tagging. Agree on the
+governance approach to implement policy (that is, central
+and decentralize), billing allocation, charge back, and
+budget reporting.
+
+For more details, refer to the following information:
+
+- AWS Cloud Financial Management Blog: Cost
+[Tagging
+and Reporting with AWS Organizations](https://aws.amazon.com/blogs/aws-cloud-financial-management/cost-tagging-and-reporting-with-aws-organizations/)
+- AWS Billing and Cost Management and Cost Management User Guide:
+[Reporting
+your budget metrics with budget reports](https://docs.aws.amazon.com/cost-management/latest/userguide/reporting-cost-budget.html),
+[Configuring
+AWS Budgets actions](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-controls.html) and
+[Creating
+an Amazon SNS topic for budget notifications](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-sns-policy.html)
+
+## Suggestion 12.1.2 – Implement cost-visibility and internal bill-back method to aggregate your teams' use of analytics resources
+
+Notify teams of their analytics usage costs periodically. Build dashboards that provide teams visibility into how their work impacts costs to the business using a self-service approach.
+
+You can view and optimize your costs through the AWS Cost and Usage Report and the Cost and Usage Dashboards Operations Solution (CUDOS) reports.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-12.1---measure-data-storage-and-processing-costs-per-user-of-the-workload..html*
+
+---
+
+# Best practice 12.2 – Build local or build centralized data analytics platforms
+
+Teams can establish their own data analytics resources that support their analytical needs locally, rather than extracting information and transferring it to a central location. Decide when teams benefit from building local analytics resources, balancing required agility and team skillset with the need for a centralized analytics platform.
+
+## Suggestion 12.2.1 – Perform regular reviews of analytics operations to determine if the business can benefit from teams managing their own infrastructure
+
+Teams may prefer to own and manage their own infrastructure, as this allows for more flexibility and agility in system design with fewer dependencies. Individual ownership also provides clear cost visibility. In other cases, a shared processing system can be more efficient, where teams send data requests to a central provider. Tracking request volume by team enables cost attribution. A centralized team managing infrastructure benefits multiple groups through increased resource utilization and concentrated expertise. Centralized data repositories make enriching data simpler and provide a single access point. Organizations find centralized analytics helps meet compliance and governance needs.
+
+In summary, there are trade-offs between decentralized team-owned infrastructure providing more flexibility compared to centralized shared infrastructure increasing utilization and governance. Teams and centralized providers can also coordinate, with centralized systems handling some processing and team systems providing customization. The best approach depends on the specific organizational needs and structure.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-12.2-build-local-or-centralized-data-analytics-platforms.html*
+
+---
+
+# Best practice 12.3 – Restrict and record resource allocation permissions using AWS Identity and Access Management (IAM)
+
+To better control costs, create distinct IAM roles that authorize users to provision certain resources. This ensures that only permitted individuals can provision the resources they are allowed to, preventing unauthorized and unnecessary spending.
+
+## Suggestion 12.3.1 – Create a cost governance framework that uses specialized IAM roles, rather than individual users, to provision costly infrastructure
+
+Restrict the authorization to launch costly resources to
+specific IAM roles. For example, certain instances types
+can only be provisioned by certain teams to reduce
+unnecessary expenditure.
+
+## Suggestion 12.3.2 – Track AWS CloudTrail logs to determine overall usage-per-user and role
+
+Track the usage across users and roles to get a clear understanding of resource
+usage. As part of your cost-allocation governance, automatically process the AWS CloudTrail logs so
+that cost allocation is properly attributed to the relevant department.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-12.3---restrict-and-record-resource-allocation-permissions-using-aws-identity-and-access-management-iam..html*
+
+---
+
+# Best practice 13.1 – Remove unused data and infrastructure
+
+Delete data that is out of its retention period, or not
+needed anymore. Delete intermediate-processed data that can
+be removed without business impacts. If the output of
+analytics jobs is not used by anyone, consider removing such
+jobs so that you don't waste resources.
+
+## Suggestion 13.1.1 – Track data freshness
+
+In many cases, maintaining a metadata repository for
+tracking data movement will be worthwhile. This is not
+only to instill confidence in the quality of the data, but
+also to identify infrequently updated data, and unused
+data.
+
+## Suggestion 13.1.2 – Delete data that is out of its retention period
+
+Data that is past its retention period should be deleted
+to reduce unnecessary storage costs. Identify data through
+the metadata catalog that is outside its retention period.
+To reduce human effort, automate the data removal process.
+If data is stored in Amazon S3, use Amazon S3 Lifecycle
+configurations to expire data automatically.
+
+## Suggestion 13.1.3 – Delete intermediate-processed data that can be removed without business impacts
+
+Many steps in analytics processes create intermediate or
+temporary datasets. Ensure that intermediate datasets are
+removed if they have no further business value.
+
+## Suggestion 13.1.4 – Remove unused analytics jobs that consume infrastructure resources but no one uses the job results
+
+Periodically review the ownership, source, and downstream
+consumers of all analytics infrastructure resources. If
+downstream consumers no longer need the analytics job,
+stop the job from running and remove unneeded resources.
+
+## Suggestion 13.1.5 – Use the lowest acceptable frequency for data processing
+
+Data processing requirements must be considered in the business context. There is no value in processing data faster than it is consumed or delivered. For example, in a sales analytics workload, it might not be necessary to perform analytics on each transaction as it arrives. In some cases, only hourly reports are needed by business management. Batch processing the transactions is more eﬃcient and can reduce unnecessary infrastructure costs between batch processing jobs.
+
+## Suggestion 13.1.6 – Compress data to reduce cost
+
+Data compression can significantly reduce storage and query costs. Columnar data formats like Apache Parquet stores data in columns rather than rows, allowing similar data to be stored contiguously. Using Parquet over CSV format can reduce storage costs significantly. Since services like Amazon Redshift Spectrum and Amazon Athena charge for bytes scanned, compressing data lowers the overall cost of using those services.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-13.1-remove-unused-data-and-infrastructure..html*
+
+---
+
+# Best practice 13.2 – Continuously evaluate your provisioned resources and identify overprovisioned workloads
+
+Workload resource utilization can change over time,
+especially with the growth of data or after process
+optimization has occurred. Your organization should review
+resource usage patterns and determine if you require the
+same infrastructure footprint to meet your business goals.
+
+## Suggestion 13.2.1 – Evaluate whether compute resources can be downsized
+
+Investigate your resource utilization by inspecting the
+metrics provided by Amazon CloudWatch. Evaluate whether
+the resources can be downsized to one-level smaller within
+the same instance class. For example, reduce Amazon EMR
+cluster nodes from m5.16xlarge to m5.12xlarge, or the
+number of instances that make up the cluster.
+
+## Suggestion 13.2.2 – Move infrequently used data out of a data warehouse into a data lake
+
+Data that is infrequently used can be moved from the data
+warehouse into the data lake. From there, the data can be
+queried in place or joined with data in the warehouse. Use
+services such as Amazon Redshift Spectrum to query and
+join data in the Amazon S3 data lake, or Amazon Athena to
+query data at rest in Amazon S3.
+
+## Suggestion 13.2.3 – Merge low utilization infrastructure resources
+
+If you have several workloads that all have
+low-utilization resources, determine if you can combine
+those workloads to run on shared infrastructure. In many
+cases, using a pooled resource model for analytics
+workloads will save on infrastructure costs.
+
+## Suggestion 13.2.4 – Move infrequently accessed data into low-cost storage tiers
+
+When designing a data lake or data analytics project,
+consider required access patterns, transaction
+concurrency, and acceptable transaction latency. These
+will inﬂuence where data is stored. It is equally
+important to consider how often data will be accessed.
+Have a data lifecycle plan to migrate data tiers from
+hotter storage to colder, less-expensive storage, while
+still meeting all business objectives.
+
+Transitioning between storage tiers is achieved using
+Amazon S3 Lifecycle policies. These automatically
+transition objects into another tier with lower cost, and
+will even delete expired data. Amazon S3
+Intelligent-Tiering will analyze the data access patterns
+and automatically move objects between tiers.
+
+## Suggestion 13.2.5 – Move to serverless when you don't need always-on infrastructure
+
+For analytics workloads that have intermittent or unpredictable usage patterns, moving to AWS serverless can provide significant cost savings compared to provisioned servers. AWS serverless analytics services like Amazon Athena, EMR Serverless, and Amazon Redshift Serverless are great options that provide on-demand access without having to provision always-on resources. These services automatically start up when needed and shut down when not in use so you don't have to pay for idle capacity.
+
+For example, with Amazon Redshift Serverless, you pay for compute only when the data warehouse is in use. By using Amazon Redshift Serverless for tasks such as loading data and leveraging Amazon Redshift data sharing, you can scale down your main cluster and still maintain the same performance for end users.
+
+For more detail, refer to the following:
+
+- [Easy analytics and cost optimization with Amazon Redshift Serverless](https://aws.amazon.com/blogs/big-data/easy-analytics-and-cost-optimization-with-amazon-redshift-serverless/)
+- [Amazon EMR Serverless cost estimator](https://aws.amazon.com/blogs/big-data/amazon-emr-serverless-cost-estimator/)
+- [Run queries 3x faster with up to 70% cost savings on the latest Amazon Athena engine](https://aws.amazon.com/blogs/big-data/run-queries-3x-faster-with-up-to-70-cost-savings-on-the-latest-amazon-athena-engine/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-13.2---reduce-overprovisioning-infrastructure..html*
+
+---
+
+# Best practice 13.3 – Evaluate and adopt new cost-effective solutions
+
+As AWS releases new services and features, it’s a best
+practice to review your existing architectural decisions to
+ensure that they remain cost effective. If a new or updated
+service can support the same workload but in a much cheaper
+way, consider implementing the change to reduce cost.
+
+## Suggestion 13.3.1 – Set Service Quotas to control resource usage
+
+Some AWS services allow setting Service Quotas per
+account. Service Quotas should be established to prevent
+runaway infrastructure deployment by accident. Ensure that
+Service Quotas are set high enough to cover the expected
+peak usage.
+
+## Suggestion 13.3.2 – Pause and resume resources if the workload is not always required
+
+Use automation to pause and resume resources when the
+resource is unneeded. For example, stop development and
+test Amazon RDS instances that are not used after working
+hours.
+
+## Suggestion 13.3.3 – Switch to a new service or take advantage of new features that can reduce cost
+
+AWS consistently adds new capabilities to enable your
+organization to leverage the latest technologies to
+experiment and innovate more quickly. Your organization
+should review new service releases frequently to
+understand the price and performance, and determine if
+such features can improve cost reduction.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-13.3---evaluate-and-adopt-new-cost-effective-solutions..html*
+
+---
+
+# Best practice 14.1 – Evaluate the infrastructure usage patterns and choose your payment options accordingly
+
+On-demand resources provide immense ﬂexibility with
+pay-as-you-go payment models across multiple scenarios and
+scales. Alternately, Reserved Instances provide significant
+cost saving for workloads that have steady resource
+utilization and serverless options for unpredictable demand. Perform regular workload resource usage
+analysis. Choose the best pricing model to ensure that you
+don’t miss cost optimization opportunities and maximize your
+discounts.
+
+## Suggestion 14.1.1 – Evaluate available payment options of the infrastructure resources of your choice
+
+Review the pricing page for specific AWS services. Each
+service will list the billing metrics, such as runtime or
+gigabytes processed, as well as any discount options for
+dedicated usage. In addition, many AWS analytics services
+offer discounted payment terms, Reserved Instances, or
+Savings Plans, in exchange for a specific usage commitment.
+Almost all AWS services offer the payment for usage on
+demand, meaning you only pay for what you use.
+
+## Suggestion 14.1.2 – For steady, permanent workloads, obtain Reserved Instances or Savings Plans price discounts instead of paying On-Demand Instance pricing
+
+Reserved Instances give you the option to reserve some AWS
+resources for a one- or a three-year term. In turn, you
+will receive a significant discount compared with the
+On-Demand Instance pricing. Workloads that have consistent
+long-term usage are good candidates for the Reserved
+Instance payment option.
+
+## Suggestion 14.1.3 – Use either on-demand, spot or serverless resources during development and in pre-production environments
+
+Development and pre-production environments frequently change and often do not require 100% availability. Use on-demand instances with start and stop resources, or serverless resources in cases where workload utilization is unpredictable, frequently changes, or is only used for portions of the day. You can use spot instances for fault-tolerant and flexible big data analytics applications. Spot instances are available at up to a 90% discount compared to on-demand prices. Spot instances are not suitable for workloads that are inflexible, stateful, fault-intolerant, or tightly coupled between instance nodes.
+
+For more detail, refer to the following:
+
+- [Optimize Cost by Automating the Start or Stop of Resources in Non-Production Environments Spot Instance Best Practices](https://aws.amazon.com/blogs/architecture/optimize-cost-by-automating-the-start-stop-of-resources-in-non-production-environments/)
+- [Optimizing Amazon EC2 Spot Instances with Spot Placement Scores](https://aws.amazon.com/blogs/compute/optimizing-amazon-ec2-spot-instances-with-spot-placement-scores/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-14.1---evaluate-the-infrastructure-usage-patterns-and-choose-your-payment-options-accordingly..html*
+
+---
+
+# Best practice 14.2 – Consult with your finance team and determine optimal payment models
+
+If you use reserved-capacity pricing options, you can reduce
+the infrastructure cost without modifying your workload
+architectures. Collaborate with your finance team on the
+planning and use of purchase discounts.
+
+Make informed decisions regarding various cost factors.
+These include the amount of capacity to reserve, the reserve
+term length, and the choice of upfront payments for their
+corresponding discount rates. The finance team should assist
+your team in determining the best long-term and
+reserved-capacity pricing options. This is because these
+options affect your IT budget plans, such as which month is
+the right moment to pay an upfront charge.
+
+## Suggestion 14.2.1 – Consolidate the infrastructure usage to maximize the coverage of reserved capacity price options
+
+Reserved Instances and Savings Plan purchases apply
+automatically to the resources that will receive the
+largest discount benefit. To maximize your discount
+utilization, consolidate resources in accounts within an
+AWS Organization structure. Allow the purchase commitments
+to apply to other AWS accounts within your organization if
+they are unused in the account for which they are
+purchased.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-14.2---consult-with-your-finance-team-and-determine-optimal-payment-models..html*
+
+---

--- a/powers/wa-review/steering/references/lenses/data-analytics/operational-excellence.md
+++ b/powers/wa-review/steering/references/lenses/data-analytics/operational-excellence.md
@@ -1,0 +1,247 @@
+# Operational excellence
+
+**Pages**: 6
+
+---
+
+# Best practice 1.1 – Validate the data quality of source systems before transferring data for analytics
+
+Data quality can have an intrinsic impact on the success or
+failure of your organization’s data analytics projects. To
+avoid committing significant resources to process potentially
+poor-quality data, your organization should understand the
+quality of the source data, and monitor the changes to data
+quality throughout the data pipeline.
+
+Data source validation can often be performed quickly on a
+subset of the latest data range to look for data defects.
+Such defects include missing values, anomalous data, or
+wrong data types that could fail the analytics job
+completion or lead to completion of the job with inaccurate
+results.
+
+For more details refer to following document:
+
+- AWS Blog:
+[How
+to Architect Data Quality on the AWS Cloud](https://aws.amazon.com/blogs/industries/how-to-architect-data-quality-on-the-aws-cloud/)
+- AWS Blog: [Getting started with AWS Glue Data Quality from the AWS Glue Data Catalog](https://aws.amazon.com/blogs/big-data/getting-started-with-aws-glue-data-quality-from-the-aws-glue-data-catalog/)
+
+## Suggestion 1.1.1 – Implement data quality validation mechanisms
+
+The critical attributes of data quality that should be measured and tracked
+through your environment are completeness, accuracy, and uniqueness. Validating and
+measuring your data quality using metrics is important to build trust in your data, which
+increases data adoption throughout your organization.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog: [Set up advanced rules to validate quality of multiple datasets with AWS Glue Data
+Quality](https://aws.amazon.com/blogs/big-data/set-up-advanced-rules-to-validate-quality-of-multiple-datasets-with-aws-glue-data-quality/)
+- AWS Big Data Blog: [Getting started with AWS Glue Data Quality for ETL Pipelines](https://aws.amazon.com/blogs/big-data/getting-started-with-aws-glue-data-quality-for-etl-pipelines/)
+- AWS Big Data Blog: [Set up alerts and orchestrate data quality rules with AWS Glue Data Quality](https://aws.amazon.com/blogs/big-data/set-up-alerts-and-orchestrate-data-quality-rules-with-aws-glue-data-quality/)
+- AWS Big Data Blog:
+[Enforce
+customized data quality rules in AWS Glue DataBrew](https://aws.amazon.com/blogs/big-data/enforce-customized-data-quality-rules-in-aws-glue-databrew/).
+- AWS Big Data Blog:
+[Build
+a data quality score card using AWS Glue DataBrew,
+Amazon Athena, and Quick](https://aws.amazon.com/blogs/big-data/build-a-data-quality-score-card-using-aws-glue-databrew-amazon-athena-and-amazon-quicksight/).
+
+## Suggestion 1.1.2 – Notify stakeholders and use business logic to determine how to remediate data that is not valid
+
+Alerts and notifications play a crucial role in maintaining data quality because they facilitate prompt and efficient responses to any data quality issues that may arise within a dataset. By establishing and configuring alerts and notifications, you can actively monitor data quality and receive timely alerts when data quality issues are identified. This proactive approach helps mitigate the risk of making decisions based on inaccurate information.
+
+It’s usually more efficient to impute missing values, but in
+other cases it’s more efficient to block processing until
+the data quality issue can be resolved at source.
+
+## Suggestion 1.1.3 – Score and share the quality of your datasets
+
+To improve the ongoing trust in data quality and adoption
+of your organization’s datasets, consider creating a data
+quality matrix that can be accessed by the relevant teams
+advertising the quality score of your datasets and
+potential issues with the data. This information can be
+incorporated in your Data Catalog.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-1.1---validate-the-data-quality-of-source-systems-before-transferring-data-for-analytics..html*
+
+---
+
+# Best practice 1.2 – Monitor operational metrics of data processing jobs and the availability of source data
+
+Data processing pipelines often consist of multiple steps that all need to run in sequence to output the desired data sets and meet business deadlines. Monitoring each job in the pipeline is key to ensure operational excellence. The operational metrics of the jobs themselves should be monitored, as well as the availability of source data, and that results are produced.
+
+For example, if your pipeline runs on a fixed schedule, and there is no new source data to process, the pipeline may still appear healthy because it runs without failures. Similarly, if the pipeline runs when new source data becomes available, it can appear healthy when no new source data becomes available if you only alert on failed runs.
+
+## Suggestion 1.2.1 – Alert when new data has not arrived or become available within the expected time
+
+You should monitor the time when new data arrives or becomes available, and alert when too much time has passed since the last occurrence. Even if the jobs in your data processing pipeline runs flawlessly, the quality of the results depend on the quality and availability of the source data.
+
+In a complex data pipeline it can also be necessary to monitor that one stage produces results within an expected time frame as it affects downstream stages.
+
+## Suggestion 1.2.2 – Alert when data processing jobs don’t complete on time or don’t produce results
+
+You should monitor the running time of data processing jobs and alert when too much time has passed since the last completed run. You should also alert if a job does not produce a result. With monitoring and alerts you can discover jobs that fail, and also jobs that fail silently by not producing results.
+
+The expected completion time should be based on the normal running time of the job, with some margin. The margin is needed because the running time of data processing jobs depend on the amount of data they process. Jobs that start as a result of new data becoming available also don’t have a set starting time, which should be factored into the margin.
+
+For very long running jobs it can also be necessary to monitor the start time of jobs, and alert when too much time has passed since the last start. Sometimes it can cause too much delay to wait until the expected completion time before the failure is discovered.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-1.2---monitor-operational-metrics-of-data-processing-jobs-and-the-availability-of-source-data..html*
+
+---
+
+# Best practice 2.1 – Use version control for job and application changes
+
+Version control systems support tracking changes and the
+ability to revert to previous versions of an analytics
+system should changes cause unintended consequences. Your
+team should version control code repositories for both
+analytics infrastructure as code (IaC) and analytics
+applications logic.
+
+## Suggestion 2.1.1 – Use infrastructure as code and version control systems so that a failed deployment can be rolled back to a previous good state
+
+Follow software development best practices when building
+analytics systems. For example, deploy resources using
+code templates, such as AWS CloudFormation or Hashicorp
+Terraform, so that all deployments occur exactly as
+intended. Use version control systems (for example, code
+repositories such as GitHub) to hold
+current and previous versions of your code templates.
+Using these tools, if a new change results in unwanted
+outcomes, you can easily roll back to the previous code
+template.
+
+For more details, refer to the following information:
+
+- AWS Whitepaper:
+[Introduction
+to DevOps on AWS](https://docs.aws.amazon.com/whitepapers/latest/introduction-devops-aws/infrastructure-as-code.html)
+- AWS Blog:
+[Automate
+building an integrated analytics solution with AWS
+Analytics Automation Toolkit](https://aws.amazon.com/blogs/big-data/automate-building-an-integrated-analytics-solution-with-aws-analytics-automation-toolkit/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.1---use-version-control-for-job-and-application-changes..html*
+
+---
+
+# Best practice 2.2 – Create test data and provision staging environment
+
+Using a known and unchanging dataset for test purposes helps
+ensure that when changes are made to the analytics
+environment or analytics application code, test results can
+be compared to previous versions.
+
+Confirming that the test datasets accurately represent
+real-world data allows the analytics workload developer to
+confirm the outcomes from the analytics job, as well as
+comparing test results to previous versions.
+
+Your organization should use a staging environment for user
+access testing. Your organization should create logically separated AWS accounts for your development, test, staging, and production
+environments depending upon your development standards.
+
+For more details, refer to the following information:
+
+AWS Whitepaper:
+[Establishing
+your best practice AWS environment](https://docs.aws.amazon.com/whitepapers/latest/organizing-your-aws-environment/organizing-your-aws-environment.html)
+
+## Suggestion 2.2.1 – Use a curated dataset to test application logic and performance improvements
+
+Analytics projects that are being developed should use the
+same curated dataset to compare results between tests of
+different versions of your code. Using the same dataset for
+all tests allows demonstrating improvement over time, as
+well as making it easier to recognize regressions in your
+code.
+
+To help control access to sensitive data, your
+organization should use data masking techniques when
+restoring development data to non-production environments.
+More information on data minimization techniques can be
+found in [Security](./security.html).
+
+For more details, refer to the following information:
+
+- AWS Database Blog: [Data Masking using AWS DMS (AWS
+Data Migration Service)](https://aws.amazon.com/blogs/database/data-masking-using-aws-dms/)
+- Amazon Redshift Data Masking: [Dynamic data masking
+(DDM) in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/t_ddm.html)
+
+## Suggestion 2.2.2 – Use a random sample of recent data to validate application edge cases and help ensure that regressions have not been introduced
+
+Use a statistically valid random sample of recent data to
+confirm that the analytics solution continues to perform
+under real-world conditions. Using a sample of recent data
+also allows you to recognize whether your dataset
+characteristics have shifted, or whether anomalous data
+has recently been introduced to your data.
+
+For more information, see the AWS Machine Learning Blog: [Create random and stratified samples of data with Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/blogs/machine-learning/create-random-and-stratified-samples-of-data-with-amazon-sagemaker-data-wrangler/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.2---create-test-data-and-provision-staging-environment..html*
+
+---
+
+# Best practice 2.3 – Test and validate analytics jobs and application deployments
+
+Before making changes in production environments, use
+standard and repeatable automated tests to validate
+performance and accuracy of results.
+
+## Suggestion 2.3.1 – Establish separate staging environments to test changes before going live
+
+Use separate environments, such as development, test, and
+production, to allow feature development to be introduced
+without disrupting production systems. Test changes for
+accuracy and performance before changes are deployed into
+the production environment.
+
+## Suggestion 2.3.2 – Automate the deployment and testing when infrastructure and applications changes are introduced
+
+The deployment of data pipelines and data infrastructure changes should be an automated process. When code is checked into version control, a CI/CD process should run tests and apply the changes to the staging environment, and once tested and confirmed correct, it should be deployed to the production environment.
+
+You can use the AWS CodePipeline service to define a CI/CD process.
+
+For more details refer to the following information:
+
+- AWS Perspective Guidance:
+[Deploy
+an AWS Glue job with an AWS CodePipeline CI/CD
+pipeline](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/deploy-an-aws-glue-job-with-an-aws-codepipeline-ci-cd-pipeline.html)
+- AWS DevOps Blog:
+[How
+to unit test and deploy AWS Glue jobs using AWS CodePipeline](https://aws.amazon.com/blogs/devops/how-to-unit-test-and-deploy-aws-glue-jobs-using-aws-codepipeline/)
+- AWS DevOps Blog: [10 ways to build applications faster with Amazon CodeWhisperer](https://aws.amazon.com/blogs/devops/10-ways-to-build-applications-faster-with-amazon-codewhisperer/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.3---test-and-validate-analytics-jobs-and-application-deployments..html*
+
+---
+
+# Best practice 2.4 – Build standard operating procedures for deployment, test, rollback, and backfill tasks
+
+Standard operating procedures for deployment, test,
+rollback, and data backfill tasks allow faster deployments,
+reduce the number of errors that reach production. Using a
+standard approach also makes remediation easier if a
+deployment results in unintended consequences.
+
+## Suggestion 2.4.1 – Document and use standard operating procedures for implementing changes in your analytics workload
+
+Standard operating procedures allow teams to make changes
+confidently, thus avoiding repeatable mistakes and reducing
+the chance of human error.
+
+## Suggestion 2.4.2 – Use automation to perform changes to underlying analytics infrastructure or application logic
+
+Automated tests can determine when changes have unintended
+consequences and can roll back without human intervention.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.4---build-standard-operating-procedures-for-deployment-test-rollback-and-backfill-tasks..html*
+
+---

--- a/powers/wa-review/steering/references/lenses/data-analytics/performance-efficiency.md
+++ b/powers/wa-review/steering/references/lenses/data-analytics/performance-efficiency.md
@@ -1,0 +1,292 @@
+# Performance efficiency
+
+**Pages**: 10
+
+---
+
+# Best practice 8.1 – Identify analytics solutions that best suit your technical challenges
+
+AWS has multiple analytics processing services that are
+built for specific purposes. These include Amazon Redshift
+for data warehousing, Amazon Kinesis for streaming data, and
+Quick for data visualization. Your organization
+should consider each step of the data analytics process as
+an opportunity to identify the right tool for the job.
+
+## Suggestion 8.1.1 – Identify the requirements based on the collected business metrics
+
+Applications and services are designed to overcome
+specific challenges. It’s essential that your organization
+identifies the right tool for the right job to meet your
+business and technical requirements. Choosing inappropriate technology can introduce performance issues,
+especially when processing data at scale.
+
+For more details, refer to the following information:
+
+- AWS Right Tool for the Job:
+[Databases
+on AWS: The Right Tool for the Right Job](https://www.youtube.com/watch?v=WE8N5BU5MeI)
+- AWS Right Tool for the Job:
+[How
+to Choose the Right Database](https://aws.amazon.com/startups/start-building/how-to-choose-a-database/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.1-identify-analytics-solutions-that-best-suit-your-technical-challenges..html*
+
+---
+
+# Best practice 8.2 – Provision the compute resources to the location of the data storage
+
+Data analytics workloads require moving data through a
+pipeline, either for ingesting data, processing intermediate
+results, or producing curated datasets. It is often
+more efficient to select the location of data processing
+services near where the data is stored. This approach is
+preferred instead of copying or streaming large amounts
+of data to the processing location. For example, if an
+Amazon Redshift cluster frequently ingests data from a data
+lake, ensure that the Amazon Redshift cluster is in the same
+Region as your data lake S3 buckets.
+
+This extends to considering where your compute and storage are located at the Availability Zone level. Co-locating in the same Availability Zone allows fast, lower latency access. It is still important, however, to replicate data across zones when required.
+
+## Suggestion 8.2.1 – Migrate or copy primary data stores from on-premises environments to AWS so that cloud compute and storage are closely located
+
+Minimize duplication of data when transferring datasets from on-premises storage to the cloud. Instead, create copies of your data near the analytics platform to avoid data transfer latency and improve overall performance of the analytics solution. For optimal performance, keep your data and analytics systems in the same AWS Region. If they are in separate Regions, relocate one of them.
+
+## Suggestion 8.2.2 – Consider where your analytics resources are placed
+
+For optimal performance, your organization should align the location of the data with the location of the resources that process it. Where possible, your organization should
+consider using a permanent Region for all data analytics
+processing as this will help with data transferring
+overhead.
+
+## Suggestion 8.2.3 – Consider the use of provisioned compared to serverless offerings to match your workload pattern
+
+When considering services for ingesting, transforming, and analyzing your data, there is often the choice between provisioned or serverless solutions. There are many trade-offs and potential advantages of each, but from a performance perspective, it can be beneficial to use serverless offerings when your workloads are consistently and unpredictably spikey. Whereas provisioned deployments may offer advantages when you have more stable, predictable workloads.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.2---provision-the-compute-resources-to-the-location-of-the-data-storage..html*
+
+---
+
+# Best practice 8.3 – Define and measure the computing performance metrics
+
+Define how you will measure performance of the analytics
+solutions for each step in the process. For example, if the
+computing solution is a transient Amazon EMR cluster, you
+can take the following approach. Define the performance as
+the Amazon EMR job runtime from the launch of the EMR
+cluster, process the job, then shut down the cluster. As
+another example, if the computing solution is an Amazon Redshift cluster that is shared by a business unit, you can
+define the performance as the runtime duration for each SQL
+query.
+
+## Suggestion 8.3.1 – Define performance efficiency metrics
+
+Collect and use metrics to scale the resources to meet
+business requirements. By doing so, your team can track
+unexpected spikes to make future improvements.
+
+## Suggestion 8.3.2 – Continually identify under-performing components and ﬁne-tune the infrastructure or application logic
+
+After you have deﬁned the performance measurement, you should identify which infrastructure components or jobs are running below the performance criteria. Performance ﬁne-tuning varies for each AWS service, but generally, optimizing queries or workloads can enhance performance without necessitating infrastructure modifications. For example, if it is an Amazon EMR cluster running a Spark application, you could explore tuning your Spark configuration. If after fine-tuning you still need more performance, you can change to a larger cluster instance type, or increase the number of cluster nodes.
+
+For an Amazon Redshift cluster, you can ﬁne-tune the SQL queries that are running below the performance criteria and if required, increase the number of cluster nodes to increase parallel computing capacity.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.3---define-and-measure-the-computing-performance-metrics..html*
+
+---
+
+# Best practice 9.1 – Identify critical performance criteria for your storage workload
+
+In data analytics, throughput is often a constraining
+factor to enable your workloads to run effectively.
+Throughput is measured by the amount of information that has
+successfully moved through the network, compute, or storage
+layers. Improving throughput in each of these layers
+generally results in better query performance.
+
+## Suggestion 9.1.1 – Use performance monitoring tools to determine if the analytics system performance is limited by compute, storage, or networking
+
+Use a metric collection and reporting system, such as
+Amazon CloudWatch, to analyze the performance
+characteristics of the analytics system. Evaluate the
+measured performance metrics relative to system reference
+documentation to characterize the system constraints for
+the workload as a percentage of maximum performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-9.1---identify-critical-performance-criteria-for-your-storage-workload..html*
+
+---
+
+# Best practice 9.2 – Identify and evaluate the available storage options for your compute solution
+
+Many AWS data analytics services allow you to use more than
+one type of storage. For example, Amazon Redshift allows
+access to data stored in the compute nodes in addition to
+data stored in Amazon S3. When performing research on each
+data analytics service, evaluate relevant storage options
+to determine the most performance efficient solution that
+meets business requirements.
+
+## Suggestion 9.2.1 – Review the available storage options for the analytics services being considered
+
+There are often multiple storage options available for each service, each offering different characteristics and potentially performance benefits. It is important to review these available options and determine which may best fit your requirements.
+
+For example, Amazon EMR provides local storage via HDFS
+file system and Amazon S3 as an external storage via EMRFS.
+For more information, refer to the AWS documentation for
+your compute solution:
+
+- Amazon EMR Management Guide:
+[Work
+with storage and file systems](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-file-systems.html)
+- Amazon Redshift Cluster Management Guide:
+[Overview
+of Amazon Redshift clusters](https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#working-with-clusters-overview)
+- Amazon OpenSearch Service Developer Guide:
+[Managing](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managing-indices.html)
+[indices
+in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managing-indices.html)
+- Amazon Aurora User Guide:
+[Overview
+of Aurora storage](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.StorageReliability.html#Aurora.Overview.Storage)
+
+## Suggestion 9.2.2 – Evaluate the performance of the selected storage option
+
+To ensure that the overall analytics system design meets
+your non-functional requirements, evaluate the performance
+by running simulated real-world tests in a test
+environment.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-9.2-identify-evaluate-available-storage-options.html*
+
+---
+
+# Best practice 9.3 – Choose the optimal storage based on access patterns, data growth, and the performance requirements
+
+Storage options for data analytics can have performance
+tradeoffs based on access patterns and data size. For
+example, in Amazon S3, can be much more efficient to retrieve a smaller number of larger objects, as opposed to a larger number of smaller objects.
+
+Evaluate your workload needs and usage patterns
+to determine if the method or location of storing your data
+can improve the overall efficiency of your solution.
+
+## Suggestion 9.3.1 – Identify available solution options for the performance improvement
+
+When data I/O is limiting performance and business
+requirements are not being met, improve I/O through the
+options available within that service. For example, with
+EBS volumes of GP3 type, increase Provisioned IOPS or
+throughput, or for Amazon Redshift, increase the number of
+nodes.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-9.3---choose-the-optimal-storage-based-on-access-patterns-data-growth-and-the-performance-metrics..html*
+
+---
+
+# Best practice 10.1 – Select format based on data write frequency and patterns for append-only compared to in-place update
+
+Review your data storage write patterns and performance requirements for streaming and batch workloads. Streaming workloads may require you to write smaller files at a higher frequency compared to batch workloads. This enables your streaming applications to reduce latency but can impact read and write performance of the data.
+
+## Suggestion 10.1.1 – Understand your analytics workload data’s write characteristics
+
+If storing data in Amazon S3, evaluate if an append-only
+method, such as Apache Hudi, is right for your needs.
+
+There are also table formats available, such as Apache Hudi, Apache Iceberg and Delta Lake that can, amongst other capabilities, provide transactional semantics over data tables in Amazon S3. These formats can also provide improved query times through the use of additional metadata. For more detail on getting started with these formats, see [Introducing native support for Apache Hudi, Delta Lake, and Apache Iceberg on AWS Glue for Apache Spark, Part 1: Getting Started](https://aws.amazon.com/blogs/big-data/part-1-getting-started-introducing-native-support-for-apache-hudi-delta-lake-and-apache-iceberg-on-aws-glue-for-apache-spark/).
+
+## Suggestion 10.1.2 – Avoid querying data stored in many small files
+
+Rather than running queries over many small data ﬁles, periodically combine the small ﬁles into a single larger compressed ﬁle for analytics. This approach provides better data retrieval performance when using analytics services. Keep in mind that in streaming use cases there is a tradeoff between latency and throughput, as time is required to batch records. The production of larger files can be done as a post process job rather than necessarily at the point of ingestion.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.1-select-format-based-on-data-write-frequency-and-patterns-for-append-only-vs.-in-place-update..html*
+
+---
+
+# Best practice 10.2 – Choose data formatting based on your data access pattern
+
+Choosing the right data type for your workload is important. There are many different data types available to support your workload. Choosing the right format is a key step in the performance optimization of your analytics workloads.
+
+## Suggestion 10.2.1 – Decide the correct data format for your analytics workload
+
+You can work on unstructured, semi-structured, and structured data formats (CSV,
+JSON, or columnar formats such as Apache Parquet and Apache ORC) with your data stored in Amazon S3 by using Amazon Athena, which lends itself to querying data as-is without the need for data preparation or ETL processes.
+
+You should also consider compression when choosing data formats. Efficient compression can help queries run faster and reduce cost. It can also lead to reductions in the amount of data stored in a storage layer, alongside improved network and I/O throughput. For more information on when to use compression, see 10.3.2.
+
+Using splittable formats is also an option. These formats allow individual files to be broken up so that they can be processed in parallel by multiple workers. Similarly to compression, this can also lead to reductions in query time. Often, you need to choose between compression or splittable formats because applying both is currently not well supported for analytics workloads.
+
+## Suggestion 10.2.2 – API-driven data access pattern constraints, such as the amount of data retrieved per API call, can impact overall performance
+
+If you are calling APIs to ingest, transform or access data, many implement a maximum amount of data or records that can be returned in a call. So, your solution may need to page through and make subsequent API calls to retrieve all results. If a large amount of data is returned this can lead to a long amount of time being spent retrieving the data in this manner. Most APIs have limits and constraints, such as number of calls in a particular time limit, so it is important to consider this, and relevant strategies for dealing with these conditions.
+
+Result caching on API sources can help speed up reads if the same or similar data is frequently queried. Using asynchronous methods can help avoid blocking calls in your processing that would otherwise have to wait for synchronous operations to complete.
+
+## Suggestion 10.2.3 – Use data, results, and query cache to improve performance and reduce reads from the storage tier
+
+Caching services can speed up the responses to common
+queries and reduce the load on the storage tier. Use
+Amazon ElastiCache, DynamoDB Accelerator (DAX), API
+gateway caching, Athena query result reuse, Amazon Redshift Advanced Query Accelerator (AQUA), or other relevant caching services.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.2-choose-data-formatting-based-on-your-data-access-pattern..html*
+
+---
+
+# Best practice 10.3 – Utilize compression techniques to both decrease storage requirements and enhance I/O efficiency
+
+Store data in a compressed format to reduce the burden on
+the underlying storage host and network. For example, for
+columnar data stored in Amazon S3, use a compatible
+compression algorithm that supports parallel reads.
+
+We recommend that your organization test the performance and
+storage overhead of both uncompressed and compressed
+datasets to determine best fit prior to implementing this
+approach.
+
+## Suggestion 10.3.1 – Compress data to reduce the transfer time
+
+When storage read/write performance becomes a bottleneck,
+use compression to reduce data transfer time. Consider the
+tradeoffs between compute time needed to perform compression
+and decompression versus the storage I/O bottleneck in your
+estimates of overall improvements in performance efficiency.
+
+## Suggestion 10.3.2 – Evaluate the available compression options for each resource of the workload
+
+Compressing data can improve the performance as there are
+fewer bytes transferred between the disk and compute
+layers. The trade-off using this approach is that it
+requires more compute for data compression and
+decompression. You can, however, obtain a net efficiency
+improvement if compression performs as well as or better
+than uncompressed data transfer time. Compression also
+requires much less storage, depending on the data type in
+use, thus saving on data storage latency and costs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.3---use-file-compression-to-reduce-number-of-files-and-to-improve-file-io-efficiency..html*
+
+---
+
+# Best practice 10.4 – Partition your data to enable efficient data pruning and reduce unnecessary file reads
+
+Storing your data in structured partitions will allow compute to identify the location of only that portion of the data relevant to the query. Determine the most frequent query parameters and store this data in the appropriate location suited to your data retrieval needs. For example, if an analytics workload regularly generates daily, weekly, and monthly reports, then store your data using partitions with a year/month/day format.
+
+## Suggestion 10.4.1 – Partition data to support the most common query predicates
+
+When your query uses a particular predicate in a WHERE clause, if your data is partitioned according to the field then the query engine can prune the data that it needs to look at and go directly to the relevant data partition. This means a full table scan is avoided, meaning faster performance and lower query cost.
+
+## Suggestion 10.4.2 – Store data partitioned based on time attributes with earlier data stored in tiers that are accessed infrequently
+
+Use the tiering capabilities of the storage service to put
+infrequently-accessed data into the tier that is most
+appropriate for the workload. For example, in an Amazon Redshift data warehouse, data that is accessed
+infrequently can be stored in Amazon S3. Then you can
+query it with Amazon Redshift Spectrum, while more
+frequently-accessed data can be stored in local Amazon Redshift storage.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.4---partition-your-data-to-avoid-unnecessary-file-reads..html*
+
+---

--- a/powers/wa-review/steering/references/lenses/data-analytics/reliability.md
+++ b/powers/wa-review/steering/references/lenses/data-analytics/reliability.md
@@ -1,0 +1,254 @@
+# Reliability
+
+**Pages**: 8
+
+---
+
+# Best practice 6.1 – Create an illustration of data flow dependencies
+
+Work with business stakeholders to create a visual illustration of the data pipeline. Identify the systems that interact with each dependency. The key architecture components that are expected to be captured are data acquisition, ingestion, data transformation, data processing, data storage, data protection and governance, and data consumption. All system dependencies need owners. Agree within your organization who owns which dependency.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.1-create-an-illustration-of-data-flow-dependencies..html*
+
+---
+
+# Best practice 6.2 – Monitor analytics systems to detect analytics or extract, transform and load (ETL) job failures
+
+Detect extract, transform, and load (ETL) and analytics job failures as soon as possible. Pinpointing where and how the error occurred is critical for notiﬁcations and corrective actions.
+
+## Suggestion 6.2.1– Monitor and track job errors from different levels, including infrastructure, ETL workﬂow, and ETL application code
+
+Failures can occur at all levels of the analytics system. Each task in the analytics workload should be instrumented to provide metrics indicating the health of the task. Monitor the emitted metrics and raise alarms if any components fail. Create dashboards to visualize metrics and govern access to them.
+
+For more details, refer to the following:
+
+- [Visualize data warehouse metrics: Query and visualize Amazon Redshift operational metrics using the Amazon Redshift plugin for Grafana](https://aws.amazon.com/blogs/big-data/query-and-visualize-amazon-redshift-operational-metrics-using-the-amazon-redshift-plugin-for-grafana/)
+- [Visualize Amazon EMR metrics: Monitor Amazon EMR on Amazon EKS with Amazon Managed Prometheus and Amazon Managed Grafana](https://aws.amazon.com/blogs/mt/monitoring-amazon-emr-on-eks-with-amazon-managed-prometheus-and-amazon-managed-grafana/)
+
+## Suggestion 6.2.2 – Establish end-to-end monitoring for the complete analytics and ETL pipeline
+
+End-to-end monitoring allows tracking the ﬂow of data as
+it passes through the analytics system. In many cases,
+data processing might be dependent on application logic,
+such as sampling a subset of data from a data stream to
+check accuracy. Properly identifying and monitoring the
+end-to-end ﬂow of data allows detecting at which step the
+analytics and ETL job fails.
+
+## Suggestions 6.2.3 – Determine what data was processed when the job failed
+
+Failures in data processing systems can cause data integrity or data quality issues. Determine what data was being processed at the time of failure and perform quality checks of both the input and output data. If possible, roll-back the committed data and restart your job.
+
+For more details, see AWS Glue: [Overview of Data Quality in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/workflows_overview.html).
+
+## Suggestions 6.2.4 – Classify the severity of the job failures based on the type of failure and the business impact
+
+Classifying the severity of different job failures helps you prioritize remediation and guide the notiﬁcation requirements to key stakeholders. Classification of jobs can be agreed upon based on importance and the impact the failure has on meeting internal and external SLAs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.2---monitor-analytics-systems-to-detect-analytics-or-etl-job-failures..html*
+
+---
+
+# Best practice 6.3 – Notify stakeholders about analytics or ETL job failures
+
+Analytics and ETL job failures can impact the SLAs for
+delivering the data on time for downstream analytics
+workloads. Failures might cause data quality or data
+integrity issues as well. Notifying all stakeholders about
+the job failure as soon as possible is important for
+remediation actions needed. Stakeholders may include IT
+operations, help desk, data sources, analytics, and
+downstream workloads.
+
+For more details, see
+AWS Well-Architected:
+[Design
+your Workload to Withstand Component Failures](https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/design-your-workload-to-withstand-component-failures.html)
+
+## Suggestions 6.3.1 – Establish automated notifications to predefined recipients
+
+Use services such Amazon Simple Notification Service
+(Amazon SNS) to send automated emails, SMS alerts, or both
+in the event of failure. Store the alert logs in an
+immutable data store for future reference.
+
+## Suggestions 6.3.2 – Do not include sensitive data in notifications
+
+Automated alerts often include indicators of useful information for troubleshooting the failure. Ensure PII and sensitive information, such as personal, medical, or ﬁnancial information is not shared in failure notiﬁcations.
+
+For more details, see AWS Glue: [Detect and process sensitive data](https://docs.aws.amazon.com/glue/latest/dg/detect-PII.html).
+
+## Suggestions 6.3.3 – Integrate the analytics job failure notification solution with the enterprise operation management system
+
+Where possible, integrate automated notifications into
+existing operations management tools. For example, an
+operations support ticket can be automatically filed in the
+event of a failure. That same ticket can automatically be
+resolved if the analytics system recovers on retry.
+
+## Suggestions 6.3.4 – Notify IT operations and help desk teams of any ETL job failures
+
+Normally, the IT operations team should be the first
+contact for production workload failures. The IT
+operations team troubleshoots and attempts to recover the
+failed job, if possible. It is also helpful to notify the
+IT help desk of system failures that have an end user
+impact. These can include issues with the data warehouse
+used by the business intelligence (BI) analysts.
+
+## Suggestions 6.3.5 – Notify downstream systems of data freshness
+
+Monitor data updates as this gives process and application information when data becomes stale. Stale data can lead to misreporting due to the correct values being stale and not current.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.3---notify-stakeholders-about-analytics-or-etl-job-failures..html*
+
+---
+
+# Best practice 6.4 – Automate the recovery of analytics and ETL job failures
+
+Many factors can cause analytics and ETL jobs to fail. Job
+failures can be recovered using automated recovery
+solutions, however, others might require manual
+intervention. Designing and implementing an automated
+recovery solution can help reduce the impact of the job
+failures and streamline IT operations.
+
+## Suggestions 6.4.1– Discover recovery procedures that work for multiple failure types
+
+Conﬁgure automatic retries to handle intermittent network disruptions. Conﬁgure managed scaling to ensure that there are sufficient resources available for jobs to complete within speciﬁc time limits.
+
+## Suggestions 6.4.2 – Limit the number of automatic reruns and create log entries for the automatic recovery attempts and results
+
+Track the number of reruns an automated recovery process has attempted. Limit the number of reruns to avoid unnecessary reruns and resources. Track the number of recovery attempts and outcomes to identify failure trends and drive future improvements.
+
+## Suggestion 6.4.3 – Design the job recovery solution based on the delivery SLA
+
+Build systems that can meet SLA requirements even if jobs must be retried or manually recovered. Consider the service-level agreements of the different services that you use, and monitor the performance of your jobs against your organization’s internal SLAs.
+
+## Suggestion 6.4.4 – Consider idempotency when designing ETL jobs
+
+To avoid unexpected outcomes when automatically rerunning pipelines such as duplicated or stale data, enforce idempotency where possible. Idempotent ETL jobs can be rerun with the same result or outcome. Some strategies to achieve this are the overwriting method (for example, Spark overwrite) and the delete-write method (deleting existing data prior to writing it to ensure that there are no duplicates or stale data), although deletion should be applied with caution.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.4-automate-the-recovery-of-analytics-and-etl-job-failures..html*
+
+---
+
+# Best practice 6.5 – Build a disaster recovery (DR) plan for the analytics infrastructure and the data
+
+Discuss with business stakeholders to understand maximum
+amount of data loss (RPO) and maximum amount of service loss
+(RTO).
+
+## Suggestion 6.5.1 – Confirm the business requirement of the disaster recovery (DR) plan
+
+Agree with the business shareholders what the internal and
+external SLAs are for your analytics processes. For
+example, not all business reports are business critical so
+it’s important that your DR plans are aligned with the
+severity of the outage.
+
+## Suggestion 6.5.2 – Design the disaster recovery (DR) solution for each layer of the solution
+
+Review the architecture for your data and analytics pipeline and select the DR pattern that meets your DR requirements, working backwards from the most important information that must be saved in the event of a DR scenario, to the least important.
+
+## Suggestion 6.5.3 – Implement and test your backup solution based on the RPO and RTO
+
+Backup solutions must be implemented to reduce data loss. Test your backup to ensure it is performing correctly by periodically restoring the data and validating the results.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.5---build-a-disaster-recovery-dr-plan-for-the-analytics-infrastructure-and-the-data..html*
+
+---
+
+# Best practice 7.1 – Build a central Data Catalog to store, share, and track metadata changes
+
+Building a central Data Catalog to store, share, and manage metadata across the organization is an integral part of data governance. This will promote standardization and reuse. Tracing metadata change history in the central Data Catalog helps you manage and control version changes in the metadata. A Data Catalog is often required for auditing and compliance but by incorporating business context to a Data Catalog, it allows users in the organization to discover data assets using business terms rather than technical naming conventions.
+
+## Suggestion 7.1.1 – Changes on the metadata in the Data Catalog should be controlled and versioned
+
+Use the Data Catalog change tracking features. For example, when the schema
+changes, AWS Glue Data Catalog will track the version change. You can use AWS Glue to compare
+schema versions, if needed. In addition, we recommend a change control process that only
+allows those authorized to make schema changes in your Data Catalog. The AWS Glue Schema registry allows you to centrally discover and control data schemas. You can create a schema contract between producers and consumers to improve data consumer awareness to data format changes.
+
+## Suggestion 7.1.2 – Capture and publish business metadata of your data assets
+
+Capturing business metadata and publishing it with metadata assets is essential for data consumers and data stewards alike. Metadata such as regulatory compliance statuses, data classification, and other important data governance characteristics, guides consumers on how to best process the data and informs data governance processes conducted by data stewards. Establishing a business glossary across the organization creates a collection of business terms that can be associated with the data assets. This ensures that business definitions are common across the organization.
+
+For more details, see AWS Data Zone: [Governed Analytics](https://aws.amazon.com/datazone/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-7.1---build-a-central-data-catalog-to-store-share-and-track-metadata-changes..html*
+
+---
+
+# Best practice 7.2 – Monitor for data quality anomalies
+
+Data quality is critical for organizations to accurately measure important business metrices, bad data can impact the accuracy of analytics insights and ML predictions. Monitor data quality and detect data anomalies as early as possible.
+
+For more details, see AWS Glue: [Getting started with AWS Glue Date Quality](https://aws.amazon.com/blogs/big-data/getting-started-with-aws-glue-data-quality-from-the-aws-glue-data-catalog/).
+
+## Suggestion 7.2.1 – Include a data quality check stage in the ETL pipeline as early as possible
+
+A data quality check helps ensure that bad data is
+identified and fixed as soon as possible to prevent bad data
+from propagating downstream.
+
+## Suggestion 7.2.2 – Understand the nature of your data and determine the types of data anomalies that must be monitored and fixed based on the business requirements
+
+The analytics workload can process various types of data,
+such as structured, unstructured, picture, audio, and
+video formats. Some data might arrive to the workload
+periodically, or some might constantly arrive in real
+time. It is pragmatic to assume that data does not always
+arrive to the analytics workload in perfect shape, and
+only a portion – not the whole set – of data matters to
+your workload.
+
+Understand the characteristics of data, and determine what forms of data anomalies you want to remediate. For example, if you expect the data always contains an important attribute like customer ID, you can deﬁne that a datum is abnormal if it doesn’t contain the `customer_id` attribute. Common data anomalies include duplicate data, missing data, incomplete data, incorrect data format, and diﬀerent measurement units.
+
+## Suggestion 7.2.3 – Select an existing data quality solution or develop your own based on the requirements
+
+There are data quality solutions that can only detect single ﬁeld data quality issues. Other solutions can handle complex stateful data quality issues related to multiple ﬁelds.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-7.2---monitor-for-data-quality-anomalies..html*
+
+---
+
+# Best practice 7.3 – Trace data lineage
+
+Have a clear understanding about where your organization’s
+data is coming from, how the data is transformed, who and
+what systems have access to the data, and how the data is
+used, is critical to increasing the business value of data.
+To achieve this goal, data lineage should be tracked,
+managed, and visualized.
+
+## Suggestion 7.3.1 – Track and control data lineage information
+
+Data lineage information should include where data has
+come from, where the data is going, and who has access to
+the data. Data changes and the business logic used should
+also be tracked in the data lineage.
+
+## Suggestion 7.3.2 – Use visualization tools to investigate data lineage
+
+Data lineage can become complicated when multiple systems
+are interacting with each other. Building a data lineage
+tool to visualize data lineage can reduce troubleshooting
+time and help identify downstream dependencies.
+
+## Suggestion 7.3.3 – Build a data lineage report to satisfy compliance and audit requirements
+
+If some derestriction data lineage is required for
+compliance or audit purposes, your organization should
+either build a data lineage process using AWS services or
+investigate third-party applications.
+
+For more details, refer to the following information:
+
+- AWS data lineage blog**:**
+[Build data lineage for data lakes using AWS Glue, Amazon Neptune, and
+Spline](https://aws.amazon.com/blogs/big-data/build-data-lineage-for-data-lakes-using-aws-glue-amazon-neptune-and-spline/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-7.3---trace-data-lineage..html*
+
+---

--- a/powers/wa-review/steering/references/lenses/data-analytics/security.md
+++ b/powers/wa-review/steering/references/lenses/data-analytics/security.md
@@ -1,0 +1,1026 @@
+# Security
+
+**Pages**: 17
+
+---
+
+# Best practice 3.1 – Privacy by Design
+
+Privacy by Design is an approach in system engineering that
+takes privacy into account throughout the whole engineering
+process. It especially focuses on systems or applications
+that capture and process personal data.
+
+There is an increased focus on ensuring that personal data
+is processed lawfully, fairly, and in a transparent manner
+in relation to the data subject. Another concern is that the
+data processing is adequate, relevant, and limited in
+relation to the purpose for which the information is used.
+
+## Suggestion 3.1.1 – Data minimization
+
+Organizations should only receive, process, and store information that is relevant for the task rather than processing all information when only a portion of the file is required. For example, if a client provided a full extract of all information from their source system containing sensitive personal information, and if a portion of the file is deemed irrelevant in meeting the overall project requirements, the remainder of the file should not be stored or processed.
+
+Data minimization coincides with data access controls in that applying data minimization rules can be implemented using data access controls. A suggestion is to create and maintain a data access matrix aligned with your data classification catalogs. This helps ensure that the correct groups of people have access to the right data. As most compliant frameworks encourage evidence that rules have been applied, a data access matrix can demonstrate to auditors that your organization has gone through the proper thought process to determine who can access what information.
+
+Data minimization can be applied at the point of capture. It can also be applied at the point of access by presenting a restricted data model or implementing role-based access controls (RBAC). For more information on controlling data access, see [4 – Implement data access control](./design-principle-4.html).
+
+Test and user acceptance test (UAT) environments, as well
+as training model datasets, must have a restricted dataset
+and not contain any personal information. If the structure
+of the data model must remain the same as production, then
+consider anonymizing or masking information to meet your
+data minimization requirements.
+
+It is common practice to create test and development
+environments using a backup of production and restore to
+the respective development or test environment. If this is
+the case, anonymization of personally identifiable
+information (PII) and other sensitive information must
+occur using inbuilt logic or services such as AWS Glue DataBrew to obfuscate the information.
+
+For more details, refer to the following documentation:
+
+- Amazon Redshift RBAC -
+[Amazon Redshift role-based access control](https://docs.aws.amazon.com/redshift/latest/dg/t_Roles.html)s
+- AWS Lake Formation RBAC -
+[Lake Formation role-based access controls](https://docs.aws.amazon.com/lake-formation/latest/dg/access-control-overview.html)
+- Amazon Athena RBAC -
+[Amazon Athena fine-grained access controls](https://docs.aws.amazon.com/athena/latest/ug/fine-grained-access-to-glue-resources.html)
+- AWS Glue DataBrew -
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) Visual Data Preparation
+
+## Suggestion 3.1.2 – Anonymization, pseudonymization, and tokenization
+
+Anonymization, pseudonymization, or tokenisation refers to the method of either rendering data anonymous or encoding data in such a manner that the data is no longer identifiable
+
+### Suggestion 3.1.2.1 – Anonymization
+
+**Anonymization is defined as the process of turning data into a
+form that does not identify individuals and where identification is not likely to take
+place.**
+
+This results in changing personal data into data that is no longer personal. An
+important factor in this process is that the anonymization must be irreversible. The
+anonymized value should be supported by the current field data type, have similar
+length, and retain some characteristics of the original value. For example, if a Vehicle
+Registration Number such as `OU51 SMR` was being anonymized, the result would
+look similar to `BB88 9AA`.
+
+Organizations need the ability to anonymize full datasets as well as single records.
+Single record anonymization functionality can help deliver right to erasure and meet
+data retention requirements. In this case, full batch anonymization is typically used
+when obfuscating development and UAT environments.
+
+The function to anonymize information should support the flexibility to anonymize
+certain fields, but not all.
+
+Operational databases, reporting databases, and analytical data marts should all be
+considered for anonymization, although reports and analytical cubes should never
+typically contain PII information regardless.
+
+Audit the reason why information was anonymized, for example, data portability, or
+data retention removal. The time, date, and user ID of when and who the anonymization
+process has affected should be recorded in an audit table.
+
+For more details, see AWS Big Data Blog: [Anonymize and manage data in your data lake with Amazon Athena and AWS Lake Formation](https://aws.amazon.com/blogs/big-data/anonymize-and-manage-data-in-your-data-lake-with-amazon-athena-and-aws-lake-formation/)
+
+### Suggestion 3.1.2.2 – Pseudonymization
+
+**Pseudonymized data is not the same as anonymized data.**
+
+When data has been pseudonymized, it still retains a level of detail in the target
+data that allows tracking back of the data to its original state. With anonymized data,
+the level of detail is reduced rendering a reverse compilation impossible.
+Pseudonymization is the processing of personal data in such a way that the data can only
+be attributed to a specific data subject by using additional information. To
+pseudonymize a dataset, the additional information must be kept separately and subject
+to technical and organizational measures to ensure non-attribution to an identified or
+identifiable person.
+
+In summary, pseudonymized data is a privacy-enhancing technique where directly
+identifying data, such as IP addresses and contact information, are held separately and
+securely from processed data to ensure non-attribution. Similar to anonymization,
+referential integrity must not be affected. Therefore, both of the following are
+required: an audit trail of the pseudonymization process, and a pseudonymization
+function that supports both single item and batch processing.
+
+For more detail, see [Amazon Redshift Data Masking](https://docs.aws.amazon.com/redshift/latest/dg/t_ddm.html).
+
+### Suggestion 3.1.2.3 – Tokenization
+
+*Tokenization*, when applied to data security, is
+the process of substituting a sensitive data element with a non-sensitive equivalent.
+This is referred to as a token, which has no extrinsic or exploitable meaning or value.
+The token is a reference that maps back to the sensitive data through a tokenization
+system. Tokenization is typically used in finance to tokenize the payment account number
+(PAN).
+
+For more details, refer to the following information:
+
+- AWS Blog – [AWS Glue DataBrew detection data masking transformations](https://aws.amazon.com/about-aws/whats-new/2021/11/aws-glue-databrew-detection-data-masking-transformations/)
+- AWS Blog - [Data Tokenization with Amazon Redshift and Protegrity](https://aws.amazon.com/blogs/apn/data-tokenization-with-amazon-redshift-and-protegrity/)
+
+## Suggestion 3.1.3 – Rights of the individual, citizen, or subject
+
+Your organization should consider the process to address
+the rights of the individual, citizen, or subject for
+their respective regional regulation.
+
+### Suggestion 3.1.3.1 – Subject Access Request (SAR)
+
+This particular right is for an individual to request
+information from the data controller, that is, how their
+personal data is being processed. If an individual’s
+information is being processed, the personal data and
+associated metadata must be provided to that individual.
+
+If the individual’s information is stored in a database, then an automated process, such as a stored procedure or User-Defined Function (UDF), should be developed to answer the Subject Access Request (SAR). There will, however, be situations when the individual’s information is stored in Amazon S3. If the information is stored in Amazon S3, the proposed solution to identify which S3 object contains the respective information is to build a lookup table in a database containing the reference number, individual contact details, and the S3 object location. This approach allows your organization to ingest the information into Amazon EMR, infer the schema using Apache Spark, and extract the information required to fulfill the request. Alternatively, your organization must process all S3 objects to identify the information to fulfill the request.
+
+If your regional regulations require that your organization handle a right to data portability request, then the SAR logic can double up to support that as well.
+
+For more details, see Apache Spark Documentation -
+[Inferring
+the Schema Using Reflection](https://spark.apache.org/docs/2.3.0/sql-programming-guide.html#:~:text=Inferring%20the%20Schema%20Using%20Reflection,-Scala&text=The%20Scala%20interface%20for%20Spark,the%20names%20of%20the%20columns.)
+
+### Suggestion 3.1.3.2 – Right to be forgotten or erasure
+
+Individuals have the right to erasure (the right to be forgotten), where an
+individual can request that all of their personal data is erased by the data controller
+organization. In some countries, there are instances where the data controller can
+refuse to comply with a right to erasure request, such as where the data is used for
+financial governance.
+
+The right to erasure does not strictly mean that the individual’s information must
+be deleted. Instead, it can be permanently masked so that the personal data is no longer
+in the clear and the update is irreversible.
+
+The organization must consider all data repositories when responding to a SAR as an
+individual’s information can reside in back up and source system databases. All these
+records must have the individual’s information removed or anonymized.
+
+If there are concerns about the impact of database referential integrity being
+affected by removing the individual’s information, then you can consider anonymization
+of the specific data attributes for the given individual. There are benefits to
+anonymization, such as being able to maintain an audit history of what actions have been
+performed against the individual by referencing a system ID. The same steps that are
+performed in production environments must also be run in UAT, development, OLTP, and
+back up repositories.
+
+The schedule of running the procedure in the other environments depends on the
+refresh schedules of those other environments.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.1-privacy-by-design..html*
+
+---
+
+# Best practice 3.2 – Classify and protect data
+
+**How do you classify and protect data
+in analytics workload?** Because analytics
+workloads ingest data from source systems, the owner of the
+source data should define the data classifications. As the
+analytics workload owner, you should honor the source data
+classifications and implement the corresponding data
+protection policies of your organization. Share the data
+classifications with the downstream data consumers to permit
+them to honor the data classifications in their
+organizations and policies as well.
+
+Data classification helps to categorize organizational data
+based on sensitivity and criticality, which then helps
+determine appropriate protection and retention controls on
+that data.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.2---classify-and-protect-data..html*
+
+---
+
+# Best practice 3.3 – Understand data classifications and their protection policies
+
+Data classification in your organization is key to
+determining how data must be protected while at rest and in
+transit. For example, since an analytics workload
+necessarily copies and shares data between operations and
+systems, we recommend that access be controlled to certain
+data classifications. Such a data protection strategy helps
+to prevent data loss, theft, and corruption, and helps to
+minimize the impact caused by malicious activities or
+unintended access.
+
+## Suggestion 3.3.1 – Identify classification levels
+
+Use the
+[Data
+Classification whitepaper](https://docs.aws.amazon.com/whitepapers/latest/data-classification/data-classification.html) to help you identify
+different classification levels. Four common levels used
+are restricted, confidential, internal, and public,
+however, these levels can vary based on the industry and
+compliance requirements of your organization.
+
+## Suggestion 3.3.2 – Define access rules
+
+The data owners should define the data access rules based
+on the sensitivity and criticality of the data. For
+example, with AWS Lake Formation, you can define and
+enforce access controls that operate at the table, column,
+row, and cell level for all the users that access your
+data lake.
+
+For more details, refer to the following information:
+
+- AWS Security Blog:
+[How
+to scale your authorization needs by using
+attribute-based access control with](https://aws.amazon.com/blogs/security/how-to-scale-authorization-needs-using-attribute-based-access-control-with-s3/)
+[S3](https://aws.amazon.com/blogs/security/how-to-scale-authorization-needs-using-attribute-based-access-control-with-s3/).
+- AWS Big Data Blog:
+[Create
+a secure data lake by masking, encrypting data, and
+enabling fine-grained access with AWS Lake Formation.](https://aws.amazon.com/blogs/big-data/create-a-secure-data-lake-by-masking-encrypting-data-and-enabling-fine-grained-access-with-aws-lake-formation/)
+- AWS Big Data Blog:
+[Control
+data access and permissions with AWS Lake Formation and
+Amazon EMR](https://aws.amazon.com/blogs/big-data/control-data-access-and-permissions-with-aws-lake-formation-and-amazon-emr/).
+- AWS Big Data Blog:
+[Enforce
+column-level authorization with Quick and
+AWS Lake](https://aws.amazon.com/blogs/big-data/enforce-column-level-authorization-with-amazon-quicksight-and-aws-lake-formation/)
+[Formation](https://aws.amazon.com/blogs/big-data/enforce-column-level-authorization-with-amazon-quicksight-and-aws-lake-formation/).
+
+## Suggestion 3.3.3 – Identify security zone models to isolate data based on classification
+
+Design the security zone models from AWS account levels
+down to AWS resource levels. For example, consider
+building AWS multi-account models to isolate different
+classes of data from AWS account level. Or, you can
+consider separating out development and test resources
+from production ones from AWS account level or from
+resource levels.
+
+For more details, refer to the following information:
+
+- AWS Whitepaper:
+[An
+Overview of the AWS Cloud Adoption Framework](https://docs.aws.amazon.com/whitepapers/latest/overview-aws-cloud-adoption-framework/welcome.html).
+- AWS Whitepaper:
+[Organizing
+Your AWS Environment Using Multiple Accounts](https://docs.aws.amazon.com/whitepapers/latest/organizing-your-aws-environment/organizing-your-aws-environment.html).
+- AWS Whitepaper:
+[Security
+Pillar – AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html).
+
+## Suggestion 3.3.4 – Identify sensitive information and define protection policies
+
+Discover sensitive data by using custom data identifiers in Amazon Macie or using AWS Glue sensitive data detection. Based on
+the sensitivity and criticality of the data, implement data protection policies to prevent
+unauthorized access. Due to compliance requirements, data might be masked or deleted after
+processing in some cases.
+
+For more details, refer to the following information:
+
+- AWS Blog:
+[Introducing
+PII data identification and handling using AWS Glue DataBrew](https://aws.amazon.com/blogs/big-data/introducing-pii-data-identification-and-handling-using-aws-glue-databrew/)
+- AWS Blog:
+[Create
+a secure data lake by masking, encrypting data, and
+enabling fine-grained access with AWS Lake Formation](https://aws.amazon.com/blogs/big-data/create-a-secure-data-lake-by-masking-encrypting-data-and-enabling-fine-grained-access-with-aws-lake-formation/)
+- AWS Info: [AWS Glue detect and process sensitive data](https://docs.aws.amazon.com/glue/latest/dg/detect-PII.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.3---understand-data-classifications-and-their-protection-policies..html*
+
+---
+
+# Best practice 3.4 – Identify the source data owners and have them set the data classifications
+
+Identify the owners of the source data, like business data owners, and agree what level of protection is required for the data within the analytics platform.
+
+Data classifications follow the data as it moves throughout
+the analytics workﬂow to ensure that the data is protected,
+and to determine who and what systems are allowed to access
+the data. By following the organization’s classification
+policies, the analytics workload should be able to
+differentiate the data protection implementations for each
+class of data. Because each organization has different kinds
+of classification, the analytics workload should provide a
+strong logical boundary between processing data of different
+sensitivity levels. These classifications include
+*restricted*,
+*confidential*, and
+*sensitive*.
+
+## Suggestion 3.4.1 – Assign owners per each dataset
+
+A dataset, or a table in relational database, is a collection of data. A Data Catalog is a collection of metadata that helps centralize share and search information about the data within your platform. In addition to assigned classifications, this capability allows teams to search for data assets and decide whether the data asset is valuable for their analyze or data science workload.
+
+The administrator of the analytics workload should know who are the owners for each dataset, and should assign the dataset ownership in the Data Catalog.
+
+## Suggestion 3.4.2 – Define attestation scope and reviewer as additional scope for sensitive data
+
+As the owner of the analytics workload, you should know
+the data owner for each dataset. For example, when a
+dataset classified as highly sensitive has permission
+issues within the organization, you might have to talk to
+the dataset owners and have them resolve the issues.
+
+## Suggestion 3.4.3 – Set expiry for data ownership and attestation, and have owners reconfirm periodically
+
+As businesses change, the data owners and the data
+classifications might change as well. Run campaigns
+periodically, such as quarterly or yearly, to request each
+of the dataset owners to reconfirm that they are still the
+right owners, and that the data classifications are still
+accurate.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.4---identify-the-source-data-owners-and-have-them-set-the-data-classifications..html*
+
+---
+
+# Best practice 3.5 – Record data classifications into the Data Catalog so that analytics workloads can understand
+
+Allow processes to update the Data Catalog so it can provide
+a reliable record of where the data is located and its
+precise classification. To protect the data effectively,
+analytics systems should know the classifications of the
+source data so that the systems can govern the data
+according to business needs. For example, if the business
+requires that confidential data be encrypted using team-owned
+private keys, such as from AWS Key Management Service (AWS KMS), then the analytics workload should be able to
+determine which data is classified as confidential by
+referencing its data catalog.
+
+## Suggestion 3.5.1 – Use tags to indicate the data classifications
+
+Use a tagging ontology to designate the classiﬁcation of sensitive data in data stores with a data catalog. A tagging ontology allows discoverability of data sensitivity without directly exposing the underlying data.
+They also can be used to authorize access in
+[tag-based access control (TBAC)](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_attribute-based-access-control.html) schemes.
+
+For more details, refer to the following information:
+
+- AWS Lake Formation Developer Guide:
+[What
+Is AWS Lake Formation?](https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html)
+- AWS Whitepaper: [Tagging
+Best Practices](https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/tagging-best-practices.html)
+- AWS Lake Formation: [Easily manage your data lake at scale using AWS Lake Formation Tag-based access control](https://aws.amazon.com/blogs/big-data/easily-manage-your-data-lake-at-scale-using-tag-based-access-control-in-aws-lake-formation/)
+
+## Suggestion 3.5.2 – Record lineage of data to track changes in the Data Catalog
+
+Data lineage is a relation among data and the processing
+systems. For example, the data lineage tells where the
+source system of the data has come from, what changes
+occurred to the data, and which downstream systems have
+access to it. Your organization should be able to
+discover, record, and visualize the data lineage from
+source to target systems.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Metadata
+classification, lineage, and discovery using Apache
+Atlas on Amazon EMR](https://aws.amazon.com/blogs/big-data/metadata-classification-lineage-and-discovery-using-apache-atlas-on-amazon-emr/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.5---record-data-classifications-into-the-data-catalog-so-that-analytics-workloads-can-understand..html*
+
+---
+
+# Best practice 3.6 – Implement encryption policies
+
+Data encryption is a way of translating data from plaintext
+(unencrypted) to ciphertext (encrypted). Encryption is a
+critical component of a *defense in
+depth* strategy. Therefore, it is highly
+recommended that your organization implement a well-designed
+encryption and key management system by separating access to
+the decryption key from access to your data to provide data
+security.
+
+## Suggestion 3.6.1 – Implement encryption policies for data at rest and in transit
+
+Each analytics service provides different types of encryption methods.
+Review the viable encryption methods of your solutions and
+implement as necessary.
+
+For more details, refer to the following information:
+
+- [AWS Key Management Service (AWS KMS) encryption best practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html)
+- AWS Big Data Blog:
+[Best
+Practices for Securing Amazon EMR](https://aws.amazon.com/blogs/big-data/best-practices-for-securing-amazon-emr/)
+- AWS Big Data Blog:
+[Encrypt
+Your Amazon Redshift Loads with Amazon S3 and AWS KMS](https://aws.amazon.com/blogs/big-data/encrypt-your-amazon-redshift-loads-with-amazon-s3-and-aws-kms/)
+- AWS Big Data Blog:
+[Encrypt
+and Decrypt Amazon Kinesis Records Using AWS KMS](https://aws.amazon.com/blogs/big-data/encrypt-and-decrypt-amazon-kinesis-records-using-aws-kms/)
+- AWS Partner Network (APN) Blog:
+[Data
+Tokenization with Amazon Redshift and Protegrity](https://aws.amazon.com/blogs/apn/data-tokenization-with-amazon-redshift-and-protegrity/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.6---implement-encryption-policies.html*
+
+---
+
+# Best practice 3.7 – Implement data retention policies for each class of data in the analytics workload
+
+The business’s data classification policies determine how
+long the analytics workload should retain the data and how
+long backups should be kept. These policies help ensure that
+every system follows the data security rules and compliance
+requirements. The analytics workload should implement data
+retention and backup policies according to these data
+classification policies. For example, if the policy requires
+every system to retain the operational data for five years,
+the analytics systems should implement rules to keep the
+in-scoped data for five years. More information on data
+retention can be found in [Sustainability](./sustainability.html).
+
+## Suggestion 3.7.1 – Create backup requirements and policies based on data classifications
+
+Data backup should be based on business requirements, such
+as recovery point objective (RPO), recovery time objective
+(RTO), data classifications, and the compliance and audit
+requirements.
+
+## Suggestion 3.7.2 – Create data retention requirement policies based on the data classifications
+
+Avoid creating blanket retention policies. Instead,
+policies should be tailored to individual data assets
+based on their retention requirements.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Building
+a cost efficient, petabyte-scale lake house with Amazon S3
+Lifecycle rules](https://aws.amazon.com/blogs/big-data/part-1-building-a-cost-efficient-petabyte-scale-lake-house-with-amazon-s3-lifecycle-rules-and-amazon-redshift-spectrum/)
+[and
+Amazon Redshift Spectrum: Part 1](https://aws.amazon.com/blogs/big-data/part-1-building-a-cost-efficient-petabyte-scale-lake-house-with-amazon-s3-lifecycle-rules-and-amazon-redshift-spectrum/)
+- AWS Big Data Blog:
+[Retaining
+data streams up to one year with Amazon Kinesis Data Streams](https://aws.amazon.com/blogs/big-data/retaining-data-streams-up-to-one-year-with-amazon-kinesis-data-streams/)
+- AWS Big Data Blog:
+[Retain
+more for less with UltraWarm for Amazon OpenSearch Service](https://aws.amazon.com/blogs/big-data/retain-more-for-less-with-ultrawarm-for-amazon-opensearch-service/)
+
+## Suggestion 3.7.3 – Create data version requirements and policies
+
+Implement a process that captures the data version to
+address, based on compliance, security, and operational
+requirements.
+
+For more details, refer to the following information:
+
+- AWS Storage Blog:
+[Reduce
+storage costs with fewer noncurrent versions using
+Amazon S3 Lifecycle](https://aws.amazon.com/blogs/storage/reduce-storage-costs-with-fewer-noncurrent-versions-using-amazon-s3-lifecycle/)
+- AWS Storage Blog:
+[Simplify
+your data lifecycle by using object tags with Amazon S3
+Lifecycle](https://aws.amazon.com/blogs/storage/simplify-your-data-lifecycle-by-using-object-tags-with-amazon-s3-lifecycle/)
+- AWS Database Blog:
+[Implementing
+version control using Amazon DynamoDB](https://aws.amazon.com/blogs/database/implementing-version-control-using-amazon-dynamodb/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.7---implement-data-retention-policies-for-each-class-of-data-in-the-analytics-workload..html*
+
+---
+
+# Best practice 3.8 – Enforce downstream systems to honor the data classifications
+
+Since other data-consuming systems will access the data that
+the analytics workload shares, the workload should require
+the downstream systems to implement the required data
+classification policies. For example, if the analytics
+workload shares the data that is required to be encrypted
+using customer managed private keys in AWS Key Management Service (AWS KMS), then the downstream systems should also
+acknowledge and implement such a data protection policy.
+
+This helps to ensure that the data is protected throughout
+the data pipelines.
+
+## Suggestion 3.8.1 – Have a centralized, shareable catalog with cross-account access to ensure that data owners manage permissions for downstream systems
+
+Downstream systems can run on independent AWS accounts,
+different from the AWS account running the majority of the
+analytics workload. Downstream systems should be able to
+discover the data, acknowledge the required data
+protection policies, and enforce those policies across the
+analytics platform.
+
+To allow the downstream systems to use the data from
+analytics workload, the analytics workload should provide
+cross-account access based on least privileges for each
+dataset.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog: [Cross-account AWS Glue Data Catalog access with Amazon Athena](https://aws.amazon.com/blogs/big-data/cross-account-aws-glue-data-catalog-access-with-amazon-athena/)
+- AWS Big Data Blog:
+[How
+JPMorgan Chase built a data mesh architecture to drive
+significant value to](https://aws.amazon.com/blogs/big-data/how-jpmorgan-chase-built-a-data-mesh-architecture-to-drive-significant-value-to-enhance-their-enterprise-data-platform/)
+[enhance
+their enterprise data platform](https://aws.amazon.com/blogs/big-data/how-jpmorgan-chase-built-a-data-mesh-architecture-to-drive-significant-value-to-enhance-their-enterprise-data-platform/)
+
+## Suggestion 3.8.2 – Monitor the downstream systems’ eligibility to access classified data from the analytics workload
+
+Monitor the downstream systems’ eligibility to handle
+sensitive data. For example, you do not want development
+or test Amazon Redshift clusters to read sensitive data
+from the analytics workload. If your organization runs a
+program that certifies which systems are eligible to
+process various classes of data, periodically verify that
+each downstream system’s data processing eligibility
+levels are correct and the list of data that it accesses
+are appropriate.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.8---enforce-downstream-systems-to-honor-the-data-classifications..html*
+
+---
+
+# Best practice 4.1 – Allow data owners to determine which people or systems can access data in analytics and downstream workloads
+
+Data owners are the people that have direct responsibility
+for data protection. For instance, the data owners want to
+determine which data is publicly accessible, or which data
+is restricted access to whom or what systems. The data
+owners should be able to provide data access rules, so that
+the analytics workload can implement the rules.
+
+## Suggestion 4.1.1 – Identify data owners and assign roles
+
+Data ownership is the management and oversight of an
+organization's data assets to help provide business users
+with high-quality data that is easily accessible in a
+consistent manner. Because the analytics workload
+consolidates multiple datasets into a central place, each
+dataset is owned by different teams or people. So, it is
+important for the analytics workload to identify which
+dataset is owned by whom to have the owners control the
+data access permissions.
+
+## Suggestion 4.1.2 – Identify permission using a permission matrix for users and roles based on actions performed on the data by users and downstream systems
+
+To aid in identifying and communicating data-access
+permissions, an Access Control Matrix is a helpful method
+to document which users, roles, or systems have access to
+which datasets, and to describe what actions they can
+perform. Below is a sample matrix for two users, and two
+roles for two schemas with a table in them:
+
+Table 1: Example Access Control Matrix for Users and Roles
+
+**Permissions**
+
+**Read**
+
+**Write**
+
+Schema 1
+
+User1, User2, Role1, Role2
+
+Role1
+
+Schema 1 / Table 1
+
+User1, User2, Role1, Role2
+
+Role2
+
+Schema 2
+
+User1, User2, Role1, Role2
+
+User1, Role1
+
+Schema 2 / Table 2v
+
+User1, User2, Role1, Role2
+
+User2, Role2
+
+The matrix format can help identify the least permissions
+that are required by various resources and to avoid
+overlaps. An Access Control Matrix should be thought of as
+an abstract model of permissions at a given point in time.
+Periodically review the actual access permissions against
+the permission matrix document to ensure accuracy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.1---allow-data-owners-to-determine-which-people-or-systems-can-access-data-in-analytics-and-downstream-workloads..html*
+
+---
+
+# Best practice 4.2 – Build user identity solutions that uniquely identify people and systems
+
+To control data access effectively, the analytics workload
+should be able to uniquely identify the people or systems.
+For example, the workload should be able to tell who
+accessed to the data by looking at the user identifiers (such
+as user names, tags, or IAM role names) with confidence that
+the identifier represents only one person or system.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Amazon Redshift identity federation with multi-factor
+authentication](https://aws.amazon.com/blogs/big-data/amazon-redshift-identity-federation-with-multi-factor-authentication/)
+- AWS Big Data Blog:
+[Federating
+single sign-on access to your Amazon Redshift cluster with
+PingIdentity](https://aws.amazon.com/blogs/big-data/federating-single-sign-on-access-to-your-amazon-redshift-cluster-with-pingidentity/)
+- AWS Database Blog:
+[Get
+started with Amazon OpenSearch Service: Use Amazon Cognito for Kibana](https://aws.amazon.com/blogs/database/get-started-with-amazon-elasticsearch-service-use-amazon-cognito-for-kibana-access-control/)
+[access
+control](https://aws.amazon.com/blogs/database/get-started-with-amazon-elasticsearch-service-use-amazon-cognito-for-kibana-access-control/)
+- AWS Partner Network (APN) Blog:
+[Implementing
+SAML AuthN for Amazon EMR Using Okta and](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+[Column-Level
+AuthZ with AWS Lake Formation](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+- AWS CloudTrail User Guide:
+[How
+AWS CloudTrail works with IAM](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/security_iam_service-with-iam.html)
+
+## Suggestion 4.2.1 – Centralize workforce identities
+
+It’s a best practice to centralize your workforce
+identities, which allows you to federate with AWS Identity and Access Management (IAM) using AWS IAM Identity Center
+or another federation
+provider. In Amazon Redshift, IAM roles can be mapped to
+Amazon Redshift database groups. In Amazon EMR, IAM roles
+can be mapped to an Amazon EMR security configuration or an
+Apache Ranger Microsoft Active Directory group-based
+policy. In AWS Glue, IAM roles can be mapped to AWS AWS Glue Data Catalog resource policies.
+
+AWS analytics services – such as Amazon OpenSearch Service
+and Amazon DynamoDB – allow integration with Amazon Cognito for authentication. Amazon Cognito lets you add
+user sign-up, sign- in, and access control to your web and
+mobile apps. Amazon Cognito scales to millions of users
+and supports sign-in with social identity providers, such
+as Apple, Facebook, Google, and Amazon, and enterprise
+identity providers via SAML 2.0 and OpenID Connect.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Federate
+Database User Authentication Easily with IAM and Amazon Redshift](https://aws.amazon.com/blogs/big-data/federate-database-user-authentication-easily-with-iam-and-amazon-redshift/)
+- WS Big Data Blog:
+[Federating
+single sign-on access to your Amazon Redshift cluster
+with PingIdentity](https://aws.amazon.com/blogs/big-data/federating-single-sign-on-access-to-your-amazon-redshift-cluster-with-pingidentity/)
+- Amazon EMR Management Guide:
+[Allow
+AWS IAM Identity Center for Amazon EMR Studio](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-enable-sso.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.2---build-user-identity-solutions-that-uniquely-identify-people-and-systems..html*
+
+---
+
+# Best practice 4.3 – Implement the required data access authorization models
+
+User authorization determines what actions that a user is
+permitted to take on the data or resource. The data owners
+should be able to use the authorization methods to protect
+their data as needed. For example, if the data owners must
+control which users are allowed to view certain columns of
+data, the analytics workload should provide column-wise data
+access authorization along with user group management for an
+effective control.
+
+## Suggestion 4.3.1 – Implement IAM policy-based data access controls
+
+Limit access to sensitive data stores with IAM policies
+where possible. Provide systems and people with rotating
+short-term credentials via role-based access control
+(RBAC).
+
+For more details, see AWS Big Data Blog: [Restrict access to your AWS Glue Data Catalog with resource-level IAM permissions and resource-based policies](https://aws.amazon.com/blogs/big-data/restrict-access-to-your-aws-glue-data-catalog-with-resource-level-iam-permissions-and-resource-based-policies/)
+
+## Suggestion 4.3.2 – Implement dataset-level data access controls
+
+As dataset owners require independent rules of granting
+data access, you should build the analytics workloads to
+have the dataset owners control the data access per each
+dataset level. For example, if the analytics workload
+hosts a shared Amazon Redshift cluster, the owners of the
+individual table should be able to authorize the table
+read and write independently.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Validate,
+evolve, and control schemas in Amazon MSK and Amazon Kinesis Data](https://aws.amazon.com/blogs/big-data/validate-evolve-and-control-schemas-in-amazon-msk-and-amazon-kinesis-data-streams-with-aws-glue-schema-registry/)
+[Streams
+with AWS Glue Schema Registry](https://aws.amazon.com/blogs/big-data/validate-evolve-and-control-schemas-in-amazon-msk-and-amazon-kinesis-data-streams-with-aws-glue-schema-registry/).
+- Amazon Redshift:
+[Amazon Redshift announces support for Row-Level Security
+(RLS)](https://aws.amazon.com/about-aws/whats-new/2022/07/amazon-redshift-row-level-security/)
+[Streams
+with AWS Glue Schema Registry](https://aws.amazon.com/blogs/big-data/validate-evolve-and-control-schemas-in-amazon-msk-and-amazon-kinesis-data-streams-with-aws-glue-schema-registry/).
+
+## Suggestion 4.3.3 – Implement column-level data access controls
+
+Care should be taken that end users of analytics
+applications are not exposed to sensitive data. Downstream
+consumers of data should only access the limited view of
+data necessary for that analytics purpose. Enforce that
+sensitive data is not exposed using column-level
+restrictions, for example, mask the sensitive columns to
+downstream systems so an accidental exposure is avoided.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Allow
+fine-grained permissions for Quick authors in
+AWS Lake](https://aws.amazon.com/blogs/big-data/enable-fine-grained-permissions-for-amazon-quicksight-authors-in-aws-lake-formation/)
+[Formation](https://aws.amazon.com/blogs/big-data/enable-fine-grained-permissions-for-amazon-quicksight-authors-in-aws-lake-formation/)
+- Amazon Redshift: [Role-based access controls](https://docs.aws.amazon.com/redshift/latest/dg/t_Roles.html)
+- AWS Partner Network (APN) Blog:
+[Implementing
+SAML AuthN for Amazon EMR Using Okta and](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+[Column-Level
+AuthZ with AWS Lake Formation](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+- AWS Big Data Blog:
+[Implementing
+Authorization and Auditing using Apache Ranger on Amazon EMR](https://aws.amazon.com/blogs/big-data/implementing-authorization-and-auditing-using-apache-ranger-on-amazon-emr/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.3---implement-the-required-data-access-authorization-models..html*
+
+---
+
+# Best practice 4.4 – Establish an emergency access process to ensure that admin access is managed and used when required
+
+Emergency access allows expedited access to your workload in
+the unlikely event of an automated process or pipeline
+issue. This will help you rely on least privilege access,
+but still provide users the right level of access when they
+require it.
+
+## Suggestion 4.4.1 – Ensure that risk analysis is performed on your analytics workload by identifying emergency situations and a procedure to allow emergency access
+
+Identify the potential events that can happen from source
+systems, analytics workload, and downstream systems.
+Quantify the risk of each event such as likelihood (low,
+medium, or high) and the size of the business impact
+(small, medium, or large).
+
+For example, after you identified priority risks, discuss
+with the source and downstream system owners on how to
+allow analytics workload access to the source and
+downstream systems to continue the data processing
+business.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.4---establish-an-emergency-access-process-to-ensure-that-admin-access-is-managed-and-used-when-required..html*
+
+---
+
+# Best practice 4.5 – Track data and database changes
+
+Data auditing involves monitoring a database to track the
+actions of a user or process, and to audit the changes that
+have occurred to the data.
+
+## Suggestion 4.5.1 – Database triggering for data auditing
+
+A database trigger is procedural code that is
+automatically run in response to certain events on a
+particular table or view in a database. Database triggers
+can then be used to update an audit table with the changes
+that have occurred. The types of information that should
+be included in the auditing process include: the original
+and updated value of what has been updated, the process or
+stored procedure that made the update, and the time and
+date the update occurred.
+
+## Suggestion 4.5.2 – Enable advanced auditing
+
+If your database engine supports auditing as a native
+feature, you should enable the feature to record and audit
+database events such as connections, disconnections,
+tables queried, or types of queries issued.
+
+## Suggestion 4.5.3 – AWS Lake Formation time travel queries
+
+Apache Iceberg and Apache Hudi provide a high-performance data lake table format that works just like a SQL table. Iceberg and Hudi make it simple to manage your data lake information and support SQL type analytics. Data that is managed by Iceberg or Hudi is version-controlled, therefore there is a complete history of all data updates. A good example is if you need to know the status of an individual at a certain time, then a time travel query allows you to select a date range to return the value that existed at that time, rather than the current value.
+
+For more details, see [Use the AWS Glue connector to read and write Apache Iceberg tables with ACID transactions and perform time travel](https://aws.amazon.com/blogs/big-data/use-aws-glue-to-read-and-write-apache-iceberg-tables-with-acid-transactions-and-perform-time-travel/).
+
+## Suggestion 4.5.4 – Change Data Capture (CDC)
+
+CDC records `INSERT`s, `UPDATE`s, and `DELETE`s
+applied to relational database tables, and makes a log available of which relational
+database objects changed, where, and when. These change tables contain columns that
+reflect the column structure of the source table you have chosen to track, along with the
+metadata required to understand the changes that have been made.
+
+For more details, refer to the following information:
+
+- AWS CloudTrail -
+[Secure
+Standardized Logging](https://aws.amazon.com/cloudtrail/)
+- Amazon RDS Aurora -
+[Advanced
+Auditing with an Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html)
+- Amazon RDS Aurora -
+[Configuring
+an audit log to capture database activities for Amazon RDS](https://aws.amazon.com/blogs/database/configuring-an-audit-log-to-capture-database-activities-for-amazon-rds-for-mysql-and-amazon-aurora-with-mysql-compatibility/)
+- AWS Database Migration Service (AWS DMS)
+[AWS Database Migration Service](https://aws.amazon.com/dms/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.5-track-data-and-database-changes..html*
+
+---
+
+# Best practice 5.1 – Prevent unintended access to the infrastructure
+
+Grant least privilege access to infrastructure to help
+prevent inadvertent or unintended access to the
+infrastructure. For example, make sure that anonymous users
+are not allowed to access to the systems, and that the
+systems are deployed into isolated network spaces. Network
+boundaries isolate analytics resources and restrict network
+access. Network access control lists (NACLs) act as a
+firewall for controlling traffic in and out. To reduce the risk
+of inadvertent access, define the network boundaries of the
+analytics systems and only allow intended access.
+
+## Suggestion 5.1.1 – Ensure that resources in the infrastructure have boundaries
+
+Use infrastructure boundaries for services such as
+databases. Place services in their own VPC private subnets
+that are configured to allow connections only to needed
+analytics systems.
+
+Use
+[AWS Identity and Access Management (IAM) Access
+Analyzer](https://aws.amazon.com/iam/features/analyze-access/) for all AWS accounts that are centrally
+managed through
+[AWS Organizations.](https://aws.amazon.com/organizations/) This allows security teams and
+administrators to uncover unintended access to resources
+from outside their AWS organization within minutes.
+
+You can proactively address whether any resource policies
+across any of your accounts violate your security and
+governance practices by allowing unintended access.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.1---prevent-unintended-access-to-the-infrastructure..html*
+
+---
+
+# Best practice 5.2 – Implement least privilege policies for source and downstream systems
+
+The principle of least privilege works by giving only enough
+access for systems to do the job. Set an expiry on temporary
+permissions to ensure that re-authentication occurs
+periodically. The system actions on the data should
+determine the permission and granting permissions to other
+systems should not be permitted.
+
+## Suggestion 5.2.1 – Ensure that permissions are least for the action performed by user/system
+
+Identify the minimum privileges that each user or system
+requires, and only allow the permissions that they need.
+For example, if a downstream system requests to read an
+Amazon Redshift table from an analytics workload, only
+give the read permission for the table using Amazon Redshift user privilege controls.
+
+For more details, refer to the following information:
+
+- AWS Security Blog:
+[Techniques
+for writing least privilege IAM policies](https://aws.amazon.com/blogs/security/techniques-for-writing-least-privilege-iam-policies/)
+- Amazon Redshift Database Developer Guide:
+[Managing
+database security](https://docs.aws.amazon.com/redshift/latest/dg/r_Database_objects.html)
+- AWS Security Blog:
+[IAM
+Access Analyzer makes it easier to implement least
+privilege permissions by](https://aws.amazon.com/blogs/security/iam-access-analyzer-makes-it-easier-to-implement-least-privilege-permissions-by-generating-iam-policies-based-on-access-activity/)
+[generating
+IAM policies based on access activity](https://aws.amazon.com/blogs/security/iam-access-analyzer-makes-it-easier-to-implement-least-privilege-permissions-by-generating-iam-policies-based-on-access-activity/)
+
+## Suggestion 5.2.2 – Implement the two-person rule to prevent accidental or malicious actions
+
+Even if you have implemented the least privilege policies,
+someone must have critical permissions for the business,
+such as the ability to delete datasets from analytics
+workloads.
+
+The two-person rule is a safety mechanism that requires
+the presence of two authorized personnel to perform tasks
+that are considered important. It has its origins in
+military protocol, but the IT security space has also
+widely adopted the practice.
+
+By implementing the two-person rule, you can have
+additional prevention of accidental or malicious actions
+of the people who have critical permissions.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.2---implement-least-privilege-policies-for-source-and-downstream-systems..html*
+
+---
+
+# Best practice 5.3 – Monitor the infrastructure changes and the user activities against the infrastructure
+
+As the infrastructure changes over time, you should monitor
+what has been changed by whom. This is to ensure that such
+changes are deliberate and the infrastructure is still
+protected.
+
+## Suggestion 5.3.1 – Monitor the infrastructure changes
+
+You want to know every infrastructure change and want to
+know that such changes are deliberate. Monitor the
+infrastructure changes using available methods on your
+team. For example, you can implement an operation
+procedure to review the infrastructure configurations every
+quarter of the year. Or, you can use AWS services that
+assist you to monitor the infrastructure changes with less
+effort.
+
+For more details, refer to the following documentation:
+
+- AWS Config Developer Guide:
+[What
+Is AWS Config?](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
+- Amazon Inspector User Guide:
+[What
+is Amazon Inspector?](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_introduction.html)
+- Amazon GuardDuty User Guide:
+[Amazon S3 protection in Amazon GuardDuty](https://docs.aws.amazon.com/guardduty/latest/ug/s3_detection.html)
+
+## Suggestion 5.3.2 – Monitor the user activities against the infrastructure
+
+You want to know who is changing the infrastructure and
+when, so that you can see that any given infrastructure
+change is performed by an authorized person or system. To
+do so, as examples, you can implement an operation
+procedure to review the AWS CloudTrail audit logs every
+quarter of the year. Or you can implement near real time
+trend analysis using AWS services such as Amazon CloudWatch Logs Insights.
+
+For more details, refer to the following information:
+
+- AWS CloudTrail User Guide:
+[Monitoring
+CloudTrail Log Files with Amazon CloudWatch Logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/monitor-cloudtrail-log-files-with-cloudwatch-logs.html)
+- AWS Management and Governance Blog:
+[Analyzing
+AWS CloudTrail in Amazon CloudWatch](https://aws.amazon.com/blogs/mt/analyzing-cloudtrail-in-cloudwatch/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.3---monitor-the-infrastructure-changes-and-the-user-activities-against-the-infrastructure..html*
+
+---
+
+# Best practice 5.4 – Secure the audit logs that record every data or resource access in analytics infrastructure
+
+Logs are an audit trail of events and should be stored in an immutable format for compliance purposes. These logs provide proof of actions
+and help in identifying misuse. The logs provide a baseline
+for analysis or for an audit when initiating an
+investigation. By using a fault-tolerant storage for these
+logs, it is possible to recover them even when there is a
+failure in the auditing systems. Access permissions to these
+logs must be restricted to privileged users. Also log audit
+log access to help in identifying unintended access to audit
+data.
+
+## Suggestion 5.4.1 – Ensure that auditing is active in analytics services and are delivered to fault-tolerant persistent storage
+
+Review the available audit log features of your analytics
+solutions, and configure the solutions to store the audit
+logs to fault-tolerant persistent storage. This helps
+ensure that you have complete audit logs for security and
+compliance purposes.
+
+For more details, refer to the following information:
+
+- AWS Management and Governance Blog:
+[AWS CloudTrail Best Practices](https://aws.amazon.com/blogs/mt/aws-cloudtrail-best-practices/)
+- Amazon Redshift Cluster Management Guide:
+[Database
+audit logging](https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html)
+- Amazon OpenSearch Service (successor to Amazon OpenSearch Service) Developer Guide:
+[Monitoring](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/audit-logs.html)
+[audit
+logs in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/audit-logs.html)
+- AWS Technical Guide – Build a Secure Enterprise Machine
+Learning Platform on AWS:
+[Audit
+trail](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/audit-trail-management.html)
+[management](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/audit-trail-management.html)
+- AWS Big Data Blog:
+[Build,
+secure, and manage data lakes with AWS Lake Formation](https://aws.amazon.com/blogs/big-data/building-securing-and-managing-data-lakes-with-aws-lake-formation/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.4---secure-the-audit-logs-that-record-every-data-or-resource-access-in-analytics-infrastructure..html*
+
+---

--- a/powers/wa-review/steering/references/lenses/data-analytics/sustainability.md
+++ b/powers/wa-review/steering/references/lenses/data-analytics/sustainability.md
@@ -1,0 +1,665 @@
+# Sustainability
+
+**Pages**: 7
+
+---
+
+# Best practice 15.1 – Define your organization’s current environmental impact
+
+As an organization, you should track your progress towards your sustainability goals. By determining your current environmental impact, you can track and report improvements as you make changes over time. Without knowing where you are you can’t know how far you’ve come.
+
+**How do you track your analytics
+carbon footprint?**
+
+## Suggestion 15.1.1 – Determine the carbon emissions of your workload using the AWS Customer Carbon Footprint Tool
+
+Determining the current carbon emissions of your analytics workloads at the start of your optimization journey is important as it enables you to track your changes and see what efforts have the biggest impact. If you are an AWS user, your
+organization can use the AWS Customer Carbon Footprint Tool. The AWS Customer Carbon
+Footprint Tool is a data tracking and visualization tool that reports on your AWS accounts carbon usage.
+
+Your organization should maintain an audit trail of the changes that your team
+have made, when they were made, and the impact that the changes had on the carbon
+footprint of each workload.
+
+For more details, refer to the following information:
+
+- [AWS Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/)
+- [AWS Customer Carbon
+Footprint Tool Overview](https://www.youtube.com/watch?v=WqhAnLdg3rg)
+- [Sustainability Pillar Improvement Process](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/improvement-process.html)
+- [Sustainability Pillar Improvement Process](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/improvement-process.html)
+
+## Suggestion 15.1.2 – Define and track your progress using proxy metrics
+
+When something is hard or impractical or very difficult to measure directly, you can instead use a related measurements in its place. This is called a *proxy metric*.
+
+Environmental impact is hard to measure directly, especially when you want fine-grained measurements. However, in the cloud, the environmental impact of a workload is often correlated with efficiency, which is also often correlated with cost. Just like you can apply many of the best practices of the performance efficiency and cost optimization pillars to lower your environmental impact, you can also use performance metrics and cost as proxy metrics to track your progress.
+
+For more details, refer to the following information:
+
+- [Evaluate specific improvements](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/evaluate-specific-improvements.html)
+- [Turning Cost and Usage Reports into Efficiency Reports](https://catalog.workshops.aws/well-architected-sustainability/en-US/5-process-and-culture/cur-reports-as-efficiency-reports)
+- [Best practice 8.3 – Define and measure the computing performance metrics](https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.3---define-and-measure-the-computing-performance-metrics..html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.1-define-organization-current-environmental-impact.html*
+
+---
+
+# Best practice 15.2 – Encourage sustainable thinking
+
+Software architects are often encouraged to apply systems thinking to the problems they tackle. To zoom out and look at the bigger picture and how the different components interact and form a whole. To build sustainable cloud workloads also requires sustainability thinking – including environmental impact as a parameter in design and planning.
+
+Organizations should include sustainability requirements when considering new projects, and continuously evaluate the environmental impact of existing workloads. They should find the balance between business needs and sustainable goals – and creative solutions to achieve both.
+
+Encourage questioning business requirements on sustainability grounds. For example, when considering the update frequency of dashboards, include the impact on things like energy usage in the discussions. Sometimes this leads to insights such as that only some of the KPIs need frequent updates, while the majority of the dashboard contents only need updating once per day. This can result in a reduction in energy usage while still delivering the same business value.
+
+## Suggestion 15.2.1 – Review the update frequency of your reports and dashboards
+
+Running reports and refreshing dashboards can be a compute intensive process. Continuously review the business requirements and question how frequently refreshes are needed. Can some reports be run only on demand because they are accessed infrequently? Can reports that today run on demand instead be run on a schedule to have them always available instead of multiple people running them many times per day? Does every KPI need to be refreshed at the same time?
+
+## Suggestion 15.2.2 – Review your reports, dashboards, and metrics and remove what is no longer needed
+
+As organizations evolve, so does business requirements.. Over time, some reports and dashboards become more important and used, and others less. New metrics become important, and reports and dashboards accumulate elements that are no longer necessary.
+
+Continually evaluate business requirements and remove what is no longer needed. Remove metrics from reports when they are not necessary, and remove whole reports and dashboards when they lose their relevance. Eﬃcient reporting has a positive impact on your sustainability goals. Your organization can also identify similar goals across teams or departments to reduce the number of separate reports and thereby reduce duplication and overlap.
+
+## Suggestion 15.2.3– Review the running frequency of your data pipelines
+
+Data pipelines are the backbone of analytics platforms. They process data and produce new data sets. They are compute-intensive processes that can have a big impact on the overall environmental impact of your analytics platform. The more frequently they run, the higher the impact. Work backwards from your business requirements and decide appropriate running frequencies that balance business value and environmental impact.
+
+Consider splitting pipeline jobs when there is an opportunity to run the majority of its calculations on a lower frequency while still maintaining the overall business goals.
+
+## Suggestion 15.2.4– Be flexible in your job schedules
+
+It’s common to run jobs on regular schedules, like hourly or daily, often at the top of the hour. When using managed and serverless technologies, the service often keeps a warm pool of compute resources to be able to meet demand. The pool needs to be managed to meet peaks in demand, and for job-oriented services this often coincides with the top of the hour. By being flexible in when you run your jobs, and for example avoiding the top of the hour, you can help the service smooth out demand.
+
+This is similar to how you can optimize your own resource usage by implementing buffering and throttling, as described in [SUS02-BP06 Implement buffering or throttling to flatten the demand curve](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sus_sus_user_a7.html).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.2-encourage-sustainable-thinking.html*
+
+---
+
+# Best practice 15.3 – Encourage a culture of data minimization
+
+Analytics relies heavily on large volumes of data being stored and processed. Minimizing the amount of data stored and processed can have a positive impact on the environmental impact of your organization’s analytics platform. Encourage architects, data engineers, and other roles that work on the platform to think about ways to minimize the amount of data stored and processed at every point in the system. A just enough data mindset can reduce the overall amount of data processed and therefore reduce the amount of compute power and storage used, and lower the environmental impact.
+
+Look for opportunities to break linear relationships so that datasets don’t need to grow at the same pace as your business. As your user base increases, find ways to avoid datasets growing at the same pace. In many cases it may be unavoidable, but for example, if you store partially aggregated data you can break the linear relationship.
+
+Encouraging a culture of always thinking about ways to minimize data can help ensure your organization does not unintentionally increase its environmental impact again after reductions have been made.
+More information on building and implementing an Improvement
+process can be found in the
+[Sustainability
+Pillar whitepaper](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/improvement-process.html).
+
+**How do you minimize the amount of
+data that is processed?**
+
+## Suggestion 15.3.1– Minimize the amount of data extracted from your source systems that gets stored in your data warehouse
+
+Data warehousing plays an important role in providing meaningful insights to your reporting layers and analytics. Data warehousing is the ingestion and merging of multiple data sources to create a single data model optimized for the business’ needs. Typically it employs techniques such as denormalization and materialized views of aggregates to provide faster query response times. It is encouraged that your organization applies these principles of building a data warehouse.
+
+It is common that all source data is ingested into a data warehouse. Since data warehouses are good at storing massive amounts of data, and because it’s hard to know in advance what is going to be needed, many organizations store everything. This leads to higher environmental impact because of the added compute and storage requirements.
+
+Work backwards from the business needs, reports, and dashboards when designing ingestion processes and data models for data warehouses. This avoids the overhead of extracting, processing, and storing source data that is not strictly needed.
+
+For more details, refer to the following information:
+
+- [Amazon Redshift development guide: Database Developer Guide](https://docs.amazonaws.cn/en_us/redshift/latest/dg/redshift-dg.pdf)
+- [Optimize your modern data architecture for sustainability: Part 1 – data ingestion and data lake](https://aws.amazon.com/blogs/architecture/optimize-your-modern-data-architecture-for-sustainability-part-1-data-ingestion-and-data-lake/)
+
+When designing your source data extraction processes, it is recommended that your organization should only extract data required for the workloads, such as reports and dashboards, that the data warehouse supports. This results in less data being transferred over the network, less data processed, less data being loaded into the data warehouse, less data being stored over time, and less data to remove when applying data retention policies.
+
+When extracting data from your source datastore, your organization should use a date range to extract only data that has been added or updated in the source datastore since the last data extract. This is called delta updates. This approach reduces the environmental impact of reprocessing the same data multiple times.
+
+Designing and building an efficient data model requires
+upfront consideration. Your development team should ensure
+that the optimal row-level granularity (for example
+customer level, address level, or product level) and data
+attributes reduces unnecessary deduplication and
+filtering further downstream.
+
+Most reporting applications support data editing and data
+filtering capabilities. Therefore, your development teams
+can develop a subset of data within the business tool
+minimizing the amount of data required for a report
+refresh.
+
+For more details, refer to the following information:
+
+- [Quick: Creating
+datasets](https://docs.aws.amazon.com/quicksight/latest/user/creating-data-sets.html)
+
+## Suggestion 15.3.2 – Use appropriate data types when developing database tables
+
+Databases and data warehouses can store many different types of data, and have optimized storage mechanisms for each type. Choosing the appropriate type for columns can optimize both the storage size of a dataset and the compute resources needed to process it. For example, storing numbers as integers, floats, and so on, instead of strings can save a lot of storage space, and greatly reduce the processing required when performing calculations. Similarly, dates and timestamps should be stored using matching data types. Consider each column and assign the most specific data type possible.
+
+For more details, refer to the following information:
+
+- [Amazon Redshift best practices for designing tables](https://docs.aws.amazon.com/redshift/latest/dg/c_designing-tables-best-practices.html)
+- [Data
+types in Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/data-types.html)
+- [Amazon Redshift data types](https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html)
+- [Quick: Supported
+data types and values](https://docs.aws.amazon.com/quicksight/latest/user/supported-data-types-and-values.html)
+
+## Suggestion 15.3.3 – Review your APIs to understand whether all data must be shared with your streaming applications
+
+APIs play an important role in connecting and sharing data between
+applications, databases and other systems. Application developers should consider the size
+of an event payload submitted to these systems.
+
+Organizations require the ability to run analytics on
+real-time data. To do so, organizations send data to
+streaming services. Streaming services, such as Amazon Managed Streaming for Apache Kafka (Amazon MSK) and Amazon Kinesis, allow organizations to run analytics on real-time
+streams of information. It is important that the data
+being shared with such streaming services is reviewed
+through the improvement process, because the more data
+provided in the payload will require more resources to
+store and process the data. Reducing the network, storage,
+and compute resources required to process unnecessary data
+can help towards reducing your organization’s analytics
+environmental impact.
+
+Review data that is captured by the application and pushed
+to the streaming platform to identify data attributes that
+can be removed. Also identify opportunities to store
+commonly used transforms to create values that can be
+computed once. Review your Kafka topic and identify if
+it’s duplicated data of whether a single topic is enough
+to deliver to multiple dependencies. Through the
+Improvement process you should consider data volumes and
+the value of your assets, and measure these against your
+organization’s proxy metrics.
+
+If it is not possible to reduce data at the point of data
+capture, as a developer, you can use AWS Lambda to trim
+event payloads of data attributes that are not required
+for downstream processing. However, as an organization,
+you should balance the trade-off of compute cost of
+removing the data versus retaining the original data
+values. This is not a binary option but should be measured
+over time to determine if it would be worthwhile removing
+data.
+
+For more details, refer to the following information:
+
+- AWS Lambda:
+[Using
+AWS Lambda with Amazon Kinesis](https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis-example.html)
+
+Implement a monitor and alert strategy to get a clear
+picture of data growth over time. Take action on any
+significant data growth by understanding what additional
+attributes have been added to the event payload. Alerts
+should be implemented on thresholds, such as 3x data
+growth, or create an internal metric that your
+organization should expect to increase the overall data
+footprint aligned with new customers.
+
+For more details, refer to the following information:
+
+- Amazon Kinesis:
+[Monitoring
+the Amazon Kinesis Data Streams Service with Amazon CloudWatch](https://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html)
+
+## Suggestion 15.3.4 – Reduce the amount of data migrated from one environment to another
+
+Migrating data from one environment to another is a common exercise. Your
+organization should consider data minimization when migrating from one environment to
+another as migration requires additional network, storage, and compute resources for
+migrating unwanted information. Your organization should regularly review all
+information that is in scope of the migration and determine whether it is necessary
+for future workloads, rather than defaulting to a *migrate all*
+approach.
+
+If your organization maintains a data catalog, a review of the data assets by a
+data owner prior to migrating the data should be performed to understand
+whether the data is required by the business.
+
+For more details, refer to the following information:
+
+- AWS Data Migration: [Top 10 Data Migration](https://pages.awscloud.com/rs/112-TZM-766/images/2020_0124-STG_Slide-Deck.pdf)
+- AWS Data Migration (video):
+[Top 10 Data
+Migration Best Practices](https://www.youtube.com/watch?v=i0-pSHQJ7pA)
+
+## Suggestion 15.3.5 – Apply the optimal data model for your data access patterns
+
+Understanding your data access patterns helps you determine which data modeling technique is most suitable. Work backwards from the way you access the data to determine the most suitable data model. There are two broad approaches to data modelling that you can start to consider: normalization and denormalization.
+
+*Normalization* is the method of arranging the data in a data model
+to reduce redundant data and improve query efficiency. This method involves designing the tables and setting up relationships between those tables according to certain rules. Each piece of data is only stored once, and is referenced using its ID. Joins are used to reassemble the full data model. Typically, normalized data models are used in online transaction processing (OLTP) and are supported by relational databases that store the database data in rows. Normalized models minimize the amount of data stored, and compute power needed to make updates.
+
+*Denormalization* is almost the opposite of normalization. Instead of referencing data using IDs, data is copied as many times as needed. Denormalized data models are typically used in online analytical processing (OLAP) where the data is stored in column-oriented massively parallel processing (MPP) databases such as Amazon Redshift. OLAP is designed for multidimensional analysis of data in a data warehouse, which contains both transactional and historical data. In MPP architectures data locality is important, and keeping redundant copies of data and avoiding joins can reduce the compute power needed, as well as network overhead. On the flip side, they may take up more storage, and updates require more compute power.
+
+Whether you should choose normalization or denormalization for your data model depends on your data access patterns. Consider the way you query and update the data set first. In analytics, denormalized data models often perform better. The extra storage requirements from data duplication is often balanced by compression. When storing data in columns instead of rows, data encoding and compression becomes more efficient.
+
+To normalize or denormalize is not an either-or proposition, but a scale. You can denormalize some parts of your data model heavily, while keeping other parts more normalized. For example, if you store personal data and have to be able to update and delete it easily, normalization of that part of the model may lead to the least environmental impact overall. Each query may become slightly less efficient, but you ensure you don’t have to rewrite the whole data set to remove multiple copies of a data point.
+
+For more details, refer to the following information:
+
+- Modern data architecture:
+[Build a modern data architecture on AWS with Amazon AppFlow, AWS Lake Formation, and Amazon Redshift](https://aws.amazon.com/blogs/big-data/build-a-modern-data-architecture-on-aws-with-amazon-appflow-aws-lake-formation-and-amazon-redshift/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.3-encourage-culture-of-data-minimization.html*
+
+---
+
+# Best practice 15.4 – Implement data retention processes to remove unnecessary data from your analytics environment
+
+The retention of data should be informed, relevant, and limited to what is
+necessary for the purposes for which the data is processed. Storing data indefinitely and
+without purpose can cause significant storage and processing overhead that can impact your
+organization’s analytics environmental impact. Ensure that the period for which the data
+should be stored is limited and reviewed on a regular basis.
+
+**How can you remove unnecessary data from an object
+store?**
+
+## Suggestion 15.4.1 – Deﬁne and implement a data lifecycle process for data at rest
+
+Implement a lifecycle management process that will either remove data that is no
+longer required, or archive data into less resource-intensive storage.
+
+When removing data from an object store, your organization should consider the
+following design points:
+
+- The data retention removal process should run on a regular basis
+- The data retention removal process should remove data from all buckets,
+sub-directories and prefixes.
+- The data retention removal process should take an
+audit of what data has been removed, when it was
+removed, and who performed the removal process. This
+audit data should be tracked in an immutable audit log
+for auditing purposes.
+- Production, user acceptance test (UAT), and
+development (DEV) environments must be included and
+adhere to the agreed retention policy across all
+environments.
+- Consider other locations where data might be stored,
+such as SFTP locations.
+- Classify your organization’s data by data temperature,
+such as *hot* for frequently
+accessed, and *cold* for
+infrequently accessed. After data has been classified
+by temperature, your organization should implement a
+strategy to move data into the respective S3 bucket
+storage classes. For example, cold data could be moved
+to Amazon Glacier storage class. For an
+illustration of data temperatures, see
+[Optimizing
+your AWS Infrastructure for Sustainability, Part II:
+Storage](https://aws.amazon.com/blogs/architecture/optimizing-your-aws-infrastructure-for-sustainability-part-ii-storage/).
+
+For more details, refer to the following information:
+
+- Amazon S3 Lifecycle
+Management:
+[Managing
+your storage lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+
+**How can you remove unnecessary
+data from databases?**
+
+## Suggestion 15.4.2 – Remove unnecessary data from databases
+
+To effectively remove information from a database, your
+organization should track when the data was loaded into
+the database and when the last customer interaction
+occurred, such as a purchase or other activity. This
+tracking helps you accurately identify when data should be
+removed.
+
+- The data retention removal process should run
+frequently, but should not be run excessively, as
+excessive deletion can increase compute resources that
+could mitigate the benefit of removing the data from
+your database.
+- The data retention removal process should remove data
+from all databases and tables.
+- The data retention removal process should retain an
+audit of what data has been removed, when it was
+removed, and who performed the removal process. This
+audit data should be tracked in an immutable audit log
+for auditing purposes.
+- If your database enforces referral integrity, you
+should redact only the data and retain the primary and
+foreign keys.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Amazon Redshift Stored Procedures](https://docs.amazonaws.cn/en_us/redshift/latest/dg/stored-procedure-create.html)
+- Amazon Redshift:
+[DELETE
+Statement](https://docs.aws.amazon.com/redshift/latest/dg/r_DELETE.html)
+- Amazon Redshift:
+[Scheduling
+a query on the Amazon Redshift console](https://docs.aws.amazon.com/redshift/latest/mgmt/query-editor-schedule-query.html)
+
+## Suggestion 15.4.3 – Use the shortest possible retention period in streaming applications
+
+The primary use-case of a streaming application is to transfer information from source to target, but they can also retain data for a configured time. This allows replaying the stream to, for example, recover from corruption in a downstream system. At the same time, data stored in a streaming application becomes redundant as soon as it has been stored downstream. Determine the shortest possible retention period that you need to meet your Recovery Point Objective (RPO).
+
+For more details, refer to the following information:
+
+- Amazon Kinesis:
+[Changing
+the Data Retention Period](https://docs.aws.amazon.com/streams/latest/dev/kinesis-extended-retention.html)
+- Amazon Managed Streaming for Apache Kafka:
+[Adjust
+data retention parameters](https://docs.aws.amazon.com/msk/latest/developerguide/bestpractices.html)
+
+## Suggestion 15.4.4 – Design your application to make it possible to efficiently remove or archive outdated data
+
+Designing a data model that supports efficient deletion of data can be surprisingly hard. In the worst case, the deletion of a single piece of data may require rewriting a large portion of the data set in a data lake. This is inefficient and has an unnecessary environmental impact. When designing an application, also design how you remove or archive data from it once that data is outdated, no longer relevant, or upon request.
+
+Consider, and design for things like:
+
+- How to delete all data belonging to a specific user
+- How to delete data older than a specific time
+- How to delete personal data
+
+In data lakes and analytics applications it is often hard to delete individual pieces of data. Consider how to organize data to reduce the amount of data that has to be rewritten to delete a single piece of data – but always balance it against the impact to query performance.
+
+It is often good practice to partition a data set in a data lake by time to make it possible to efficiently delete historical data when it is no longer needed. Similarly, in a data warehouse, keeping data sorted by time yields similar efficiencies.
+
+For more details see:
+
+- [Optimize your modern data architecture for sustainability: Part 1 – data ingestion and data lake](https://aws.amazon.com/blogs/architecture/optimize-your-modern-data-architecture-for-sustainability-part-1-data-ingestion-and-data-lake/)
+- [AWS Well-Architected Framework: SUS04-BP05 Remove unneeded or redundant data](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sus_sus_data_a6.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.4-implement-data-retention-processes-to-remove-redundant-data-from-your-analytics-environment..html*
+
+---
+
+# Best practice 15.5 – Optimize your data modeling and data storage for efficient data retrieval
+
+How your data is organized in a data store, database, or ﬁle system can have an impact on the amount of resources that are required to store, process, and analyze the data. Using encoding, compression, indexes, partitioning, and similar tools we can make this more efficient and reduce the overall environmental impact of our analytics workloads.
+
+**How can your organization reduce the
+resources required to store, process, and analyze your
+organization’s data in a sustainable manner?**
+
+Reducing data that a database system scans to return a result is an eﬃcient way in reducing your organization’s analytics environmental impact. This approach requires less resources to scan the disk to retrieve the information to service the request, and reduces the amount of provisioned storage required to service the workload. There are diﬀerent methods that database engines use to optimize the amount of information scanned, such as partitioning, bucketing, and sorting.
+
+## Suggestion 15.5.1 – Implement an efficient partitioning strategy for your data lake
+
+Partitioning plays a crucial role when optimizing data sets for
+Amazon Athena or Amazon Redshift Spectrum. By partitioning a data set, you can reduce the amount of data scanned by queries dramatically. This reduces the amount of compute power needed, and therefore the environmental impact.
+
+When implementing a partitioning scheme for your data model, work backwards from your queries and identify the properties that would reduce the amount of data scanned the most. For example, it is common to partition data sets by date. Data sets tend to grow over time, and queries tend to look at specific windows of time, such as the last week, or last month.
+
+For more details, refer to the following information:
+
+- Amazon S3 and Amazon Athena:
+[Partitioning and bucketing in Athena](https://docs.aws.amazon.com/athena/latest/ug/ctas-partitioning-and-bucketing.html)
+- Amazon Athena:
+[Partitioning
+data in Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/partitions.html)
+
+## Suggestion 15.5.2 – Configure and sort distribution keys on your Amazon Redshift tables
+
+Amazon Redshift sort keys determine the order in which
+rows in a table are stored on the disk. When you query a data set in Redshift, it can leverage the sort order of the data to avoid reading blocks that are outside of the range of values you are looking for. By reading fewer blocks of data, this approach can result in a reduction of compute resources required.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Choose
+the best sort key](https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html)
+
+In Amazon Redshift, the distribution key, or distkey, determines how data is distributed between the nodes in a cluster. Choosing the right distribution keys can improve the performance of common analytical operations like joins and aggregations.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Automate
+your Amazon Redshift performance tuning with automatic
+table optimization](https://aws.amazon.com/blogs/big-data/automate-your-amazon-redshift-performance-tuning-with-automatic-table-optimization/)
+- Amazon Redshift:
+[Distribution
+styles](https://docs.aws.amazon.com/redshift/latest/dg/c_choosing_dist_sort.html)
+
+## Suggestion 15.5.3 – Enable results and query plan caching
+
+Computing the same result over and over again is wasteful. Query engines and data warehouses often support result caching, and/or query plan caching. By enabling these you can reduce the overall amount of compute power needed for your analytics workload by eliminating recomputing results and/or query plans when the data set hasn’t changed. This saves on compute resource and reduce the environmental impact.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Performance
+optimization](https://docs.aws.amazon.com/redshift/latest/dg/c_challenges_achieving_high_performance_queries.html)
+- Amazon Athena: [Query result reuse](https://docs.aws.amazon.com/athena/latest/ug/reusing-query-results.html)
+
+## Suggestion 15.5.4 – Enable data compression to reduce storage resources
+
+Your organization should consider compressing data in both
+object stores, such as Amazon S3, and if supported, in
+your organization’s database systems. By compressing data,
+your organization is reducing the amount of storage and
+networking resources required for the workload. Database
+systems can decompress the data at a rate that is almost
+unnoticeable to the end user or application. As the data
+is compressed and then decompressed, this will also reduce
+the retrieval time of the database engine to fetch all the
+data from the storage array leading to a potential
+reduction in compute resources.
+
+For more details, refer to the following information:
+
+- **Amazon Redshift compression
+and encoding:**
+[Amazon Redshift Engineering’s Advanced Table Design Playbook:
+Compression Encodings](https://aws.amazon.com/blogs/big-data/amazon-redshift-engineerings-advanced-table-design-playbook-compression-encodings/)
+- **Amazon Redshift file
+compression parameter:**
+[File
+compression parameters](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-file-compression.html)
+- Amazon Redshift
+Compression:
+[Compression
+encodings](https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html)
+- Amazon DynamoDB
+Compression:
+[Using
+data compression](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EMRforDynamoDB.CopyingData.Compression.html)
+- Amazon Athena Compression
+Support:
+[Amazon Athena compression support](https://docs.aws.amazon.com/athena/latest/ug/compression-formats.html)
+
+## Suggestion 15.5.5– Use file formats that optimize storage and compute needs
+
+There are many diﬀerent file formats that can be used to store data from the ubiquitous CSV format, through structured formats like JSON, and data lake-optimized formats like Parquet – each is designed to overcome speciﬁc technical challenges. There is no file format that meets all needs, and different formats have different uses.
+
+For analytical workloads, columnar file formats like Parquet and ORC often perform better overall. They achieve higher compression rates, and help query engines scan less data. Through reduced storage and compute needs they can help reduce the environmental impact of your workload.
+
+More information on how to choose the right format can be found in [Choose the best-performing file format and partitioning](https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/design-principle-10.html).
+
+## Suggestion 15.5.6– Avoid using unnecessary operations in queries, use approximations where possible, and pre-compute commonly used aggregates and joins
+
+Consider the computational requirements of the operations you use when writing queries. For example, think about how the result gets consumed. For example, avoid adding an ORDER BY clause unless the result strictly needs to be ordered.
+
+Many compute-intensive operations can be replaced by approximations. Modern query engines and data warehouses, like Amazon Athena and Amazon Redshift, have functions that can calculate approximate distinct counts, approximate percentiles, and similar analytical functions. These often require much less compute power to run, which can lower the environmental impact of your analytical workload.
+
+Consider pre-computing operations. When you notice that the complexity of your queries increase, or that many queries include the same joins, aggregates, or other compute intensive operations, this can be a sign that you should pre-compute these. Depending on your platform this can be in the form of adding steps to your data transformation pipeline, or by introducing a materialized view.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.5-optimize-your-data-modeling-and-data-storage-for-efficient-data-retrieval..html*
+
+---
+
+# Best practice 15.6 – Prevent unnecessary data movement between systems and applications
+
+Moving data around your organization can be very costly as
+it requires compute, networking, and storage resources. This
+can be particularly costly for analytics workloads as they
+generally require large quantities of information. When
+businesses move data around their organization, they
+increase the risk of creating duplicate data, which can
+impact your storage resource.
+
+At the same time, making multiple copies of data can also reduce the overall amount of data transferred from each access to the data. When designing your data platform, consider the overall environmental impact and make informed choices about when and when not to duplicate data.
+
+**How does your organization mitigate
+the unnecessary data movement from one part of your
+organization to another?**
+
+## Suggestion 15.6.1 – Implement data virtualization techniques to query information where the data resides
+
+In data virtualization, only the data that is required to service the request is copied from the source location into the data virtualization layer and temporarily cached in memory. This data is then used to service the user’s request. By copying the most frequently used parts of the data set closer to the compute instances, overhead associated with data movement is reduced, and the query processing has more efficient access to the data.
+
+For more details, refer to the following information:
+
+- Use Amazon Athena for data
+virtualization:
+[Amazon Athena](https://aws.amazon.com/athena/?whats-new-cards.sort-by=item.additionalFields.postDateTime&whats-new-cards.sort-order=desc)
+- Running Presto and Trino on Amazon EMR:
+[Presto
+and Trino](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-presto.html)
+
+## Suggestion 15.6.2 – Reduce the ﬂow of data between application and database by implementing predicates pushdown
+
+Filtering data by pushing down predicates as close to the storage as possible reduces the amount of data that upstream systems need to process. Query engines like Amazon Athena have query planners that leverage predicate pushdown where possible. For example, when using columnar file formats like Parquet and ORC, Athena can use metadata stored in the files to determine which sections of the files to read, effectively pushing down some predicates to the storage layer. Similarly, when querying a federated data source, Athena can push down some, but not all, predicates into the source systems. This reduces the amount of data that needs to be transferred from the source system into the query engine itself. Research the query engine you use to determine under which circumstances it is able to perform predicate pushdown, and leverage this in your application.
+
+For more details, refer to the following information:
+
+- Use pushdown predicated with Amazon Athena:
+[Top
+10 Performance Tuning Tips for Amazon Athena](https://aws.amazon.com/blogs/big-data/top-10-performance-tuning-tips-for-amazon-athena/)
+- Optimizing EMR Spark with leveraging pushdown
+predicates:
+[Optimize
+Spark performance](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-performance.html)
+
+## Suggestion 15.6.3 – Prevent data movement by leveraging pre-calculated materialized views
+
+A materialized view can reduce the amount of data shared
+between your data warehouse and reporting layers by
+pre-computing the results of a pre-defined query.
+Materialized views are especially useful for speeding up
+queries that are predictable and repeated. Instead of
+performing resource-intensive queries against large tables
+(such as aggregates or multiple joins), applications can
+query a materialized view and retrieve a precomputed
+result set, therefore, saving on compute resource and
+reducing an organization’s analytics environmental impact.
+
+Where materialized views are not available, you can use operations such as CREATE TABLE AS (CTAS) to create pre-computed versions of queries.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Creating
+materialized views in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html)
+- Amazon Athena: [Creating a table from query results (CTAS)](https://docs.aws.amazon.com/athena/latest/ug/ctas.html)
+
+## Suggestion 15.6.4 – Reduce the flow of data between an operational database and a data warehouse by using federated querying
+
+A federated query allows you to directly
+query data stored in external databases without data movement. This allows data
+analysts, engineers, and data scientists to perform SQL
+queries across data stored in relational, non-relational,
+object, and custom data sources.  With federated querying,
+you can submit a single SQL query and analyze data from
+multiple sources running on premises or hosted in the
+cloud, which reduces data latency in reporting. Federated
+querying can reduce the amount of information shared
+between data stores, however, the sustainability trade-off
+is that your organization could transfer the same
+information multiple times rather than a once-off single
+bulk copy of all information on a daily basis. Your
+organization should frequently review your federated
+querying patterns to identify whether it’s more
+sustainable to use federated query or single bulk copies.
+To do this, your organization could review the amount of
+data that has been queried in a week, versus calculating
+the size of a full extract, and implement the approach
+that processes the least amount of data.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Querying
+data with federated queries in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/federated-overview.html)
+- Amazon Athena:
+[Using
+Amazon Athena Federated Query](https://docs.aws.amazon.com/athena/latest/ug/connect-to-a-data-source.html)
+
+## Suggestion 15.6.5 – Decrease the amount of data duplication between Amazon Redshift clusters by using data sharing
+
+Data sharing allows an administrator to share databases, tables, and views from one Amazon Redshift cluster to another cluster without copying the underlying data. The consumer cluster can query live data, meaning changes made on the producer cluster reflect immediately on the consumer cluster. This removes the need to create, store, and keep copies of data sets up-to-date.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Amazon Redshift Data Sharing](https://aws.amazon.com/redshift/features/data-sharing/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.6-prevent-unnecessary-data-movement-between-systems-and-applications..html*
+
+---
+
+# Best practice 15.7 – Efficiently manage your analytics infrastructure to reduce underutilized resources
+
+Ensuring your organization has the correct amount of resource provisioned for your workload is a diﬃcult and challenging task. The common approach for ensuring your organization has the suﬃcient number of resources available for unpredicted peaks is to overprovision your resources. However, this approach generally leads to underutilization, and energy waste.
+
+When designing your analytics workloads, consider using managed and serverless services. Managed services shift responsibility for maintaining high average utilization, and sustainability optimization of the deployed hardware, to AWS. Use managed services to distribute the sustainability impact of the service across all tenants of the service, reducing your individual contribution.
+
+For a wider understanding of optimizing infrastructure for sustainability, refer to the
+following information:
+
+- Well-Architected Sustainability: [Optimizing your AWS Infrastructure for Sustainability, Part I: Compute](https://aws.amazon.com/blogs/architecture/optimizing-your-aws-infrastructure-for-sustainability-part-i-compute/)
+- Well-Architected Sustainability: [Optimizing your AWS Infrastructure for Sustainability, Part II: Storage](https://aws.amazon.com/blogs/architecture/optimizing-your-aws-infrastructure-for-sustainability-part-ii-storage/)
+
+**How does your organization ensure efficient infrastructure
+usage?**
+
+## Suggestion 15.7.1– Use managed and serverless services
+
+Serverless is ideal when it is diﬃcult to predict compute needs, such as with variable workloads, periodic workloads with idle time, and steady-state workloads with spikes. These kinds of workloads are common in analytics applications. Data processing pipelines, running reports, and as-necessary queries are some examples.
+
+Use serverless services AWS Glue ETL and Amazon EMR Serverless to run your data processing jobs and let AWS manage and optimize the underlying resources efficiently. Similarly, using Amazon Athena and Amazon Redshift Serverless for data lakes and data warehousing ensures that you only use compute resources when needed, and allow these services to optimize resource utilization behind the scenes.
+
+For more details, refer to the following information:
+
+- [Amazon Athena](https://aws.amazon.com/athena/)
+- [AWS Glue](https://aws.amazon.com/glue/engines/)
+- [Amazon Redshift Serverless](https://aws.amazon.com/redshift/redshift-serverless/)
+- [Amazon EMR Serverless](https://aws.amazon.com/emr/serverless/)
+
+## Suggestion 15.7.2– Pause your data warehouse and compute clusters when not in use
+
+Compute resources should only be allocated when needed. If your workload cannot leverage serverless technologies, you should implement a process of stopping your compute clusters if there are periods when they will not be used (for example, during nights and weekends).
+
+If your data warehouse uses Amazon Redshift, you can use the pause and resume feature. This retains the underlying data structures so that you can resume the cluster when needed. You can pause and resume clusters using the console, or the API, or even create a schedule that automatically pauses and resumes the cluster at set times.
+
+Pausing data warehouse and compute clusters when not in use ensures there are fewer underutilized resources and reduces the environmental impact of your analytics workload.
+
+For more details, refer to the following information:
+
+- [Amazon Redshift pause and resume: Lower your costs with the new pause and resume actions on Amazon Redshift](https://aws.amazon.com/blogs/big-data/lower-your-costs-with-the-new-pause-and-resume-actions-on-amazon-redshift/)
+- [Amazon Redshift pause and resume: Pausing and resuming clusters](https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html#rs-mgmt-pause-resume-cluster)
+- [AWS Well-Architected Framework Data Analytics: Decouple storage from compute](https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.1---decouple-storage-from-compute..html)
+
+## Suggestion 15.7.3 – Scale your data warehouses and compute clusters to match demand
+
+Only the necessary amount of compute resources should be allocated at any time. Scaling your data warehouse and compute clusters to match demand helps you maximize resource utilization, and reduce the environmental impact of your analytics workload.
+
+For more details, refer to the following information:
+
+- [AWS Well-Architected Framework: SUS05-BP01 Use the minimum amount of hardware to meet your needs](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sus_sus_hardware_a2.html)
+- AWS Well-Architected Framework Data Analytics: Best practice 11.4 – Use auto scaling where appropriate
+- [Scale Amazon Redshift to meet high throughput query requirements](https://aws.amazon.com/blogs/big-data/scale-amazon-redshift-to-meet-high-throughput-query-requirements/)
+- [Amazon Redshift: Elastic resize](https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html#elastic-resize)
+- [Amazon Redshift: Working with concurrency scaling](https://docs.aws.amazon.com/redshift/latest/dg/concurrency-scaling.html)
+
+## Suggestion 15.7.4 – Run your analytics workloads on spare capacity in your Amazon EKS environment for optimal application infrastructure usage
+
+If you use Amazon EKS to run your applications, you can use Amazon EMR on Amazon EKS to also run your analytics workloads, such as Apache Spark jobs, on the same infrastructure. This can make it possible to increase the utilization of your existing compute resources.
+
+For more details, refer to the following information:
+
+- [Amazon EMR on Amazon EKS](https://aws.amazon.com/emr/features/eks/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.7-efficiently-manage-your-analytics-infrastructure-to-reduce-underutilized-resources.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLCOST01.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLCOST01.md
@@ -1,0 +1,342 @@
+# MLCOST01
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLCOST01-BP01 Define overall return on investment (ROI) and opportunity cost
+
+Machine learning projects require careful evaluation of their
+business value and resource requirements. By analyzing the ROI and
+opportunity costs of ML implementations, you can make informed
+decisions that optimize resource allocation while delivering maximum
+business impact.
+
+**Desired outcome:** When you
+implement this practice, you have a clear understanding of the
+financial and business implications of your ML projects. You can
+differentiate between research-oriented and development-oriented ML
+initiatives, track costs effectively through tagging mechanisms, and
+make data-driven decisions about resource allocation. You have
+established processes to continuously evaluate the cost-benefit
+ratio of ML initiatives as business conditions evolve, and your
+investments deliver measurable value while managing risks
+appropriately.
+
+**Common anti-patterns:**
+
+- Initiating ML projects without defining clear business
+objectives or expected outcomes.
+- Failing to distinguish between research projects (long-term
+returns) and development projects (near-term returns).
+- Not implementing cost tracking mechanisms for ML projects.
+- Overlooking the ongoing operational costs of maintaining ML
+models in production.
+- Failing to reassess the cost-benefit model when business
+conditions change.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved allocation of limited resources to ML initiatives with
+highest potential returns.
+- Clear visibility into project costs and benefits for better
+budgeting and planning.
+- Reduced risk of project failure through upfront analysis and
+ongoing monitoring.
+- Enhanced ability to communicate ML value to stakeholders.
+- Accelerated time-to-value through focus on high-impact use
+cases.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Understanding the financial implications of machine learning
+initiatives is crucial for making strategic technology
+investments. Machine learning projects can vary significantly in
+terms of resource requirements, timeline to value, and overall
+business impact. By carefully evaluating the ROI and opportunity
+costs, you can prioritize initiatives that deliver the most
+significant business value while managing costs effectively.
+
+Start by working with both technical and business teams to clearly
+define whether an ML project is research-oriented (focused on
+exploring potential future value) or development-oriented
+(applying established methods to deliver immediate business
+value). This distinction assists to set appropriate expectations
+around timelines, resources, and outcomes. Implement comprehensive
+cost tracking through tagging mechanisms to maintain visibility
+into project expenses across data engineering, model development,
+and production deployment phases.
+
+When assessing ML project costs, consider both direct expenses
+(infrastructure, tools, services) and indirect costs (staff time,
+training requirements, maintenance). Factor in potential costs
+associated with data preparation, model accuracy, and production
+errors. Develop a comprehensive cost-benefit model that accounts
+for these elements while considering business-specific factors
+like competitive advantage and strategic positioning.
+
+### Implementation steps
+
+- **Specify the objectives of the ML
+project as research or development**. Work with
+both business stakeholders and data science teams to
+determine if your ML initiative is exploratory research with
+long-term returns or development applying established
+methods for faster ROI. Align between technical teams and
+business leaders on project classification, timelines, and
+expected outcomes.
+- **Use tagging to track costs by
+project and business unit**. Implement
+comprehensive tagging in your AWS environment using
+[AWS Cost Categories](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-categories.html) and
+[AWS Tagging](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html) strategies to allocate ML-related expenses to
+specific projects and business functions. Monitor these
+costs through
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) to maintain clear visibility of ROI by
+project.
+- **Evaluate and assess the data
+pipeline, the ML model, and the expected quality of
+production inferences**. Analyze the infrastructure
+requirements, operational costs, and potential business
+impact of errors in your ML system. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) to assess model quality and
+identify potential bias that could impact business outcomes
+and add remediation costs.
+- **Develop a cost-benefit
+model**. Create a comprehensive financial model
+that accounts for initial development costs, ongoing
+operational expenses, and expected business benefits.
+Regularly reassess this model as business conditions change
+or when considering new data sources. Use
+[Quick](https://aws.amazon.com/quicksight/) to build dashboards tracking ML costs
+against business KPIs.
+- **Understand, evaluate, and monitor
+project risks**. Identify technical, operational,
+and business risks associated with your ML project.
+Establish monitoring systems to track these risks through
+development and production phases. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor technical metrics and
+[AWS Budgets](https://aws.amazon.com/aws-cost-management/aws-budgets/) to track spending against forecasts.
+- **Estimate the cost of resources
+needed for production maintenance**. Calculate the
+ongoing expenses required to maintain your ML model in
+production, including data engineers, data scientists,
+infrastructure costs, and monitoring systems. Consider using
+[AWS Application Cost Profiler](https://aws.amazon.com/aws-cost-management/aws-application-cost-profiler/) to attribute costs
+accurately across your ML applications.
+- **Leverage enhanced cost tracking and
+optimization tools**. Use
+[AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html) to automatically identify
+unusual spending patterns in your ML workloads and receive
+alerts for unexpected cost increases.
+- **Consider model selection trade-offs
+for generative AI projects**. When implementing
+generative AI solutions, carefully evaluate the balance
+between model size, performance, and cost. Smaller,
+domain-specific models may be more cost-effective than large
+foundation models for certain use cases. Consider using
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for access to multiple foundation models
+through a single API, allowing for streamlined model
+selection and optimization.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Pricing Calculator](https://calculator.aws/#/createCalculator)
+- [What
+is AWS Billing and Cost Management and Cost Management?](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-categories.html)
+- [Optimizing
+cost for building AI models with Amazon EC2 and SageMaker AI](https://aws.amazon.com/blogs/aws-cloud-financial-management/optimizing-cost-for-developing-custom-ai-models-with-amazon-ec2-and-sagemaker-ai/)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 4: Training jobs](https://aws.amazon.com/blogs/machine-learning/part-4-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-4-training-jobs/)
+- [AWS Application Cost Profiler](https://aws.amazon.com/aws-cost-management/aws-application-cost-profiler/)
+- [Getting
+started with AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html)
+- [Managing
+costs with AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [AWS Cost and Usage Report](https://aws.amazon.com/aws-cost-management/aws-cost-and-usage-reporting/)
+- [Generative
+AI Cost Optimization Strategies](https://aws.amazon.com/blogs/enterprise-strategy/generative-ai-cost-optimization-strategies/)
+
+**Related videos:**
+
+- [Maximizing
+ML ROI: Amazon SageMaker AI's High-Performance Inference and Cost
+Optimization Strategies](https://aws.amazon.com/awstv/watch/3cf59d4c5e5/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost01-bp01.html*
+
+---
+
+# MLCOST01-BP02 Use managed services to reduce total cost of ownership (TCO)
+
+Using managed machine learning services enables organizations to
+operate more efficiently with reduced resources and costs compared
+to self-managed options. This approach reduces undifferentiated
+heavy lifting, reduces operational burden, and allows teams to focus
+on delivering business value.
+
+**Desired outcome:** By adopting
+managed services and pay-per-usage models, you significantly reduce
+your total cost of ownership while gaining access to a comprehensive
+suite of AI/ML tools. You can use pre-built capabilities instead of
+developing custom solutions, automatically scale resources based on
+demand, and benefit from AWS's continuous innovations without
+additional investment. Your teams can focus on creating business
+value rather than managing infrastructure.
+
+**Common anti-patterns:**
+
+- Building and maintaining custom ML infrastructure on EC2 or
+Kubernetes.
+- Overprovisioning resources for peak ML workloads.
+- Failing to use commitment discounts for persistent workloads.
+- Developing proprietary AI services when managed services would
+suffice.
+- Not analyzing workload patterns to optimize instance selection.
+
+**Benefits of establishing this best
+practice:**
+
+- Significantly lower total cost of ownership compared to
+self-managed options.
+- Reduced operational overhead and simplified management.
+- Increased team productivity with focus on core business
+problems.
+- Access to continuously updated and improved AI/ML capabilities.
+- Flexibility to scale resources based on actual demand.
+- Ability to use commitment-based pricing for additional savings.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Managed services remove the operational burden of maintaining
+infrastructure, allowing you to concentrate on developing ML
+models and applications that drive business value. Using AWS's
+managed ML services provides a comprehensive environment for
+building, training, and deploying models with significantly lower
+costs than self-managed options.
+
+When evaluating your ML strategy, consider the total cost of
+ownership including infrastructure, operational personnel,
+maintenance, scaling, and upgrades. Amazon SageMaker AI provides a
+fully managed service that avoids many of these costs while
+offering advanced ML capabilities. Similarly, AWS's pre-trained AI
+services can address common use cases without requiring ML
+expertise, further reducing implementation time and costs.
+
+To maximize cost efficiency, analyze your workload patterns and
+determine which components would benefit from commitment
+discounts. By using Savings Plans, you can significantly reduce
+your AWS usage costs while maintaining flexibility across instance
+families, sizes, regions, and components.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI as your
+fully managed ML solution.**
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) enables building, training, and
+deploying models at scale with significantly lower costs.
+The total cost of ownership (TCO) of SageMaker AI over a
+three-year period is much lower than other self-managed
+cloud-based ML options, such as
+[Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html) (Amazon EC2) and
+[Amazon Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) (Amazon EKS). SageMaker AI
+includes technologies such as
+[Autopilot](https://aws.amazon.com/sagemaker/autopilot/),
+[Feature
+Store](https://aws.amazon.com/sagemaker/feature-store/),
+[Clarify](https://aws.amazon.com/sagemaker/clarify/),
+[Debugger](https://aws.amazon.com/sagemaker/debugger/),
+[Studio](https://aws.amazon.com/sagemaker/studio/),
+[Training](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html),
+Model deployment,
+[Monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html),
+and
+[Pipelines](https://aws.amazon.com/sagemaker/pipelines/).
+- **Use Amazon managed AI services for
+common use cases.** AWS pre-trained AI services
+provide ready-made intelligence for your applications and
+workflows. These services address common use cases such as
+personalized recommendations, contact center modernization,
+safety and security improvement, and customer engagement
+enhancement. They don't require machine learning expertise,
+are fully managed, and offer pay-as-you-go pricing with no
+upfront commitment.
+- **Perform pricing model analysis for
+cost optimization.** Analyze each component of your
+ML workload to determine if it will run for extended
+periods, making it eligible for commitment discounts such as
+[AWS Savings Plans](https://docs.aws.amazon.com/savingsplans/latest/userguide/what-is-savings-plans.html). You can use Savings Plans to reduce
+AWS usage costs by committing to a consistent amount of
+usage.
+[Amazon SageMaker AI Savings Plans](https://aws.amazon.com/savingsplans/ml-pricing/) offer flexible attributes
+such as instance family, instance size, AWS Region, and
+component for your SageMaker AI instance usage.
+- **Implement right-sizing strategies
+for ML resources.** Evaluate your actual ML
+workload resource requirements and adjust instance types and
+sizes accordingly. This blocks overprovisioning and assists
+to control costs while maintaining performance. Use
+SageMaker AI's automatic scaling capabilities to match
+resources with demand.
+- **Use serverless options when
+appropriate.** For intermittent workloads or those
+with variable demand, consider serverless options like
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) to avoid paying for
+idle resources.
+- **Use Amazon Bedrock for foundation
+model access.**
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) provides a unified API for accessing various
+foundation models, making it simple to experiment with and
+integrate generative AI capabilities without investing in
+model training infrastructure. This fully managed service
+assists to reduce costs while allowing flexibility to choose
+the right model for your use case.
+- **Use Foundation Model Hub for
+centralized model access**. Use the Foundation
+Model Hub to access a centralized catalog of popular
+foundation models with simplified deployment and performance
+benchmarking tools, reducing the time and cost of model
+selection and deployment.
+- **Use AI-powered code generation
+tools.** Use
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and AI-powered IDEs like Kiro to
+accelerate ML development through AI-assisted coding,
+automated code generation, and intelligent troubleshooting,
+significantly reducing developer time and associated costs.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon
+managed AI services](https://aws.amazon.com/machine-learning/ai-services/)
+- [AWS AI Services overview](https://aws.amazon.com/machine-learning/)
+- [ML
+Savings Plans](https://aws.amazon.com/savingsplans/ml-pricing/)
+- [AWS Pricing Calculator for SageMaker AI](https://calculator.aws/#/createCalculator/SageMaker AI)
+- [Viewing
+resource recommendations](https://docs.aws.amazon.com/compute-optimizer/latest/ug/viewing-recommendations.html)
+- [What
+is Amazon Bedrock?](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
+- [What
+is AWS Migration Hub?](https://docs.aws.amazon.com/migrationhub/latest/ug/whatishub.html)
+- [What
+are AWS Cost and Usage Reports?](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost01-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLCOST02.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLCOST02.md
@@ -1,0 +1,338 @@
+# MLCOST02
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLCOST02-BP01 Identify if machine learning is the right solution
+
+Evaluating whether machine learning is the appropriate solution for
+your business problem is crucial for cost optimization. Not every
+problem requires ML solutions, and sometimes simpler approaches may
+be more effective and less costly. By thoroughly evaluating
+alternatives against ML approaches, you can make informed decisions
+that optimize both your technical resources and business outcomes.
+
+**Desired outcome:** You identify
+whether machine learning is truly the optimal solution for your
+business problem by comparing it against simpler alternatives. You
+make informed decisions about resource allocation, understanding the
+cost implications of ML adoption including data preparation,
+storage, training, hosting, and maintenance. You validate your
+approach using tools like Amazon SageMaker AI Autopilot and Amazon SageMaker AI Clarify to verify that ML provides measurable benefits
+over alternative solutions.
+
+**Common anti-patterns:**
+
+- Jumping directly to ML solutions without evaluating simpler
+alternatives.
+- Underestimating the total cost of implementing ML, including
+data preparation and maintenance.
+- Failing to establish a baseline for comparison with existing or
+rules-based approaches.
+- Overlooking specialized resource constraints such as data
+scientist availability or model time-to-market.
+
+**Benefits of establishing this best
+practice:**
+
+- Avoids unnecessary complexity and cost in solution design.
+- Optimizes resource allocation based on actual business value.
+- Reduces risk of project failure due to inappropriate technology
+selection.
+- Provides quantifiable metrics for evaluating ML solution
+effectiveness.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When considering machine learning for a business problem, start by
+thoroughly evaluating whether ML is truly necessary. Many problems
+can be effectively solved with simpler rule-based approaches that
+may be less expensive to develop and maintain. Machine learning
+requires significant investment in data preparation, specialized
+hardware, and ongoing maintenance that must be justified by the
+business value it delivers.
+
+Begin by clearly articulating your problem and determining if it
+requires the adaptive learning capabilities that ML provides.
+Consider if the problem involves complex patterns that rules can't
+simply capture, or if it requires continuous adaptation to
+changing conditions. For example, fraud detection in financial
+transactions might benefit from ML due to constantly evolving
+fraudulent behaviors, while simple inventory management might be
+better served by a rules-based system.
+
+Evaluate costs associated with an ML solution, including data
+preparation, storage, compute resources for training, potential
+data labeling, model hosting, and ongoing maintenance. Compare
+these costs against the business value gained from using ML versus
+alternative approaches. Remember that specialized resources like
+data scientists might be your most constrained resource, making
+their time allocation a critical consideration.
+
+### Implementation steps
+
+- **Articulate your problem
+clearly**. Define the business problem you're
+trying to solve, the desired outcomes, and how success will
+be measured. Be specific about what decisions need to be
+made and what data is available to support those decisions.
+- **Identify your data
+sources**. Evaluate what data you already have,
+what data you need to collect, and whether the quality and
+quantity are sufficient for ML applications. Consider
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) to catalog and manage your data assets.
+- **Calculate comprehensive cost
+implications**. Consider the aspects of
+implementing an ML solution:
+
+Data preparation and engineering costs
+- Data storage requirements and associated costs using
+[Amazon S3](https://aws.amazon.com/s3/) or other storage services
+- Model training expenses on various hardware options in
+[Amazon SageMaker AI Model Training](https://aws.amazon.com/sagemaker/ai/train/)
+- Data labeling costs if supervised learning is required
+- Potential retraining costs due to model drift or bias
+- Model hosting and inference costs
+- Ongoing maintenance and monitoring expenses
+
+- **Establish a baseline
+solution**. Evaluate how the problem is currently
+being solved or how it could be solved with a simpler
+approach. If a rules-based solution exists, use it as a
+baseline for comparison. For basic ML approaches, consider
+pre-built solutions from
+[AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning) or
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/).
+- **Build and evaluate an ML
+prototype**. Use
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) or
+[Amazon SageMaker AI Autopilot](https://docs.aws.amazon.com/sagemaker/latest/dg/autopilot-automate-model-development.html) to quickly develop an ML model.
+Compare the performance metrics of this solution against
+your baseline approach, including accuracy, inference time,
+and total cost of operation.
+- **Analyze model
+explainability**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-fairness-and-explainability.html) to understand how your ML model
+makes decisions and evaluate if these explanations align
+with business expectations and requirements.
+- **Make a data-driven
+decision**. Based on your comparative analysis,
+determine if the ML approach demonstrates sufficient
+improvement over simpler solutions to justify the
+investment. Consider both quantitative metrics and
+qualitative factors like flexibility and scalability.
+- **Use no-code ML for rapid
+validation**. Use
+[SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html) with natural language support to quickly
+validate whether ML approaches provide value over simpler
+solutions, reducing the time and cost of initial feasibility
+assessment. Export Canvas-generated models and code to
+notebooks for further customization and integration into
+production workflows.
+- **Use AI-powered code generation for
+rapid prototyping**. Use AI-powered development
+tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to quickly
+generate ML prototype code, automate data preprocessing
+scripts, and accelerate the validation process for
+determining if ML is the right solution.
+- **Assess hybrid approaches**.
+Consider whether combining rules-based systems with ML or
+generative AI could provide the optimal balance of cost,
+performance, and explainability for your specific use case.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [SageMaker AI
+autopilot](https://docs.aws.amazon.com/sagemaker/latest/dg/autopilot-automate-model-development.html)
+- [Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/)
+- [Machine
+Learning solutions in AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning)
+- [Cost
+Optimization Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [What
+is Amazon Bedrock?](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost02-bp01.html*
+
+---
+
+# MLCOST02-BP02 Perform a tradeoff analysis between custom and pre-trained models
+
+Optimize machine learning costs by carefully analyzing the tradeoffs
+between developing custom models and using pre-trained models. This
+analysis should maintain security and performance efficiency within
+acceptable thresholds while minimizing unnecessary expenses.
+
+**Desired outcome:** You achieve
+optimal cost efficiency in your machine learning initiatives by
+making informed decisions about when to use pre-trained models
+versus developing custom solutions. You balance development costs,
+time-to-market, model performance, and specific business
+requirements while maintaining appropriate security standards. This
+strategic approach allows you to accelerate ML development while
+optimizing your investment in AI/ML resources.
+
+**Common anti-patterns:**
+
+- Building custom models for every use case without considering
+available pre-trained alternatives.
+- Using pre-trained models without evaluating if they meet your
+specific business requirements.
+- Ignoring the total cost of ownership including data scientist
+time, infrastructure, and ongoing maintenance.
+- Overlooking security and compliance requirements when selecting
+pre-trained models.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time-to-market for ML solutions.
+- Lower development and operational costs.
+- Ability to use state-of-the-art models without needing extensive
+expertise.
+- More efficient use of data scientist and ML engineer resources.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When implementing machine learning solutions, the decision between
+building custom models and using pre-trained ones significantly
+impacts costs, time-to-market, and solution effectiveness. Custom
+models offer greater flexibility and potential performance
+advantages for specialized tasks but require substantial
+investment in data collection, training infrastructure, and
+expertise. Pre-trained models provide rapid deployment and reduced
+initial costs but may not perfectly align with specific business
+needs.
+
+Your analysis should consider factors including data availability,
+task specificity, performance requirements, available expertise,
+and long-term maintenance costs. For many common use cases like
+sentiment analysis, image classification, or document processing,
+pre-trained models can deliver excellent results without the
+overhead of custom development. For highly specialized domains or
+when competitive advantage depends on model performance, custom
+development may justify the additional investment.
+
+### Implementation steps
+
+- **Assess your machine learning
+needs**. Begin by clearly defining your business
+use case, required model accuracy, latency requirements, and
+available data. Understand whether your use case is standard
+(for example, image classification or sentiment analysis) or
+highly specialized to guide your decision-making process.
+- **Use Amazon SageMaker AI built-in
+algorithms and AWS Marketplace**.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/ai/?nc=sn&loc=1) provides a suite of built-in algorithms
+for data scientists and machine learning practitioners to
+get started on training and deploying machine learning
+models. Pre-trained ML models are ready-to-use models that
+can be quickly deployed on Amazon SageMaker AI. By pre-training
+the ML models for you, solutions in the
+[AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning/pre-trained-models) take care of the heavy lifting so that
+you can deliver AI- and ML-powered features faster and at a
+lower cost. Evaluate the cost of your data scientists' time
+and other resource requirements to develop your own custom
+model vs. bringing a pre-trained model and deploying it on
+SageMaker AI for inferencing. The advantage of a custom model
+is the flexibility to fine-tune it to match the needs of
+your business use case. A pre-trained model can be difficult
+to modify and you might have to use it as is.
+- **Use Amazon SageMaker AI
+JumpStart**. Use
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) to access pre-trained models and
+accelerate the ML development process. SageMaker AI JumpStart
+provides a set of solutions for the most common use cases
+that can be deployed readily with just a few clicks. The
+solutions are fully customizable and showcase the use of AWS CloudFormation templates and reference architectures so you
+can accelerate your ML journey. Amazon SageMaker AI JumpStart
+also supports one-click deployment and fine-tuning of more
+than 150 popular open-source models such as natural language
+processing, object detection, and image classification
+models.
+- **Conduct a cost-benefit
+analysis**. Calculate the total cost of ownership
+for both custom and pre-trained approaches, including
+development time, infrastructure costs, and ongoing
+maintenance. Consider factors such as data preparation,
+training resources, and the expertise required. Compare
+these costs against expected business value and performance
+requirements to determine the most cost-effective approach.
+- **Implement cost monitoring and
+optimization**. Use
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and
+[AWS Budgets](https://aws.amazon.com/aws-cost-management/aws-budgets/) to monitor and manage your ML workload costs.
+Implement automatic shutdown of idle resources to reduce
+unnecessary expenses. Consider using
+[AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/) to get cost optimization
+recommendations for your ML infrastructure.
+- **Explore model customization
+options**. When pre-trained models don't fully meet
+your requirements, explore customization options like
+fine-tuning or transfer learning before committing to full
+custom development. This approach can provide a middle
+ground between cost and performance and access to existing
+models while adapting them to your specific needs.
+- **Implement a multi-model
+approach**. For complex use cases, consider using
+different models for different components of your solution
+based on their requirements. This allows you to optimize
+costs by using simpler, more economical models where
+appropriate while reserving more powerful models for tasks
+that require them.
+- **Evaluate foundation models in Amazon
+Bedrock**.
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) provides a fully managed service that offers
+foundation models from leading AI companies through a single
+API. Consider using these models for text, image, and
+multimodal generative AI applications instead of building
+custom models. You can customize these models to your
+specific needs using retrieval-augmented generation (RAG) or
+fine-tuning while maintaining cost efficiency.
+- **Use expanded pre-trained model
+libraries**. Use the expanded
+[SageMaker AI
+JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) catalog which now includes broader
+selection of pre-trained models and industry-specific
+solutions, reducing the need for custom model development
+and associated costs.
+- **For generative AI workloads,
+consider retrieval-augmented generation (RAG)**.
+For many generative AI applications, implementing RAG can
+enhance the performance of foundation models by providing
+them with relevant context from your organization's data.
+This approach can be more cost-effective than fine-tuning
+and still provide customized outputs tailored to your
+business domain.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/)
+- [Pre-trained
+machine learning models available in AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning/pre-trained-models)
+- [Amazon SageMaker AI pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [Cloud
+Financial Management with AWS](https://aws.amazon.com/aws-cost-management/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost02-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLCOST03.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLCOST03.md
@@ -1,0 +1,679 @@
+# MLCOST03
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLCOST03-BP01 Use managed data labeling
+
+Use managed labeling tools that provide automation and access to
+cost-effective teams of human data labelers. These tools should
+offer flexibility to choose a variable number of labelers for each
+input, include a user-friendly interface, and incorporate learning
+capabilities to improve labeling efficiency over time.
+
+**Desired outcome:** You have access
+to high-quality labeled datasets for your machine learning models
+without building and managing your own labeling infrastructure. Your
+data labeling process is streamlined, cost-efficient, and scales
+according to your needs, allowing you to focus on model development
+rather than data preparation logistics.
+
+**Common anti-patterns:**
+
+- Building custom data labeling infrastructure from scratch.
+- Relying solely on in-house teams for labeling tasks regardless
+of scale.
+- Using labeling solutions that don't improve through machine
+learning.
+- Managing inconsistent labeling quality without proper oversight
+tools.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduce time-to-market for ML models by accelerating the data
+labeling process.
+- Lower total labeling costs through efficient automation and
+on-demand workforce.
+- Improve labeling quality and consistency through specialized
+tools and workflows.
+- Scale labeling operations up or down based on project
+requirements.
+- Focus your team's effort on model development rather than
+labeling infrastructure.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+To build effective machine learning models, you need large,
+high-quality labeled datasets. Creating these datasets manually is
+time-consuming, expensive, and difficult to scale. By using
+managed data labeling services, you can accelerate this critical
+step in the ML development process while controlling costs and
+maintaining quality.
+
+Managed data labeling combines human intelligence with machine
+learning to improve efficiency over time. As your models process
+more data, they can begin to automate parts of the labeling
+process, reducing costs and time required. These services also
+provide quality control mechanisms through consensus models, where
+multiple labelers evaluate the same data to check accuracy.
+
+When selecting a managed data labeling solution, consider factors
+like the types of data you need to label (like images, text, and
+video), the complexity of your labeling tasks, integration with
+your existing ML workflow, and cost structure. The right solution
+will scale with your needs and provide consistent, high-quality
+labeled data.
+
+### Implementation steps
+
+- **Assess your data labeling
+requirements**. Define what types of data you need
+labeled (images, text, audio, or video), the complexity of
+annotations required, expected volume, and quality
+standards. Determine whether you need specialized domain
+expertise for your labeling tasks.
+- **Use Amazon SageMaker Ground Truth**. To train a machine learning model, you
+need a large, high-quality, labeled dataset.
+[Amazon SageMaker Ground Truth](https://docs.aws.amazon.com/sagemaker/latest/dg/sms.html) assists you to build
+high-quality training datasets for your ML models. With
+Ground Truth, you can use ML along with workers from a
+vendor company that you choose, or an internal, private
+workforce to create a labeled dataset. You can use the
+labeled dataset output from Ground Truth to train your own
+models. You can also use the output as a training data set
+for an Amazon SageMaker AI model.
+- **Use Amazon SageMaker Ground Truth
+Plus**. Ground Truth Plus is a turn-key service
+that uses an expert workforce to deliver high-quality
+training datasets fast, and reduces costs by up to 40
+percent.
+[Amazon SageMaker Ground Truth Plus](https://docs.aws.amazon.com/sagemaker/latest/dg/gtp.html) enables you to create
+high-quality training datasets without having to build
+labeling applications and manage the labeling workforce on
+your own. By using this approach, you don't need to have
+deep ML expertise or extensive knowledge of workflow design
+and quality management. You simply provide data along with
+labeling requirements and Ground Truth Plus sets up the data
+labeling workflows and manages them on your behalf in
+accordance with your requirements.
+- **Configure active learning
+workflows**. Set up your labeling projects to use
+active learning, where the system learns from human
+annotations and begins to automate labeling for similar
+items. This reduces the number of items requiring manual
+labeling over time, improving efficiency and reducing costs.
+Amazon SageMaker Ground Truth provides built-in support for
+active learning.
+- **Implement quality control
+mechanisms**. Configure your labeling jobs to use
+multiple workers per data item and determine consensus
+approaches based on your quality requirements. Monitor
+labeling performance and adjust your quality control
+parameters as needed.
+- **Set up real-time data labeling
+pipelines**. For ongoing ML projects, establish
+continuous data labeling pipelines that can process new data
+as it becomes available. This way, your models can be
+regularly retrained with fresh data.
+- **Create custom labeling interfaces
+when needed**. For specialized labeling tasks, use
+Ground Truth's custom template capabilities to create
+tailored labeling interfaces that make the process more
+efficient for your specific use case.
+- **Use enhanced Ground Truth
+capabilities**. Use improved Ground Truth Plus
+features that provide up to 40% cost reduction through
+expert workforce management and automated quality control
+mechanisms.
+- **Use foundation models for
+pre-labeling**. Use generative AI models through
+Amazon Bedrock to assist with initial data labeling, which
+can then be verified by human labelers. This hybrid approach
+can significantly accelerate the labeling process while
+maintaining quality control.
+
+## Resources
+
+**Related documents:**
+
+- [Training
+data labeling using humans with Amazon SageMaker Ground Truth](https://docs.aws.amazon.com/sagemaker/latest/dg/sms.html)
+- [Use
+Amazon SageMaker Ground Truth Plus to Label Data](https://docs.aws.amazon.com/sagemaker/latest/dg/gtp.html)
+- [Using
+the Amazon Mechanical Turk Workforce](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-workforce-management-public.html)
+- [Automate
+data labeling](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-automated-labeling.html)
+- [Custom
+labeling workflows](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-custom-templates.html)
+- [Annotation
+consolidation](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-annotation-consolidation.html)
+- [Ground
+Truth streaming labeling jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-streaming-labeling-job.html)
+- [Implementing
+a custom labeling GUI with built-in processing logic with
+Amazon SageMaker Ground Truth](https://aws.amazon.com/blogs/machine-learning/implementing-a-custom-labeling-gui-with-built-in-processing-logic-with-amazon-sagemaker-ground-truth/)
+
+**Related examples:**
+
+- [Bring
+your own model for SageMaker AI labeling workflows with active
+learning](https://github.com/aws/amazon-sagemaker-examples/blob/master/ground_truth_labeling_jobs/bring_your_own_model_for_sagemaker_labeling_workflows_with_active_learning/bring_your_own_model_for_sagemaker_labeling_workflows_with_active_learning.ipynb)
+- [SageMaker AI
+Ground Truth recipe](https://github.com/aws-samples/aws-sagemaker-ground-truth-recipe)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp01.html*
+
+---
+
+# MLCOST03-BP02 Use no-code or low-code and code generation tools for interactive analysis
+
+Prepare data through data wrangler tools for interactive data
+analysis and model building. The no-code/low-code, automation, and
+visual capabilities improve productivity and reduce the cost for
+interactive analysis. Integrate with generative AI code generation
+tools.
+
+**Desired outcome:** You will be able
+to streamline your data preparation workflow using visual interfaces
+with minimal coding required. By implementing no-code or low-code
+tools like Amazon SageMaker AI Canvas and Data Wrangler, you reduce
+time spent on data preprocessing tasks and gain improved insights
+through interactive visualizations. Amazon Q integration provides
+intelligent assistance for data preparation and code generation,
+enabling faster iteration cycles on model development while
+maintaining data quality and consistency across your machine
+learning projects.
+
+**Common anti-patterns:**
+
+- Writing custom data preparation scripts for every analysis task.
+- Using disjointed tools for data import, transformation, and
+visualization.
+- Manually performing repetitive data cleaning operations.
+- Creating non-reproducible data preparation workflows.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time and cost for data preparation and feature
+engineering.
+- Improved productivity through visual interfaces and automation.
+- Streamlined workflow from data import to model deployment.
+- Support for code and no-code approaches to accommodate different
+skill levels.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Data preparation is often cited as the most time-consuming aspect
+of machine learning projects, typically consuming 60-80% of data
+scientists' time. Data wrangler tools provide visual interfaces to
+simplify and accelerate this process through automation and
+low-code solutions.
+
+Amazon SageMaker AI Data Wrangler offers an end-to-end solution for
+data preparation that integrates directly with your machine
+learning workflow. By using a visual interface, you can import
+data from various sources, identify and fix data quality issues,
+transform features, and generate insights—all with minimal coding
+required. The tool provides transparency by generating code for
+your transformations, fostering reproducibility and allowing
+customization when needed.
+
+Data wrangler tools are particularly valuable for exploratory data
+analysis, where quick iteration and visualization are essential.
+They allow you to rapidly identify patterns, outliers, and
+relationships in your data, accelerating the feature engineering
+process. With built-in data quality and insights features, you can
+understand your data characteristics and address issues before
+model training begins.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Canvas or
+Studio environment**. Access SageMaker AI Canvas for a
+no-code experience or SageMaker AI Studio for more advanced
+capabilities through the AWS Management Console. Canvas
+provides a visual, drag-and-drop interface for business
+analysts and citizen data scientists, while Studio offers
+Data Wrangler for more technical users. Both environments
+support the complete machine learning workflow with varying
+levels of coding requirements.
+- **Import data from various
+sources**. Use SageMaker AI Canvas or Data Wrangler to
+connect to multiple data sources including Amazon S3, Amazon Athena, Amazon Redshift, Snowflake, and various databases.
+Canvas provides a simplified point-and-click interface for
+business users, while Data Wrangler offers more advanced
+data source connectivity options. Both tools avoid the need
+for custom connector code.
+- **Explore and visualize your
+data**. USe Data Wrangler's built-in data
+visualizations to understand distributions, correlations,
+and outliers. These visualizations assist to identify
+potential issues early and inform feature engineering
+decisions without writing complex plotting code.
+- **Use Amazon Q for generative
+AI-powered data preparation and code generation**.
+Use Amazon Q integrated within SageMaker AI Canvas and Data
+Wrangler to get natural language assistance for data
+preparation tasks, automated code generation, and
+intelligent suggestions for data transformations. Amazon Q
+can explain data patterns, suggest optimal preprocessing
+steps, and generate code snippets for custom
+transformations, significantly reducing the time needed for
+data preparation tasks. Additionally, use AI-powered
+development tools like Kiro for intelligent code generation
+and optimization of your data processing workflows.
+- **Apply transformations to prepare
+your data**. Use the visual transformation
+interface to clean and prepare data through operations like
+handling missing values, encoding categorical features,
+scaling numerical values, and feature extraction. Data
+Wrangler provides over 300 built-in transformations while
+allowing custom Python transformations when needed.
+- **Analyze data quality and generate
+insights**. Use the built-in data quality and
+insights features to detect anomalies, check for imbalanced
+data, and understand feature importance. These automated
+analyses identify potential issues before model training
+begins.
+- **Balance your datasets**.
+Address imbalanced datasets using built-in techniques like
+random oversampling, random undersampling, and synthetic
+minority oversampling (SMOTE). Data Wrangler provides visual
+controls to implement these techniques without specialized
+knowledge.
+- **Scale to larger datasets**.
+Process larger datasets by configuring instance types and
+using distributed processing capabilities. Data Wrangler
+supports processing wide datasets with thousands of columns
+and large datasets with billions of rows through appropriate
+resource allocation.
+- **Prepare time series data**.
+Use specialized time series transformations to handle
+temporal data, including resampling, lagged feature
+creation, and time-based aggregations. These operations
+simplify working with sequential data patterns.
+- **Export your data flow for
+production**. Deploy your data preparation workflow
+by exporting to various destinations including Amazon S3,
+SageMaker AI Feature Store, or directly to model building
+workflows. Data Wrangler generates Python code that can be
+integrated into production pipelines. Canvas workflows can
+also be exported to SageMaker AI notebooks for further
+customization and integration into production pipelines.
+- **Use enhanced Canvas
+capabilities**. Use SageMaker AI Canvas's improved
+natural language support and Q integration for
+conversational data analysis, enabling business users to
+perform complex data preparation tasks without technical
+expertise.
+- **Integrate with the broader machine
+learning workflow**. Connect your prepared data
+directly to SageMaker AI's model building capabilities like
+SageMaker AI Autopilot for automated model development or
+custom model training. This integration creates a seamless
+path from data to deployed models.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Get
+Started with Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-getting-started.html)
+- [Prepare
+ML Data with Amazon SageMaker AI Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler.html)
+- [What
+is Amazon Q Developer?](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/what-is.html)
+- [What
+is AWS Glue DataBrew?](https://docs.aws.amazon.com/databrew/latest/dg/what-is.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Accelerate
+data preparation with data quality and insights in Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/blogs/machine-learning/accelerate-data-preparation-with-data-quality-and-insights-in-amazon-sagemaker-data-wrangler/)
+- [Process
+larger and wider datasets with Amazon SageMaker AI Data
+Wrangler](https://aws.amazon.com/blogs/machine-learning/process-larger-and-wider-datasets-with-amazon-sagemaker-data-wrangler/)
+- [Fuel
+Your Data with Generative AI](https://aws.amazon.com/blogs/enterprise-strategy/fuel-your-data-with-generative-ai/)
+
+**Related examples:**
+
+- [Prepare
+ML Data with Amazon SageMaker AI Data Wrangler](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/data-wrangler.md)
+- [SageMaker AI
+Data Wrangler Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-datawrangler)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp02.html*
+
+---
+
+# MLCOST03-BP03 Use managed data processing capabilities
+
+With managed data processing, you can use a simplified, managed
+experience to run your data processing workloads, such as feature
+engineering, data validation, model evaluation, and model
+interpretation.
+
+**Desired outcome:** By implementing
+managed data processing capabilities, you can streamline your
+machine learning workflow with fully managed infrastructure for data
+preprocessing and postprocessing tasks. You gain the ability to run
+processing jobs that integrate with popular frameworks while
+maintaining operational efficiency, allowing your team to focus on
+creating valuable ML models rather than managing infrastructure.
+
+**Common anti-patterns:**
+
+- Building and maintaining custom data processing infrastructure.
+- Managing your own compute clusters for data processing tasks.
+- Manually handling scaling, deployment, and cleanup of processing
+resources.
+- Using inconsistent processing environments across development
+and production.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced operational overhead with fully managed infrastructure.
+- Simplified integration with popular ML frameworks and AWS
+services.
+- Enhanced productivity by focusing on ML development rather than
+infrastructure management.
+- Seamless integration with other SageMaker AI capabilities.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Amazon SageMaker AI Processing provides a managed solution for
+running these data processing workloads. Instead of provisioning
+and managing your own infrastructure, SageMaker AI handles the
+provisioning, scaling, and cleanup of resources. Processing jobs
+accept data from Amazon S3 as input and store processed results
+back to S3 as output. You can use AWS-provided container images
+that come pre-configured with popular data science frameworks, or
+you can bring your own custom containers for specialized
+processing needs.
+
+By using SageMaker AI Processing, you can integrate data processing
+steps seamlessly into your ML pipelines and create consistency
+between development and production environments while reducing
+operational overhead. This allows your data scientists and ML
+engineers to focus on extracting insights from data rather than
+managing infrastructure.
+
+### Implementation steps
+
+- **Set up your processing job
+environment**. Create an Amazon SageMaker AI notebook
+instance or Studio environment from which you'll configure
+and launch your processing jobs. This provides an
+interactive environment for development and testing of your
+data processing scripts before scaling to larger datasets.
+- **Select or create a processing
+container**. Choose from SageMaker AI's built-in
+processing containers for frameworks like scikit-learn,
+PyTorch, TensorFlow, or Apache Spark. Alternatively, create
+a custom Docker container if you have specialized framework
+requirements. The container will include the runtime
+environment and dependencies needed for your processing
+tasks.
+- **Prepare your processing
+script**. Develop a script that runs within the
+processing container to perform your data transformation,
+feature engineering, model evaluation, or other processing
+tasks. This script should read input data, process it
+according to your requirements, and write output to the
+designated locations.
+- **Configure storage
+locations**. Set up Amazon S3 buckets to store your
+input data, processing scripts, and output results.
+SageMaker AI Processing jobs use S3 as the primary storage
+mechanism for exchanging data between steps in your ML
+workflow.
+- **Launch a processing job**.
+Use the SageMaker AI Python SDK or AWS console to configure and
+start your processing job. Specify parameters such as
+instance type, instance count, environment variables, and
+input and output configurations. SageMaker AI will provision
+the requested resources, run your processing script, and
+then automatically clean up the resources when the job
+completes.
+- **Monitor job progress and analyze
+results**. Track your processing job through the
+SageMaker AI console or API. Review logs to debug issues. Once
+completed, access the processed data in the specified S3
+output locations for use in subsequent ML workflow steps.
+- **Integrate with ML
+pipelines**. Incorporate your processing jobs into
+[SageMaker AI
+Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to create automated end-to-end ML
+workflows. This enables you to orchestrate data
+preprocessing, model training, evaluation, and deployment
+steps in a repeatable manner.
+- **Optimize resource utilization and
+costs**. Review processing job metrics to identify
+opportunities for optimizing instance selection and
+parallelization strategies. Consider using Spot instances
+for cost savings on non-time-sensitive processing jobs.
+- **Use enhanced processing
+capabilities**. Use SageMaker AI Processing with
+better integration to popular ML frameworks and enhanced
+monitoring capabilities for more efficient data processing
+workflows.
+- **Use AI-powered code generation for
+data processing**. Use AI-powered development tools
+like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+data processing scripts, automate pipeline creation, and
+accelerate the development of custom data transformation
+workflows.
+- **Implement data validation and
+quality checks**. Incorporate data validation steps
+in your processing jobs to check data quality before model
+training. Use SageMaker AI Clarify within processing jobs to
+detect bias in your datasets and implement model
+explainability.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [CreateProcessingJob](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateProcessingJob.html)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Processing jobs](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_processing/scikit_learn_data_processing_and_model_evaluation/scikit_learn_data_processing_and_model_evaluation.html)
+- [SageMaker AI
+Processing with Spark](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_processing/spark_distributed_data_processing)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp03.html*
+
+---
+
+# MLCOST03-BP04 Enable feature reusability
+
+Reduce duplication and the rerunning of feature engineering code
+across teams and projects by using feature storage. The store should
+have online and offline storage, and data encryption capabilities.
+An online store with low-latency retrieval capabilities is ideal for
+real-time inference. An offline store maintains a history of feature
+values and is suited for training and batch scoring.
+
+**Desired outcome:** You gain a
+centralized repository for storing, sharing, and managing machine
+learning features that reduces redundant work across teams and
+projects. You access features with low latency for real-time
+applications while maintaining a historical record for training
+purposes. Your feature store integrates seamlessly with your ML
+workflows, enhancing collaboration and accelerating model
+development while maintaining data security through robust
+encryption.
+
+**Common anti-patterns:**
+
+- Recreating the same features repeatedly across different teams
+and projects.
+- Storing features in isolated data silos that avoid reuse.
+- Lacking version control for features, leading to inconsistencies
+between training and inference.
+- Using separate systems for real-time and batch feature access.
+- Implementing homegrown feature storage solutions that lack
+scalability and proper governance.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces redundant work and computational costs.
+- Creates consistency between training and inference environments.
+- Enables collaboration and knowledge sharing across teams.
+- Provides feature governance, lineage, and traceability.
+- Reduces time to production for ML models.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Feature engineering is often one of the most time-consuming
+aspects of machine learning development. When teams work in silos,
+they frequently recreate the same features, wasting valuable time
+and resources. By implementing a centralized feature store, you
+create a single source of truth for ML features that promotes
+reusability across your organization.
+
+A well-designed feature store addresses the dual requirements of
+offline storage for training and batch inference and online
+storage for low-latency real-time inference. This dual-storage
+paradigm creates consistency between training and serving
+environments while optimizing for different access patterns. The
+feature store should also provide capabilities for feature
+versioning, access control, and monitoring to maintain data
+quality and governance.
+
+Amazon SageMaker AI Feature Store offers these capabilities as a
+fully managed service, which reduces the need to build and
+maintain complex infrastructure. It seamlessly integrates with
+your ML pipelines and supports both batch and real-time inference
+workflows, making it an ideal solution for feature reusability.
+
+### Implementation steps
+
+- **Identify common features across
+projects**. Begin by analyzing your existing ML
+workflows to identify frequently used features that would
+benefit from centralization. Look for redundancies in
+feature engineering code across different teams and
+prioritize these for migration to the feature store.
+- **Set up Amazon SageMaker AI Feature
+Store**. Create feature groups in
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to organize related
+features. Define the schema for each feature group,
+including feature names, data types, and primary keys.
+Consider the access patterns for both training and inference
+when designing your feature groups.
+- **Configure storage options based on
+requirements**. Determine whether each feature
+group needs online storage, offline storage, or both.
+Configure the appropriate storage options:
+
+**Online store:** Set up
+for low-latency access (milliseconds) needed for
+real-time inference
+- **Offline store:**
+Configure Amazon S3 storage for training and batch
+inference workloads
+- **Online and offline:**
+Implement both for maximum flexibility
+
+- **Implement data ingestion
+pipelines**. Develop automated pipelines to ingest
+data into your feature store. You can use
+[Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/) for data preparation and
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) for orchestration.
+- **Establish feature access
+patterns**. Create standardized methods for
+retrieving features for both training and inference. For
+training, use the offline store with Amazon Athena queries
+to efficiently access historical data. For real-time
+inference, implement API calls to the online store for
+low-latency feature retrieval.
+- **Enable cross-account and cross-team
+sharing**. Configure resource policies to enable
+feature sharing across different teams and AWS accounts.
+This promotes collaboration and maximizes feature reuse
+across your organization while maintaining appropriate
+access controls.
+- **Implement feature versioning and
+lineage tracking**. Track changes to features over
+time using versioning capabilities. Link features to models
+through
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to maintain full lineage
+tracking from data source to deployed model.
+- **Monitor feature usage and
+drift**. Implement monitoring for your feature
+store to detect data drift and track feature usage patterns.
+Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect changes in feature
+distributions that might impact model performance.
+- **Create documentation and discovery
+mechanisms**. Document features and their intended
+use cases to facilitate discovery and reuse. Implement
+tagging and search capabilities so that data scientists can
+find relevant features for their projects.
+- **Use enhanced Feature Store
+capabilities**. Use improved SageMaker AI Feature
+Store with better performance, enhanced monitoring
+capabilities, and improved integration with other SageMaker AI
+services for more efficient feature management.
+- **Use generative AI for feature
+discovery and documentation**. Use large language
+models through
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to automatically generate feature
+descriptions, identify potential feature relationships, and
+improve feature discoverability through natural language
+search capabilities.
+
+## Resources
+
+**Related documents:**
+
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Amazon SageMaker AI Feature Store resources](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-notebooks.html)
+- [Understanding
+the key capabilities of Amazon SageMaker AI Feature
+Store](https://aws.amazon.com/blogs/machine-learning/understanding-the-key-capabilities-of-amazon-sagemaker-feature-store/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Feature Store Notebook Examples](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-notebooks.html)
+
+**Related videos:**
+
+- [Training
+and Tuning State-of-the-Art Models with Amazon SageMaker AI](https://aws.amazon.com/awstv/watch/90cac7f03b4/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp04.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLCOST04.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLCOST04.md
@@ -1,0 +1,2150 @@
+# MLCOST04
+
+**Pillar**: Unknown  
+**Best Practices**: 14
+
+---
+
+# MLCOST04-BP01 Select optimal computing instance size
+
+Right size your machine learning training instances according to the
+algorithm and workload requirements to maximize efficiency and
+reduce costs. By selecting the most appropriate computing resources,
+you can improve performance while minimizing unnecessary expenses.
+
+**Desired outcome:** You can identify
+and select the optimal computing instance types for your machine
+learning workloads based on actual resource utilization metrics. You
+can systematically evaluate different instance options, understand
+their cost implications, and optimize your machine learning
+infrastructure spending while maintaining or improving performance.
+
+**Common anti-patterns:**
+
+- Using oversized instances for training jobs regardless of model
+complexity.
+- Ignoring resource utilization metrics during training.
+- Failing to experiment with different instance types to find the
+optimal cost-performance balance.
+- Not considering the communication overhead in distributed
+training scenarios.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced infrastructure costs for machine learning workloads.
+- Improved resource utilization and efficiency.
+- Better understanding of ML workload performance characteristics.
+- Optimization of price-performance ratio for different model
+types.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning training workloads vary significantly in their
+resource requirements based on model complexity, dataset size, and
+algorithm characteristics. Simple models might not train faster on
+larger instances because they cannot effectively utilize
+additional compute resources, and might even train slower due to
+high GPU communication overhead. By evaluating your workload's
+resource needs, you can identify the most cost-effective instance
+configuration.
+
+The key to optimizing instance selection is understanding the
+actual resource utilization patterns of your machine learning
+workloads. Start with smaller instances and scale up only when
+necessary based on performance data. Amazon SageMaker AI provides
+tools like Debugger to monitor resource utilization and
+Experiments to compare training performance across different
+instance configurations. This data-driven approach assists you to
+avoid paying for unused resources while maintaining optimal
+training performance.
+
+### Implementation steps
+
+- **Understand your algorithm's resource
+requirements**. Begin by analyzing whether your
+machine learning algorithm is compute-bound, memory-bound,
+or I/O-bound. Different algorithms have different scaling
+characteristics and resource needs. For deep learning
+workloads, consider whether GPU acceleration would provide
+significant benefits or if CPU instances would be more
+cost-effective for your specific model.
+- **Use Amazon SageMaker AI
+Experiments**.
+[Amazon EC2](https://aws.amazon.com/ec2/instance-types/) provides a wide selection of instance types
+optimized to fit different use cases. Machine learning
+workloads can use either a CPU or a GPU instance. Select an
+instance type from
+[the
+available EC2 instance types](https://aws.amazon.com/ec2/instance-types/) depending on the needs
+of your ML algorithm. Experiment with both CPU and GPU
+instances to learn which one gives you the best cost
+configuration. Amazon SageMaker AI lets you use a single
+instance or a distributed cluster of GPU instances. Use
+[Amazon SageMaker AI Experiments](https://aws.amazon.com/sagemaker/ai/experiments/) to evaluate alternative
+options, and identify the size resulting in optimal outcome.
+With the pricing broken down by time and resources, you can
+optimize the cost of Amazon SageMaker AI and only pay for
+what is needed.
+- **Use Amazon SageMaker AI
+Debugger**.
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) automatically monitors the
+utilization of system resources, such as GPUs, CPUs,
+network, and memory, and profiles your training jobs to
+collect detailed ML framework metrics. You can inspect
+resource metrics visually through SageMaker AI Studio and
+take corrective actions if the resource is under-utilized to
+optimize cost.
+- **Start small and scale
+gradually**. Begin with smaller instance sizes for
+new models and monitor performance. Only increase instance
+size when you have data showing that your workload can
+benefit from additional resources. This approach assists you
+to avoid overprovisioning and unnecessary costs.
+- **Consider the communication
+overhead**. For distributed training across
+multiple GPUs or instances, evaluate the communication
+overhead between nodes. In some cases, adding more compute
+resources might actually slow down training due to increased
+coordination requirements.
+- **Monitor and analyze training
+metrics**. Track key metrics like CPU/GPU
+utilization, memory usage, I/O patterns, and training
+throughput across different instance types to identify
+bottlenecks and optimization opportunities.
+- **Use Spot Instances for cost
+savings**. For non-critical training jobs, consider
+using
+[Amazon EC2 Spot Instances](https://aws.amazon.com/ec2/spot/) through SageMaker AI to reduce costs
+by up to 90%. Configure your training jobs to checkpoint
+regularly to minimize the impact of potential interruptions.
+- **Use SageMaker AI Inference Recommender
+for optimal instance selection**. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) with enhanced algorithms and
+support for multi-model endpoints to get sophisticated cost
+optimization recommendations for your specific workloads.
+- **For generative AI workloads, use
+foundation model optimization techniques**. For
+generative AI workloads, consider techniques like
+quantization, distillation, and efficient fine-tuning
+methods to reduce the computational resources needed while
+maintaining model quality.
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) provides optimized foundation
+models that can significantly reduce training time and
+resource requirements.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html)
+- [Accelerate
+generative AI development with Amazon SageMaker AI and
+MLflow](https://aws.amazon.com/sagemaker/ai/experiments/)
+- [Amazon EC2 instance types](https://aws.amazon.com/ec2/instance-types/)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Amazon SageMaker AI Training Compiler](https://docs.aws.amazon.com/sagemaker/latest/dg/training-compiler.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp01.html*
+
+---
+
+# MLCOST04-BP02 Use managed build environments
+
+Using managed build environments for machine learning development
+instead of local setups provides significant cost, time, and
+resource advantages. Managed notebooks come pre-configured with
+security, networking, storage, and compute capabilities that would
+otherwise require extensive development and maintenance effort.
+These environments also offer flexible machine selection, including
+access to powerful GPUs and high-memory instances that may be
+impractical in local setups.
+
+**Desired outcome:** You can quickly
+start machine learning development work without spending time
+setting up infrastructure, managing dependencies, or configuring
+development environments. You gain access to scalable compute
+resources, including specialized hardware like GPUs, and benefit
+from built-in security and collaboration features, allowing you to
+focus on building ML models rather than managing infrastructure.
+
+**Common anti-patterns:**
+
+- Spending excessive time configuring local development
+environments for each project.
+- Encountering hardware limitations when training complex models
+locally.
+- Struggling with inconsistent development environments across
+team members.
+- Managing security and networking configurations manually.
+- Inability to scale resources up or down based on workload
+requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time to start development with pre-configured
+environments.
+- Access to powerful compute resources on demand.
+- Consistent development environments for team members.
+- Built-in security, networking, and storage capabilities.
+- Simplified collaboration and sharing of notebooks and models.
+- Cost optimization through pay-for-what-you-use model.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When implementing machine learning projects, your development
+environment plays a critical role in productivity and efficiency.
+Local development environments often lead to inconsistencies
+between team members, dependency conflicts, and hardware
+limitations. Managed build environments address these challenges
+by providing standardized, scalable, and secure solutions for ML
+development.
+
+Amazon SageMaker AI offers several managed environment options
+tailored to different user needs and expertise levels. These
+include SageMaker AI Notebook Instances for individual developers,
+SageMaker AI Studio for comprehensive ML development, and SageMaker AI
+Canvas for no-code ML solutions. These environments come
+pre-configured with the necessary tools and libraries, saving
+setup time and fostering consistency.
+
+These managed environments integrate seamlessly with other AWS
+services, making it simple to access data stored in Amazon S3, use
+specialized hardware like GPUs, and deploy models to production
+endpoints. They also provide built-in security features, version
+control, and collaboration capabilities that would be difficult to
+implement in a local setup.
+
+### Implementation steps
+
+- **Evaluate your ML development
+needs**. Begin by assessing your team's
+requirements, including technical expertise, project
+complexity, and compute resource needs. Identify which
+SageMaker AI offering best matches these requirements.
+- **Use Amazon SageMaker AI Notebook
+Instances**. Set up SageMaker AI Notebook Instances
+which provide a fully managed Jupyter notebook environment.
+These instances come pre-loaded with popular ML frameworks
+and libraries, allowing you to start working immediately.
+- **Implement Amazon SageMaker AI
+Studio**. Deploy SageMaker AI Studio as your
+comprehensive ML development environment. SageMaker AI Studio
+provides a web-based visual interface where your team can
+perform ML development steps from data preparation to model
+deployment. Access Studio by creating a SageMaker AI domain
+through the SageMaker AI console, which enables team management
+and resource sharing capabilities.
+- **Deploy SageMaker AI Canvas for business
+users**. Implement SageMaker AI Canvas for business
+analysts and non-technical team members who need to create
+ML models without coding. Canvas provides an intuitive
+visual interface for importing data, creating models, and
+generating predictions.
+- **Set up proper IAM roles and
+permissions**. Configure appropriate IAM roles for
+your SageMaker AI environments to provide secure access to AWS
+resources. Create specific roles that follow the principle
+of least privilege, granting only the permissions necessary
+for your ML workflows.
+- **Configure data access and
+storage**. Set up connections between your
+SageMaker AI environments and data sources such as Amazon S3,
+Amazon Redshift, or Amazon RDS. Configure appropriate
+permissions to access these data sources securely.
+- **Implement version control and
+collaboration**. Integrate your managed
+environments with version control systems like Git to track
+changes to notebooks and code. Use SageMaker AI Studio's
+built-in collaboration features to share work among team
+members.
+- **Optimize for cost
+efficiency**. Configure auto-shutdown policies for
+notebook instances when they're idle to reduce costs.
+Monitor resource usage and adjust instance types as needed
+to balance performance and cost.
+- **Use SageMaker AI HyperPod for
+large-scale training**. For distributed training of
+large models, use
+[SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) which provides purpose-built infrastructure
+with automatic checkpoint storage and recovery, optimizing
+resource utilization for long-running training jobs.
+- **Enable SageMaker AI JupyterLab 3
+features**. Take advantage of the productivity
+improvements in JupyterLab 3, which is available in both
+SageMaker AI Studio and Notebook Instances, providing better
+performance and enhanced features for developers.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio.html)
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Amazon SageMaker AI Pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [Amazon SageMaker AI notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp02.html*
+
+---
+
+# MLCOST04-BP03 Select local training for small scale experiments
+
+When developing machine learning models, choosing the right training
+environment is crucial for both cost efficiency and rapid
+experimentation. By evaluating whether to train your ML model
+locally or in the cloud, you can optimize your development workflow
+and appropriately match resources to the scale of your experiment.
+
+**Desired outcome:** You can rapidly
+iterate on machine learning experiments with small datasets by
+training models locally, while having a clear path to scale up to
+cloud-based training when working with larger datasets. This
+approach enables faster development cycles during the
+experimentation phase and cost-effective scaling when required for
+production workloads.
+
+**Common anti-patterns:**
+
+- Deploying cloud-based training clusters regardless of dataset
+size.
+- Using oversized compute instances for small-scale
+experimentation.
+- Not considering the time and cost implications of repeatedly
+launching training clusters during the experimentation phase.
+- Failing to right-size compute resources based on specific
+workload requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced development costs during experimentation phases.
+- Faster iteration cycles when testing various algorithms and
+configurations.
+- Simplified workflow for early-stage development.
+- Clear scaling path from local experimentation to production
+deployment.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When developing machine learning models, you often need to
+experiment with multiple algorithms, configurations, and
+hyperparameters before finding an optimal solution. The choice
+between local training and cloud-based training significantly
+impacts both development speed and cost efficiency.
+
+Local training is most advantageous during early experimentation
+phases when working with small datasets. This approach reduces the
+overhead of provisioning cloud resources and waiting for training
+clusters to spin up for each experiment iteration. Your
+development cycle becomes more agile as you can quickly test
+hypotheses and make adjustments without incurring additional cloud
+costs.
+
+As your models and datasets grow in size and complexity,
+transitioning to cloud-based training becomes necessary. Cloud
+environments offer scalable computing resources that can handle
+large datasets and complex models that would be impractical to
+process on local machines. By right-sizing your compute instances
+based on your specific workload requirements, you can maintain
+cost efficiency while gaining the performance benefits of cloud
+infrastructure.
+
+### Implementation steps
+
+- **Evaluate your training
+requirements**. Before deciding on local or
+cloud-based training, assess your dataset size, model
+complexity, and computational requirements. Small datasets
+(typically under a few gigabytes) and simpler models are
+generally good candidates for local training, especially
+during initial experimentation.
+- **Set up Amazon SageMaker AI local
+mode**. When experimenting with small datasets, use
+Amazon SageMaker AI's local mode to train models directly on
+your notebook instance. This approach allows you to test and
+iterate on your code without provisioning separate training
+clusters. To implement local mode:
+
+```
+`from sagemaker.estimator import Estimator
+
+estimator = Estimator(
+image_uri="your-container-image",
+role="your-sagemaker-role",
+instance_count=1,
+instance_type="local"
+)
+
+estimator.fit({"train": "s3://your-bucket/train-data"})`
+```
+- **Use local development environment
+with SageMaker AI SDK**. For development outside of
+SageMaker AI notebooks, install the SageMaker AI Python SDK on
+your local machine. This allows you to develop and test
+locally while still having the ability to deploy models to
+AWS:
+
+```
+`pip install sagemaker`
+```
+- **Profile your workloads for cloud
+deployment**. As your models mature and datasets
+grow, prepare for cloud deployment by profiling your
+workloads. Identify memory usage, CPU and GPU requirements,
+and processing time to determine appropriate instance types
+for cloud-based training.
+- **Right-size cloud-based training
+clusters**. When moving to cloud training, select
+appropriate instance types based on your workload profiling.
+Consider factors such as:
+
+Model architecture (CPU and GPU requirements)
+- Memory needs
+- Dataset size and I/O patterns
+- Training time constraints
+- Cost constraints
+
+- **Implement distributed training for
+large-scale workloads**. For large datasets or
+complex models, configure distributed training across
+multiple instances to reduce training time.
+- **Monitor and optimize cloud resource
+usage**. Regularly review your training job metrics
+to identify opportunities for optimization. Use SageMaker AI
+Experiments to track and compare resource utilization across
+different training configurations.
+- **Use enhanced local development
+capabilities**. Use improved SageMaker AI local mode
+with better debugging and monitoring capabilities, allowing
+for more efficient local experimentation before scaling to
+cloud resources.
+- **For generative AI workloads, use
+foundation models efficiently**. When working with
+generative AI and foundation models, consider using Amazon SageMaker AI JumpStart for local experimentation with smaller,
+distilled versions of foundation models before fine-tuning
+larger models in the cloud. This approach allows for rapid
+prototyping while managing costs effectively.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+training](https://docs.aws.amazon.com/sagemaker/latest/dg/train-model.html)
+- [AWS Pricing Calculator](https://calculator.aws/#/createCalculator/SageMaker AI)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [SageMaker AI
+Python SDK Documentation](https://sagemaker.readthedocs.io/en/stable/)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Generative
+AI Cost Optimization Strategies](https://aws.amazon.com/blogs/enterprise-strategy/generative-ai-cost-optimization-strategies/)
+
+**Related videos:**
+
+- [Train
+with Amazon SageMaker AI on your local machine](https://www.youtube.com/watch?v=K3ngZKF31mc)
+
+**Related examples:**
+
+- [SageMaker AI
+Local Mode Examples](https://github.com/aws-samples/amazon-sagemaker-local-mode)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp03.html*
+
+---
+
+# MLCOST04-BP04 Select an optimal ML framework
+
+Selecting the most cost-effective machine learning (ML) framework
+for your requirements can significantly impact your operational
+efficiency and return on investment. By systematically comparing
+frameworks like TensorFlow, PyTorch, and Scikit-learn, you can
+determine which delivers the best performance for your specific use
+cases at the optimal cost.
+
+**Desired outcome:** You establish a
+systematic approach for evaluating ML frameworks and instance types,
+and you can select the optimal combination based on performance,
+cost, and use case requirements. You can track, compare, and analyze
+experiments across different frameworks, leading to informed
+decisions that maximize performance while minimizing costs.
+
+**Common anti-patterns:**
+
+- Selecting ML frameworks based on popularity rather than
+suitability for your specific use case.
+- Using a single framework for ML projects regardless of workload
+characteristics.
+- Not tracking experiment metrics systematically across different
+frameworks.
+- Failing to benchmark performance and cost metrics before moving
+to production.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced operational costs through optimized infrastructure
+selection.
+- Improved model performance by selecting the most suitable
+framework.
+- Enhanced productivity by streamlining experiment tracking and
+comparison.
+- Faster iteration and deployment of ML models.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Selecting the optimal ML framework involves evaluating different
+options against your specific requirements and constraints.
+Consider factors such as model complexity, data volume,
+performance requirements, and team expertise when choosing between
+frameworks. Tracking experiments systematically assists you to
+compare approaches objectively and make data-driven decisions.
+
+When implementing this best practice, use AWS' comprehensive ML
+infrastructure, which supports major frameworks and provides tools
+for experiment tracking and resource optimization. Regular
+performance benchmarking and cost analysis should become standard
+procedures in your ML development process.
+
+### Implementation steps
+
+- **Implement systematic experiment
+tracking with SageMaker AI Experiments**. Amazon SageMaker AI Experiments enables you to organize, track,
+compare, and evaluate your machine learning experiments.
+Create experiments to group related trials, assign
+parameters, metrics, and artifacts to each trial, and track
+the lineage of model artifacts to experiments for governance
+and reproducibility.
+- **Compare multiple ML
+frameworks**. Evaluate frameworks like TensorFlow,
+PyTorch, Apache MXNet, and Scikit-learn for your specific
+use cases. Use
+[AWS Deep Learning AMIss](https://aws.amazon.com/machine-learning/amis/) and
+[AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) to experiment with different
+frameworks using consistent infrastructure. These AMIs come
+with popular frameworks preinstalled, making it simple to
+switch between them for comparison.
+- **Benchmark framework
+performance**. Design standardized benchmarking
+tests for your specific workloads across different
+frameworks. Track metrics such as training time, inference
+latency, memory usage, and accuracy to determine which
+framework performs best for your use case.
+- **Implement right-sizing strategies
+for ML instances**. Use SageMaker AI's managed
+instances to automatically select the most appropriate and
+cost-effective instance type for your workloads. Experiment
+with different instance types to find the optimal balance
+between performance and cost.
+- **Use SageMaker AI's
+bring-your-own-container capability**. If you need
+to use specialized ML frameworks or versions not available
+in standard containers, use SageMaker AI's flexibility to bring
+your own containers so that you can use a framework while
+maintaining the benefits of SageMaker AI's managed
+infrastructure.
+- **Implement automatic resource
+scaling**. Configure automatic scaling for
+inference endpoints based on traffic patterns to optimize
+costs during varying load conditions. Use SageMaker AI
+Inference Recommender to identify the best configuration for
+deployment.
+- **Use enhanced experiment tracking
+with MLflow**. Use
+[managed
+MLflow on SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to create, manage, analyze, and
+compare your machine learning experiments across different
+frameworks with better organization and tracking
+capabilities.
+- **Monitor and optimize costs
+continuously**. Implement cost monitoring using AWS Cost Explorer and SageMaker AI's built-in monitoring
+capabilities. Set up alerts for unusual spending patterns
+and regularly review resource utilization to identify
+optimization opportunities.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Deep Learning AMIss](https://aws.amazon.com/machine-learning/amis/)
+- [Machine
+Learning Frameworks and Languages](https://docs.aws.amazon.com/sagemaker/latest/dg/frameworks.html)
+- [Accelerate
+generative AI development with Amazon SageMaker AI and
+MLflow](https://aws.amazon.com/sagemaker/ai/experiments/)
+- [Amazon SageMaker AI Studio Classic](https://docs.aws.amazon.com/sagemaker/latest/dg/studio.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp04.html*
+
+---
+
+# MLCOST04-BP05 Use automated machine learning
+
+Automate your model development process by using systems that
+experiment with and select the best algorithms from high-performing
+options. These automated systems test various solutions and
+parameter settings to achieve optimal models, significantly speeding
+up development while reducing the need for manual experimentation
+and comparisons.
+
+**Desired outcome:** You gain the
+ability to develop high-quality machine learning models in a
+fraction of the time traditionally required. By using automated
+machine learning tools like Amazon SageMaker AI Autopilot, you can
+focus on business problems rather than algorithm selection and
+parameter tuning. Your team can produce optimized models with better
+performance, reduce development costs, and accelerate time-to-market
+for ML-powered solutions.
+
+**Common anti-patterns:**
+
+- Manually testing multiple algorithms and configurations one by
+one.
+- Spending excessive time on hyperparameter tuning without
+systematic approach.
+- Using the same algorithm for each problem without considering
+alternatives.
+- Neglecting cross-validation during model selection.
+
+**Benefits of establishing this best
+practice:**
+
+- Dramatically reduced time to develop production-ready models.
+- Access to a broader range of algorithms and optimization
+techniques.
+- Improved model performance through systematic evaluation.
+- Lower costs through optimized resource utilization.
+- Ability for domain experts to build models without deep ML
+expertise.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Automated machine learning (AutoML) systems democratize the
+process of building machine learning models. By automating key
+steps in model development—from data preparation to algorithm
+selection and hyperparameter tuning—these systems enable even
+those without extensive machine learning expertise to develop
+high-quality models.
+
+When using AutoML solutions like Amazon SageMaker AI Autopilot,
+you provide your dataset and define your objective, and the system
+handles the complex work of exploring potential algorithms,
+optimizing parameters, and evaluating model performance. The
+system applies cross-validation procedures automatically to check
+that models can generalize well to new data. By ranking optimized
+models by their performance, AutoML can identify the best solution
+for your specific problem.
+
+Beyond simply producing models, modern AutoML systems provide
+visibility into the development process, allowing you to
+understand what choices were made and why. This transparency
+builds trust in the models and provides learning opportunities for
+your team to understand what approaches work best for different
+problem types.
+
+### Implementation steps
+
+- **Evaluate your use case
+compatibility**. Determine if your ML problem is
+suitable for automated machine learning solutions. AutoML
+works particularly well for standard machine learning tasks
+like classification, regression, and some time series
+forecasting scenarios.
+- **Prepare your data for
+AutoML**. Clean your dataset, handle missing
+values, and convert categorical features appropriately.
+While AutoML handles feature engineering, providing
+high-quality data improves results. Use
+[Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/) to simplify this preparation
+process.
+- **Set up Amazon SageMaker AI Autopilot
+with Canvas**. Open
+[Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html), import your dataset into Amazon S3,
+and configure to access this data. Define your target
+variable and specify your problem type (classification or
+regression) if known.
+- **Launch the automated ML
+job**. Start Canvas training and let it analyze
+your data, select algorithms, and optimize models. Specify
+resources like maximum runtime and instance types to control
+costs. Canvas will automatically handle data preprocessing,
+feature engineering, algorithm selection, and hyperparameter
+optimization.
+- **Review candidate models**.
+Examine the generated models along with their performance
+metrics. Autopilot provides detailed reports on the data
+exploration, feature engineering decisions, and model
+optimization steps it performed.
+- **Deploy the best model**.
+Select the best-performing model from the Canvas
+recommendations and deploy it using Amazon SageMaker AI's
+deployment capabilities. You can deploy as a real-time
+endpoint or for batch inference depending on your needs.
+- **Monitor and evaluate
+performance**. Set up model monitoring to track
+your model's performance in production and detect concept
+drift. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automate this process.
+- **Customize and refine
+models**. If needed, extract and customize the
+models generated by Autopilot. The solution provides full
+visibility into the notebooks and artifacts it creates,
+allowing you to further refine specific aspects of the
+model.
+- **Enhance model development with
+foundation models**. Use
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to incorporate foundation model capabilities
+into your AutoML workflow for tasks like text processing,
+content generation, and multimodal applications. Foundation
+models can complement traditional ML approaches handled by
+Autopilot.
+- **Use enhanced Canvas capabilities
+with Q integration**. Use
+[SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html) with improved natural language support and Q
+integration for conversational data analysis, enabling
+business users to build models through natural language
+interactions.
+- **Implement intelligent preprocessing
+with generative AI**. Use generative AI tools to
+enhance data preprocessing, augment training datasets,
+generate synthetic data for edge cases, and improve feature
+engineering through intelligent text and image processing.
+
+## Resources
+
+**Related documents:**
+
+- [Getting
+started with using Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-getting-started.html)
+- [SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/)
+
+**Related examples:**
+
+- [SageMaker AI Autopilot](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/automl/README.rst)
+- [Amazon SageMaker AI Autopilot Sample Notebooks](https://github.com/aws/amazon-sagemaker-examples/tree/main/autopilot)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp05.html*
+
+---
+
+# MLCOST04-BP06 Use managed training capabilities
+
+Machine learning model training can be an iterative,
+compute-intensive, and time-consuming process. Instead of using the
+notebook itself, which might be running on a small instance,
+offloading the training to a managed cluster of compute resources
+including both CPUs and GPUs enables more efficient and
+cost-effective model training.
+
+**Desired outcome:** By using managed
+training capabilities, you optimize your machine learning training
+workflows and infrastructure management. You gain access to scalable
+computing resources that automatically adjust based on your workload
+needs, from single GPUs to thousands, without managing the
+underlying infrastructure. You can significantly reduce training
+costs through specialized hardware options, compiler optimizations,
+and spot instance utilization while maintaining visibility into
+metrics and logs for proper monitoring and governance.
+
+**Common anti-patterns:**
+
+- Running complex model training jobs on notebook instances,
+leading to resource constraints and inefficiency.
+- Managing your own GPU clusters for training, requiring
+significant operational overhead.
+- Using exclusively on-demand instances for training jobs,
+resulting in higher costs.
+- Not using specialized training optimizations like distributed
+training or compiler acceleration.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower training costs by up to 90% using managed spot instances.
+- Accelerate training time by up to 50% with training compiler
+optimizations.
+- Scale resources automatically based on training job
+requirements.
+- Track and monitor training experiments and resource utilization
+effectively.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning training is computationally intensive and can
+become prohibitively expensive when not optimized properly. Using
+managed training capabilities allows you to focus on model
+development while the infrastructure scales and optimizes
+automatically to your needs. Managed training services provide a
+range of optimization options from distributed training across
+multiple GPUs to cost-saving options through spot instances.
+Additionally, these services integrate with monitoring tools to
+track resource utilization, model metrics, and training progress
+to continually refine your training approach.
+
+For example, when training large language models, you can use
+SageMaker AI's distributed training libraries to split the model
+across multiple GPUs and instances, reducing training time from
+weeks to days while maintaining control over your training costs
+through automatic scaling and spot instance usage.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI managed
+training capabilities**. Amazon SageMaker AI
+reduces the time and cost to train and tune ML models
+without the need to manage infrastructure. With SageMaker AI, you can train and tune ML models using built-in tools to
+manage and track training experiments, automatically choose
+optimal hyperparameters, debug training jobs, and monitor
+the utilization of system resources such as GPUs, CPUs, and
+network bandwidth. SageMaker AI can automatically scale
+infrastructure up or down based on your training job
+requirements, from one GPU to thousands, or from terabytes
+to petabytes of storage. SageMaker AI also offers the
+highest-performing ML compute infrastructure currently
+available-including
+[Amazon EC2 P4d instances](https://aws.amazon.com/ec2/instance-types/p4/), which can reduce ML training costs
+by up to 60% compared with previous generations. And, since
+you pay only for what you use, you can manage your training
+costs more effectively.
+- **Use Spot Instances for cost
+optimization**. Amazon SageMaker AI makes it simple
+to train machine learning models using managed Amazon EC2
+Spot Instances. Managed Spot training can optimize the cost
+of training models up to 90% over On-demand Instances.
+SageMaker AI manages the Spot interruptions on your behalf.
+You can specify which training jobs use Spot Instances and a
+stopping condition that specifies how long SageMaker AI
+waits for a job to run using Spot Instances. Metrics and
+logs generated during training runs are available in Amazon CloudWatch.
+- **Configure optimal data
+sources**. Select the appropriate data source for
+your training job to optimize performance and cost. Consider
+using [Amazon S3](https://aws.amazon.com/s3/) for persistent storage,
+[Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) for high-performance file systems, or
+[Amazon EFS](https://aws.amazon.com/efs/) based on your specific training requirements and
+dataset characteristics.
+- **Implement experiment tracking and
+management**. Use
+[Amazon SageMaker AI Experiments](https://aws.amazon.com/sagemaker/ai/experiments/) to track training jobs, compare
+results, and manage different versions of your models. This
+provides visibility into model performance, resource
+utilization, and training metrics to optimize future
+iterations.
+- **Use SageMaker AI HyperPod for
+large-scale training**. Use
+[SageMaker AI
+HyperPod](https://aws.amazon.com/sagemaker/ai/hyperpod/) to scale and accelerate generative AI model
+development across thousands of AI accelerators with
+purpose-built infrastructure, automatic checkpoint storage
+and recovery, and support for both Slurm and Amazon EKS for
+cluster orchestration.
+- **For generative AI, optimize large
+language model training**. Use
+[SageMaker AI
+Model Parallelism](https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-v2.html) to efficiently distribute model
+parameters across multiple devices and instances. Consider
+using
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for foundation model access and fine-tuning
+capabilities to further reduce the computational cost of
+training generative AI models from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Train
+a Model with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html)
+- [Model
+training](https://docs.aws.amazon.com/sagemaker/latest/dg/train-model.html)
+- [Distributed
+training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training.html)
+- [Accelerate
+generative AI development with Amazon SageMaker AI and
+MLflow](https://aws.amazon.com/sagemaker/ai/experiments/)
+
+**Related examples:**
+
+- [SageMaker AI
+Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples)
+- [SageMaker AI
+Training Workshop](https://github.com/aws-samples/amazon-sagemaker-immersion-day)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp06.html*
+
+---
+
+# MLCOST04-BP07 Use distributed training
+
+Accelerate your machine learning model training process by utilizing
+distributed computing resources, which can significantly reduce
+training time and optimize costs. Amazon SageMaker AI distributed
+training capabilities enable efficient processing of large models
+and datasets across multiple compute instances.
+
+**Desired outcome:** You achieve
+faster training times for your machine learning models by
+distributing the workload across multiple instances. You optimize
+resource utilization and reduce overall training costs by using
+SageMaker AI's managed distributed training capabilities, which
+automatically handle infrastructure provisioning and termination
+when training completes. This approach allows you to train complex
+models that may be too large for a single machine or train standard
+models much faster through parallel processing.
+
+**Common anti-patterns:**
+
+- Training large models on a single instance even when they could
+benefit from distribution.
+- Manually managing distributed training infrastructure rather
+than using managed services.
+- Keeping training instances running after training is complete.
+- Implementing custom distributed training code when built-in
+libraries would suffice.
+
+**Benefits of establishing this best
+practice:**
+
+- Significantly reduced training time for large models and
+datasets.
+- Cost optimization through efficient resource utilization.
+- Ability to train models that are too large to fit on a single
+GPU.
+- Automatic infrastructure management with no need to maintain
+distributed training clusters.
+- Enhanced team productivity by reducing waiting time for model
+results.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Distributed training allows you to split your machine learning
+workloads across multiple compute instances to accelerate the
+training process. This approach is particularly valuable when
+working with large models or datasets that would otherwise take
+too long to train on a single instance. Amazon SageMaker AI provides
+built-in support for distributed training through its specialized
+libraries that handle the complexity of distributing workloads
+efficiently.
+
+When implementing distributed training, you need to consider the
+most appropriate approach based on your model architecture and
+data size. Data parallelism works by dividing your dataset across
+multiple GPUs, with each GPU having a complete copy of the model.
+This approach is ideal for scenarios where your model fits on a
+single GPU but training on the full dataset is time-consuming.
+Alternatively, model parallelism is designed for situations where
+your model is too large to fit on a single GPU. In this case, the
+model itself is partitioned across multiple GPUs.
+
+SageMaker AI's distributed training libraries automatically handle
+the communication between nodes and optimize the distribution
+strategy, making it straightforward to scale your training
+workloads without managing the underlying infrastructure.
+
+### Implementation steps
+
+- **Evaluate your workload for
+distributed training suitability**. Assess if your
+training job would benefit from distribution by considering
+factors like model size, dataset size, and current training
+times. Ideal candidates are models that take hours or days
+to train on a single instance or models too large to fit in
+a single GPU's memory.
+- **Choose the appropriate distributed
+training approach**. Select between data
+parallelism and model parallelism based on your specific
+needs. Use data parallelism when your model fits on a single
+GPU but you want to process data faster. Use model
+parallelism when your model is too large to fit on a single
+GPU.
+- **Utilize Amazon SageMaker AI distributed
+training libraries**. Implement distributed
+training using
+[SageMaker AI's
+distributed training libraries](https://aws.amazon.com/sagemaker/distributed-training/), which automatically
+handle the complexities of distributing workloads across
+multiple instances. These libraries provide optimized
+implementations for both data parallelism and model
+parallelism strategies.
+- **Configure your training
+cluster**. Define the number and type of instances
+for your training cluster in your SageMaker AI training job
+configuration. Consider using GPU-optimized instance types
+like P3, P4d, or G4dn based on your model requirements and
+budget constraints.
+- **Adapt your training script for
+distributed processing**. Modify your training code
+to work with SageMaker AI's distributed training libraries. For
+data parallelism, you'll need to use the SageMaker AI data
+parallelism library to distribute data across workers. For
+model parallelism, you'll integrate the SageMaker AI model
+parallelism library to partition your model across devices.
+- **Monitor and optimize training
+performance**. Use
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) to monitor your distributed
+training jobs, identify bottlenecks, and optimize resource
+utilization. Analyze metrics like GPU utilization,
+communication overhead, and training throughput to fine-tune
+your distributed training configuration.
+- **Consider Amazon SageMaker AI HyperPod
+for persistent training clusters of foundation
+models**. For workloads requiring long-running or
+repeated distributed training jobs, use
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) to create persistent, managed
+clusters that can handle multiple training jobs efficiently
+while maintaining cost optimization through automatic
+scaling and resource management.
+- **Use SageMaker AI HyperPod for
+persistent training clusters**. Use
+[SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) for workloads requiring long-running or
+repeated distributed training jobs, providing persistent,
+managed clusters with automatic scaling, checkpoint storage
+and recovery, and support for various instance types
+including P5e, G6, and Trn2.
+- **Use AI-powered code generation for
+distributed training implementation**. Use
+AI-powered development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+complex distributed training code, automate infrastructure
+setup scripts, and accelerate the implementation of
+distributed training workflows.
+- **Consider Amazon Bedrock for
+fine-tuning foundation models**. For generative AI
+applications, consider using
+[Amazon
+Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/custom-model-fine-tuning.html/) for fine-tuning foundation models, model
+distillation, or continued pretraining, which provides
+optimized distributed training capabilities specifically
+designed for large language models.
+
+## Resources
+
+**Related documents:**
+
+- [Run
+distributed training with the SageMaker AI distributed data
+parallelism library](https://docs.aws.amazon.com/sagemaker/latest/dg/data-parallel.html)
+- [SageMaker AI
+model parallelism library v2](https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-v2.html)
+- [Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+- [Distributed
+Training](https://sagemaker-examples.readthedocs.io/en/latest/training/distributed_training/index.html)
+- [Amazon SageMaker AI XGBoost now offers fully distributed GPU
+training](https://aws.amazon.com/blogs/machine-learning/amazon-sagemaker-xgboost-now-offers-fully-distributed-gpu-training/)
+
+**Related examples:**
+
+- [Distributed
+Training](https://github.com/aws/amazon-sagemaker-examples/blob/master/training/distributed_training/index.rst)
+- [Distributed
+training using Amazon SageMaker AI Distributed Data Parallel
+library and debugging using Amazon SageMaker AI Debugger](https://github.com/aws-samples/amazon-sagemaker-dist-data-parallel-with-debugger)
+- [SageMaker AI
+developer guide on distributed training](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/distributed-training.md#distributed-training-optimize)
+- [Distributed
+Training Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/training/distributed_training)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp07.html*
+
+---
+
+# MLCOST04-BP08 Stop resources when not in use
+
+Stop resources that are not in use to reduce cost. For example,
+hosted Jupyter environments used to explore small samples of data
+can be stopped when not actively in use. Where practical, commit the
+work, stop them, and restart when needed. The same approach can be
+used to stop the computing and the data storage services.
+
+**Desired outcome:** You
+significantly reduce your ML infrastructure costs by only paying for
+resources when they are actively being used. You have automated
+systems in place to monitor and shut down idle resources, along with
+proper alerts to track spending patterns and avoid unexpected
+charges. You maintain the ability to quickly restart resources when
+needed while minimizing wasteful spending on idle compute and
+storage.
+
+**Common anti-patterns:**
+
+- Leaving development environments running regardless of actual
+usage.
+- Neglecting to set up automatic shutdown mechanisms for idle
+resources.
+- Ignoring cost monitoring tools and billing alerts.
+- Using persistent storage for temporary data that could be
+deleted.
+
+**Benefits of establishing this best
+practice:**
+
+- Significant cost savings (up to 75% by running resources only
+during business hours compared to running continually).
+- Better alignment of spending with actual usage patterns.
+- Reduced environmental impact through more efficient resource
+consumption.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Optimizing costs is a crucial aspect of running machine learning
+workloads in the cloud. ML workloads often require significant
+computational resources, but those resources aren't needed
+continuously. By implementing automatic shutdown mechanisms for
+idle resources, you can achieve substantial cost savings while
+maintaining the ability to rapidly resume work when needed.
+
+For ML development environments like SageMaker AI notebooks, the
+cost-optimization opportunity is particularly significant since
+these environments are typically used intermittently during the
+exploration and development phases. By committing code to
+repositories regularly and shutting down environments when not in
+use, you improve both cost efficiency and version control of your
+work.
+
+Additionally, proper monitoring of spending patterns assists you
+in identifying optimization opportunities and avoiding unexpected
+costs. With AWS tools, you can set up alerts, track resource
+utilization, and implement automated responses to idle resources.
+
+### Implementation steps
+
+- **Set up Amazon CloudWatch billing
+alarms**. Use
+[Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html) to monitor your estimated AWS charges.
+When you enable monitoring of estimated charges, these
+calculations are sent several times daily to CloudWatch as
+metric data. Configure alerts to be notified when your
+resource charges exceed predefined thresholds to stay within
+budget and quickly identify unexpected spending patterns.
+- **Configure Amazon SageMaker AI notebook
+lifecycle configurations**. Create
+[lifecycle
+configurations](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html) that include shell scripts to run when
+you create or start notebook instances. These scripts can
+check for notebook instance activity and automatically shut
+down idle instances. This way, you're not paying for compute
+resources when they aren't actively processing workloads.
+- **Implement Amazon SageMaker AI Studio
+idle shutdown**. For
+[Amazon SageMaker AI Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-idle-shutdown.html) environments, install the
+auto-shutdown JupyterLab extension either
+[manually
+or automatically](https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension). This extension detects idle Studio
+resources and can shut down individual components, including
+notebooks, terminals, kernels, applications, and instances
+when they're not being used.
+- **Use AWS Cost Explorer to identify
+optimization opportunities**. Regularly analyze
+your ML infrastructure spending patterns using
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) to identify resources that might be
+consistently underutilized. Look for patterns that indicate
+resources could benefit from scheduled shutdowns during
+off-hours.
+- **Implement instance
+scheduling**. Use the
+[AWS Instance Scheduler](https://aws.amazon.com/solutions/implementations/instance-scheduler/) to create automated schedules for
+starting and stopping resources based on your team's working
+hours. This is particularly useful for development
+environments that are only needed during business hours.
+- **Train teams on cost-aware
+practices**. Educate your ML teams on the
+importance of shutting down resources when not in use and
+committing their work regularly. Create a cost-aware culture
+where resource efficiency is valued alongside development
+productivity.
+- **Implement enhanced auto-shutdown
+capabilities**. Use improved SageMaker AI Studio
+auto-shutdown features with better idle detection and more
+granular control over resource shutdown policies to minimize
+costs from unused resources.
+- **Use Spot Instances for interruptible
+workloads**. For ML training jobs that can handle
+interruptions, use
+[Amazon EC2 Spot Instances](https://aws.amazon.com/ec2/spot/) to achieve significant cost
+savings compared to on-demand pricing. Make sure your
+workloads are designed to checkpoint progress and can resume
+from interruptions.
+
+## Resources
+
+**Related documents:**
+
+- [Idle
+shutdown](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-idle-shutdown.html)
+- [Customization
+of a SageMaker AI notebook instance using an LCC script](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html)
+- [Instance
+Scheduler on AWS](https://aws.amazon.com/solutions/implementations/instance-scheduler/)
+- [Create
+a billing alarm to monitor your estimated AWS charges](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [Amazon SageMaker AI Pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [Cloud
+Financial Management with AWS](https://aws.amazon.com/aws-cost-management/)
+
+**Related videos:**
+
+- [Saving
+cost on your machine learning training and inference on
+AWS](https://www.youtube.com/watch?v=keowy9YfxlcDeploy)
+- [Deploy
+an ML model for best performance, cost, and prediction
+quality](https://www.youtube.com/watch?v=ftCFf57dQQY)
+
+**Related examples:**
+
+- [AWS CloudFormation templates for automated instance
+scheduling](https://github.com/aws-solutions/aws-instance-scheduler)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp08.html*
+
+---
+
+# MLCOST04-BP09 Start training with small datasets
+
+Start experimentation with smaller datasets on a small compute
+instance or local system. This approach allows you to iterate
+quickly at low cost. After the experimentation period, scale up to
+train with the full dataset available on a separate compute cluster.
+Choose the appropriate storage layer for training data based on the
+performance requirements.
+
+**Desired outcome:** You can develop
+your machine learning models cost-effectively by starting with small
+datasets for rapid iteration and experimentation. When you're
+confident in your approach, you scale up to the full dataset on
+appropriate compute resources. This progressive scaling methodology
+optimizes both development time and infrastructure costs while
+maintaining the flexibility to refine your models before committing
+to full-scale training.
+
+**Common anti-patterns:**
+
+- Immediately training with the full dataset on large instances,
+leading to excessive costs during experimentation.
+- Using the same compute resources for both experimentation and
+full-scale training.
+- Not planning for the transition from small-scale to large-scale
+training.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced costs during the experimentation phase.
+- Faster iteration cycles for model development.
+- More efficient use of compute resources.
+- Ability to identify and fix issues early in the development
+process.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning development often requires multiple iterations to
+achieve optimal results. Using smaller, representative samples of
+your dataset during initial experimentation can significantly
+reduce costs and increase productivity. This approach lets you
+rapidly test various model architectures, hyperparameters, and
+preprocessing techniques without the expense and time required to
+process the full dataset.
+
+When implementing this approach, check that your smaller dataset
+properly represents the characteristics of your full dataset to
+avoid developing models that don't generalize well. Once you've
+established effective approaches using the smaller dataset, you
+can scale up your training to use the complete dataset on
+appropriately sized compute resources.
+
+The cloud makes this approach particularly powerful, as you can
+scale your compute resources to match your current phase of
+development. For example, you might use a notebook instance with
+modest resources during experimentation, then transition to
+distributed training on a cluster of more powerful instances when
+you're ready for full-scale training.
+
+### Implementation steps
+
+- **Create a representative subset of
+your data**. Extract a small but representative
+sample of your full dataset that maintains the same
+distribution of features and classes as your original data.
+Aim for 10-20% of your data or a size that can be processed
+on your local machine or small instance.
+- **Set up SageMaker AI notebook instances
+for experimentation**.
+[Amazon SageMaker AI notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) provide a hosted Jupyter
+environment ideal for exploring and experimenting with your
+sample dataset. Choose a smaller instance type to keep costs
+low during experimentation.
+- **Configure notebook lifecycle
+management**. Use
+[lifecycle
+configuration scripts](https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples) to automate the setup of your
+development environment, including installing necessary
+libraries and dependencies when your notebook instance
+starts.
+- **Develop and iterate on your
+model**. Use the notebook environment to build,
+train and evaluate your models on the sample data. Take
+advantage of this faster iteration cycle to explore
+different approaches, hyperparameters, and preprocessing
+techniques.
+- **Test scaling
+considerations**. Before moving to full-scale
+training, test your code with slightly larger data samples
+to identify scaling issues that might arise when processing
+the full dataset.
+- **Prepare for distributed
+training**. Once your approach is validated with
+the sample data, refactor your code as needed to support
+distributed training using SageMaker AI's distributed training
+capabilities.
+- **Scale up compute resources for full
+training**. Launch appropriately sized training
+instances or clusters for your full-scale training job.
+SageMaker AI training jobs allow you to select the instance
+type and count that matches your workload requirements.
+- **Monitor training metrics and
+costs**. Use Amazon CloudWatch to track the
+performance and resource utilization of your training jobs
+to check that they're running efficiently.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html)
+- [Amazon SageMaker AI Studio Lab](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab.html)
+- [Customization
+of a SageMaker AI notebook instance using an LCC script](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html)
+- [Distributed
+training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Notebook Instance Lifecycle Config Samples](https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples)
+- [SageMaker AI
+Local Mode](https://github.com/aws-samples/amazon-sagemaker-local-mode)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp09.html*
+
+---
+
+# MLCOST04-BP10 Use warm start and checkpointing hyperparameter tuning
+
+When training machine learning models, you can significantly reduce
+time and costs by using previous training efforts. This practice
+shows how to use warm start and checkpointing techniques in
+hyperparameter tuning to accelerate your model development process
+and optimize resource utilization.
+
+**Desired outcome:** You can create
+more efficient hyperparameter tuning jobs by using knowledge from
+previous tuning efforts and saved model states. By implementing warm
+start capabilities, you can initialize new tuning jobs with
+information from previous runs, avoiding unnecessary repetition.
+With checkpointing, you can save intermediate model states during
+training, allowing you to resume jobs from the last checkpoint
+rather than starting from scratch. These techniques enable you to
+accelerate your model development process, reduce computational
+costs, and find optimal hyperparameter configurations more
+efficiently.
+
+**Common anti-patterns:**
+
+- Starting every hyperparameter tuning job from scratch without
+using previous knowledge.
+- Not saving model checkpoints during lengthy training jobs,
+risking complete loss of progress if interrupted.
+- Using unnecessarily wide hyperparameter search ranges when
+previous jobs have already identified promising areas.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower computational costs through more efficient resource
+utilization.
+- Accelerated convergence to optimal model configurations.
+- Improved resilience to training interruptions through checkpoint
+recovery.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Hyperparameter tuning is an essential but computationally
+intensive part of machine learning model development. Without warm
+start capabilities, each tuning job begins with no prior
+knowledge, potentially wasting resources by exploring
+already-evaluated hyperparameter combinations. Without
+checkpointing, an interrupted training job must restart from the
+beginning, losing progress.
+
+You can overcome these inefficiencies by implementing warm start
+and checkpointing strategies in your ML workflow. Warm start
+allows you to use knowledge from previous hyperparameter tuning
+jobs, focusing the search on promising areas of the hyperparameter
+space. Checkpointing enables you to save model states periodically
+during training, providing a recovery point if training is
+interrupted.
+
+Amazon SageMaker AI offers built-in support for both warm start and
+checkpointing capabilities. For warm start, you can specify one or
+more parent tuning jobs whose results inform the new job's
+hyperparameter search. SageMaker AI offers two warm start types:
+TRANSFER_LEARNING for adapting knowledge to new
+datasets and IDENTICAL_DATA_AND_ALGORITHM for
+continuing tuning with the same dataset. For checkpointing, you
+can configure your training jobs to periodically save model states
+to Amazon S3, which can be used to resume training if needed.
+
+### Implementation steps
+
+- **Configure warm start for
+hyperparameter tuning jobs**. Set up a new
+hyperparameter tuning job that builds upon the knowledge
+gained from previous tuning jobs. In Amazon SageMaker AI, you
+can configure this by specifying one or more parent tuning
+jobs and selecting an appropriate warm start type. This
+approach is particularly effective when you want to refine
+hyperparameter search after initial exploration or adapt a
+model to a similar dataset.
+- **Select appropriate parent jobs for
+warm start**. Choose parent jobs that are relevant
+to your current tuning objective. The best parent jobs are
+those that used similar datasets, algorithms, or
+optimization objectives. In SageMaker AI, you can specify up to
+five parent jobs when configuring a warm start tuning job.
+- **Choose the right warm start
+type**. Select
+IDENTICAL_DATA_AND_ALGORITHM when
+continuing tuning with the same dataset and algorithm, or
+TRANSFER_LEARNING when adapting knowledge
+to a new but related dataset or problem. The warm start type
+determines how SageMaker AI will use information from the
+parent jobs.
+- **Configure checkpointing for training
+jobs**. Enable checkpointing in your training
+script by saving model states at regular intervals. In
+SageMaker AI, specify a checkpoint S3 location where these
+model states will be stored. This allows you to resume
+training from the last saved checkpoint if a job is
+interrupted or if you want to extend training later.
+- **Implement checkpoint saving in your
+training code**. Add callback functions in your ML
+framework (such as TensorFlow, PyTorch, or MXNet) to
+periodically save model states during training. These
+frameworks typically provide built-in checkpoint
+functionality that you can configure with minimal code
+changes.
+- **Set up checkpoint recovery
+mechanisms**. Configure your training jobs to check
+for existing checkpoints at startup and resume from the
+latest checkpoint if available. In SageMaker AI, you can
+specify the checkpoint configuration when creating a
+training job, including the S3 location where checkpoints
+are stored.
+- **Optimize hyperparameter search
+ranges based on previous results**. When using warm
+start, refine your hyperparameter search ranges based on
+promising values identified in parent jobs. Narrowing search
+ranges around previously successful values can significantly
+improve tuning efficiency.
+- **Run parallel hyperparameter tuning
+jobs strategically**. Use warm start to distribute
+the hyperparameter tuning workload across multiple jobs that
+can share knowledge. This approach is particularly effective
+for exploring large hyperparameter spaces efficiently.
+- **Monitor and evaluate warm start
+efficiency**. Track the performance and efficiency
+gains from warm start by comparing with cold-start
+approaches. This analysis refines your warm start strategy
+for future jobs.
+- **Use enhanced hyperparameter tuning
+capabilities**. Use improved SageMaker AI
+hyperparameter tuning with better algorithms and support for
+multi-objective optimization to find optimal configurations
+more efficiently.
+- **Use generative AI for hyperparameter
+selection**. Use large language models to suggest
+promising hyperparameter ranges based on model architecture
+and dataset characteristics. Generative AI can identify
+sensible starting points for hyperparameter tuning jobs,
+especially for new model architectures.
+
+## Resources
+
+**Related documents:**
+
+- [Run
+a Warm Start Hyperparameter Tuning Job](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-warm-start.html)
+- [Checkpoints
+in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-checkpoints.html)
+- [Automatic
+model tuning in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [HyperparameterTuner](https://sagemaker.readthedocs.io/en/stable/api/training/tuner.html)
+
+**Related examples:**
+
+- [Automatic
+Model Tuning: Warm Starting Tuning Jobs](https://github.com/aws/amazon-sagemaker-examples/blob/master/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb)
+- [Hyperparameter
+Optimization with Checkpointing Example](https://github.com/aws/amazon-sagemaker-examples/tree/master/hyperparameter_tuning)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp10.html*
+
+---
+
+# MLCOST04-BP11 Use hyperparameter optimization technologies
+
+Optimize your machine learning models through automatic
+hyperparameter tuning to find the optimal model configuration with
+minimal manual effort, reducing the time and resources needed to
+achieve peak model performance.
+
+**Desired outcome:** You achieve
+better performing machine learning models by using automatic
+hyperparameter optimization technologies that run multiple training
+jobs in parallel. You can efficiently explore a wide range of
+hyperparameter combinations to find the optimal configuration that
+maximizes model performance according to your specified metrics,
+ultimately delivering better business results while reducing the
+time and resources spent on manual tuning.
+
+**Common anti-patterns:**
+
+- Manually tuning hyperparameters through trial and error.
+- Using a narrow range of hyperparameter values that don't
+adequately explore the solution space.
+- Selecting arbitrary hyperparameter values without considering
+the specific requirements of your business problem.
+- Running one training job at a time instead of using parallel
+capabilities.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time to develop high-performing machine learning models.
+- Lower computational costs by efficiently exploring the
+hyperparameter space.
+- Consistent and repeatable approach to model optimization.
+- Ability to scale hyperparameter tuning efforts across multiple
+algorithms.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+*Hyperparameter optimization (HPO)* is a
+critical aspect of developing effective machine learning models.
+Unlike model parameters that are learned during training,
+hyperparameters are configuration variables that govern the
+training process itself and significantly impact model
+performance. Finding the optimal combination of hyperparameters
+manually is time-consuming and inefficient.
+
+By implementing automatic hyperparameter tuning, you can
+systematically explore the hyperparameter space and identify the
+configuration that maximizes model performance. SageMaker AI's
+automatic model tuning service employs techniques like Bayesian
+optimization to intelligently search through the hyperparameter
+space, focusing computational resources on the most promising
+regions and accelerating the discovery of the optimal
+configuration.
+
+When implementing hyperparameter optimization, you should define
+appropriate search spaces for your hyperparameters based on domain
+knowledge and previous experiments. You also need to select
+relevant evaluation metrics that align with your business
+objectives. For classification problems, this might include
+accuracy, F1 score, or AUC-ROC, while for regression problems, it
+could be mean squared error or mean absolute error.
+
+### Implementation steps
+
+- **Identify key hyperparameters for
+your model**. Begin by determining which
+hyperparameters have the greatest impact on your model's
+performance. For neural networks, this might include
+learning rate, batch size, and network architecture
+parameters. For tree-based models, this could include tree
+depth, number of trees, and minimum samples per leaf.
+- **Define appropriate hyperparameter
+ranges**. Establish meaningful ranges for each
+hyperparameter based on domain knowledge and best practices
+for your chosen algorithm. Use logarithmic scales for
+parameters that span multiple orders of magnitude (like
+learning rate) for efficient exploration.
+- **Select relevant evaluation
+metrics**. Choose metrics that align with your
+business requirements and the problem you're solving. Check
+that these metrics provide a meaningful assessment of model
+performance in the context of your specific application.
+- **Configure SageMaker AI automatic model
+tuning**. Create a hyperparameter tuning job using
+the
+[SageMaker AI
+Python SDK](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html) or the SageMaker AI console. Specify the
+algorithm or framework you're using, the hyperparameter
+ranges, and the evaluation metric to optimize.
+- **Implement early stopping for
+efficiency**. Enable early stopping features to
+automatically terminate poorly performing training jobs,
+saving computational resources. SageMaker AI can monitor the
+evaluation metric during training and stop jobs that are
+unlikely to produce competitive models.
+- **Use warm start for incremental
+tuning**. Use the warm start feature to accelerate
+new hyperparameter tuning jobs by using information from
+previous tuning jobs, reducing the time and resources needed
+to find optimal configurations.
+- **Implement parallel training
+jobs**. Configure SageMaker AI to run multiple
+training jobs concurrently to explore different
+hyperparameter combinations simultaneously, dramatically
+reducing the time required to find optimal values.
+- **Analyze tuning job
+results**. Review the performance of different
+hyperparameter combinations to understand how each parameter
+affects model performance. Use this information to refine
+your hyperparameter ranges for future tuning jobs.
+- **Select the best model for
+deployment**. After the tuning job completes,
+identify the best-performing model based on your evaluation
+metric and deploy it using SageMaker AI's deployment
+capabilities.
+- **Use no-code hyperparameter
+optimization**. Use
+[SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html) with enhanced capabilities for business users
+to perform hyperparameter optimization through natural
+language interfaces without requiring deep technical
+expertise.
+- **Document hyperparameter
+configurations**. Maintain comprehensive
+documentation of hyperparameter configurations, tuning
+strategies, and results to facilitate knowledge sharing and
+reproducibility.
+
+## Resources
+
+**Related documents:**
+
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [Stop
+Training Jobs Early](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-early-stopping.html)
+- [Best
+Practices for Hyperparameter Tuning](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html)
+- [Create
+a Hyperparameter Optimization Tuning Job for One or More
+Algorithms (Console)](https://docs.aws.amazon.com/sagemaker/latest/dg/multiple-algorithm-hpo-create-tuning-jobs.html)
+- [Run
+a Warm Start Hyperparameter Tuning Job](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-warm-start.html)
+
+**Related examples:**
+
+- [SageMaker AI
+examples - hyperparameter tuning](https://github.com/aws/amazon-sagemaker-examples/tree/main/hyperparameter_tuning)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp11.html*
+
+---
+
+# MLCOST04-BP12 Set up a budget and use resource tagging to track costs
+
+Setting up budgets and implementing resource tagging for machine
+learning workloads provides clear visibility into your ML-related
+expenses and optimizes costs across your organization. By tracking
+costs effectively, you can make data-driven decisions about resource
+allocation and identify opportunities for cost optimization.
+
+**Desired outcome:** You gain
+complete visibility into your machine learning costs across
+development, training, and production environments. You can track
+expenses by project, business unit, or environment, allowing for
+accurate cost allocation and forecasting. Through tagging and
+budgeting tools, you can proactively manage your ML spending,
+receive alerts before exceeding budgeted amounts, and make informed
+decisions about resource provisioning and termination.
+
+**Common anti-patterns:**
+
+- Running ML workloads without cost monitoring mechanisms in
+place.
+- Using generic cost tracking that doesn't differentiate between
+ML projects or environments.
+- Failing to tag ML resources consistently, making cost allocation
+difficult.
+- Ignoring budget alerts or failing to take action when exceeding
+thresholds.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear visibility into where ML spending occurs across your
+organization.
+- Ability to accurately allocate costs to specific projects or
+business units.
+- Early warning through alerts when costs exceed or are forecasted
+to exceed budgeted amounts.
+- Improved governance and financial accountability for ML
+initiatives.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Cost management is a critical aspect of running machine learning
+workloads in the cloud. Without proper cost tracking and budget
+controls, ML expenses can quickly escalate due to
+compute-intensive training jobs, large storage requirements for
+datasets, and continuous inference endpoints. By implementing
+comprehensive budgeting and tagging strategies, you gain
+visibility and control over these costs.
+
+AWS provides several tools that work together to track, analyze,
+and optimize your ML costs. AWS Budgets allows you to set custom
+budgets for your SageMaker AI resources, while AWS Cost Explorer
+provides visualization and analysis capabilities to understand
+spending patterns. Resource tagging serves as the foundation for
+detailed cost tracking, enabling you to categorize expenses by
+project, team, environment, or other dimension important to your
+organization.
+
+For example, you might tag resources related to a fraud detection
+model with a Project tag value of
+FraudDetection and an
+Environment tag value of
+Production. This allows you to track the total
+cost of this specific ML use case across its components, from
+development notebooks to training jobs to deployment endpoints.
+
+### Implementation steps
+
+- **Set up AWS Budgets for ML cost
+tracking**. Create customized budgets in AWS
+Budgets to monitor your Amazon SageMaker AI costs across
+development, training, and hosting. Configure the budget to
+track specific services (such as SageMaker AI) or specific
+tagged resources. Set thresholds for actual costs and
+forecasted costs to receive notifications before you exceed
+your budget. This gives you time to make adjustments to your
+resource usage if needed. Access your budgets through the
+[AWS Budgets console](https://aws.amazon.com/aws-cost-management/aws-budgets/) to track progress and make
+adjustments as necessary.
+- **Implement a tagging strategy for ML
+resources**. Develop a consistent tagging strategy
+for all your ML resources. Define mandatory tags such as
+Project, BusinessUnit, Environment (dev/test/prod), and
+Owner. Document your tagging standards and verify that team
+members understand and follow these standards. Apply these
+tags to relevant resources, including
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) notebook instances, training jobs, models,
+endpoints, and related resources like
+[Amazon S3](https://aws.amazon.com/s3/) buckets for dataset storage.
+- **Activate cost allocation
+tags**. After implementing your tagging strategy,
+activate your tags as cost allocation tags in the AWS Billing and Cost Management console. Note that it may take up to 24 hours for
+newly activated tags to appear in your cost management
+tools. Once activated, you can use your tags to filter and
+group costs in AWS Cost Explorer and other cost reporting
+tools.
+- **Configure detailed cost analysis
+using AWS Cost Explorer**. Use
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) to visualize and analyze your ML costs
+over time. Create custom reports that filter costs by
+specific tags (like Project or Environment) or by specific
+services like SageMaker AI. Set up regular reports to track
+spending trends, identify cost spikes, and understand usage
+patterns. Use the insights gained to optimize your resource
+allocation and scheduling for ML workloads.
+- **Create cost anomaly
+detection**. Set up
+[AWS Cost Anomaly Detection](https://aws.amazon.com/aws-cost-management/aws-cost-anomaly-detection/) to automatically identify
+unusual spending patterns in your ML workloads. Configure
+alerts to notify relevant stakeholders when anomalies are
+detected. This assists you in quickly identifying and
+addressing unexpected cost increases, which can happen with
+ML workloads due to extended training times or inefficient
+resource usage.
+- **Establish cost governance
+processes**. Create clear processes for reviewing
+costs, responding to budget alerts, and making cost
+optimization decisions. Assign responsibility for cost
+monitoring to specific individuals or teams. Conduct regular
+cost reviews with stakeholders to discuss spending trends,
+identify optimization opportunities, and align ML resource
+usage with business priorities. Document cost-saving actions
+taken and their impact on the overall budget.
+- **Optimize ML resources based on cost
+data**. Use the cost insights gained from your
+tagging and budgeting tools to optimize ML resource usage.
+Identify underutilized notebook instances that can be
+stopped when not in use. Select appropriate instance types
+based on workload requirements. Consider using
+[Amazon SageMaker AI Managed Spot Training](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html) to reduce training
+costs by up to 90%. Implement auto-scaling for inference
+endpoints to match capacity with demand.
+
+## Resources
+
+**Related documents:**
+
+- [Managing
+your costs with AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [Organizing
+and tracking costs using AWS cost allocation tags](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
+- [Getting
+started with AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html)
+- [Best
+Practices for Tagging AWS Resources](https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/tagging-best-practices.html)
+- [Cost
+Optimization Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
+- [Amazon SageMaker AI Pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [AWS Cloud Financial Management](https://aws.amazon.com/aws-cost-management/)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 4: Training jobs](https://aws.amazon.com/blogs/machine-learning/part-4-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-4-training-jobs/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp12.html*
+
+---
+
+# MLCOST04-BP13 Enable data and compute proximity
+
+Positioning data and compute resources in the same AWS Region
+reduces data transfer costs and improves processing speeds for
+machine learning workloads. By minimizing the physical distance
+between data storage and compute resources, you can significantly
+decrease latency and avoid cross-region data transfer fees.
+
+**Desired outcome:** You achieve
+cost-efficient and high-performance machine learning operations by
+placing your data and compute resources in the same AWS Region. You
+experience faster training times, reduced latency, and avoid
+unnecessary data transfer costs that can significantly impact your
+ML project budgets.
+
+**Common anti-patterns:**
+
+- Storing data in one Region and running compute resources in
+another Region.
+- Repeatedly transferring large datasets across Regions for
+training or inference.
+- Failing to consider the impact of data transfer costs on overall
+ML project budgets.
+
+**Benefits of establishing this best
+practice:**
+
+- Decreased latency for data access during model training and
+inference.
+- Improved overall machine learning workflow performance.
+- Simplified management of data compliance and sovereignty
+requirements.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data transfer costs between AWS Regions can significantly impact
+your machine learning project's budget, especially when working
+with large datasets that are repeatedly accessed during model
+training. By keeping your compute resources in the same Region as
+your data storage, you minimize these costs and improve
+performance.
+
+When planning your machine learning infrastructure on AWS,
+consider data locality as a primary design principle. For example,
+if your organization stores datasets in Amazon S3 buckets in the
+US West (Oregon) Region, you should provision EC2 instances,
+SageMaker AI notebooks, or other ML compute resources in that same
+Region.
+
+This principle applies to various machine learning scenarios,
+including model training, data preprocessing, and inference. Even
+though AWS provides high-speed network connections between
+Regions, the laws of physics still impose latency limitations, and
+cross-Region data transfers incur additional costs that can be
+avoided.
+
+### Implementation steps
+
+- **Identify data storage
+locations**. Determine where your primary data is
+stored on AWS. Check which Regions contain your Amazon S3
+buckets, Amazon EFS file systems, or other storage services
+holding your training data. Use the AWS Management Console,
+AWS CLI, or infrastructure as code tools to inventory your
+data storage resources across Regions.
+- **Audit compute resource
+placement**. Review your current machine learning
+compute resources, including Amazon EC2 instances, Amazon SageMaker AI notebooks, and training jobs. Verify if they are
+in the same Regions as your data sources. Use AWS Cost Explorer and AWS Trusted Advisor to identify cross-Region
+data transfer costs that may indicate misaligned resources.
+- **Consolidate resources by
+Region**. When creating new compute resources for
+machine learning workloads, consistently provision them in
+the same Region as your data. For example, if using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/), create your notebook instances, training
+jobs, and endpoints in the Region where your training data
+is stored in Amazon S3.
+- **Use Regional data transfer
+analysis**. Review your AWS billing information to
+identify and quantify cross-Region data transfer costs. The
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) service can assist you in analyzing
+data transfer costs between AWS services and across Regions.
+Set up cost allocation tags to track expenses related to
+machine learning projects specifically.
+- **Consider data replication for
+specific use cases**. In scenarios requiring
+multi-Region deployments for high availability or disaster
+recovery, implement a data replication strategy to maintain
+copies of datasets in each Region where compute resources
+exist. Services like
+[Amazon S3 Cross-Region Replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html) can automate this process
+while managing costs.
+- **Leverage edge computing for
+distributed ML workloads**. When working with data
+that exists at the edge of the network, consider using
+[AWS Outposts](https://aws.amazon.com/outposts/),
+[AWS Wavelength](https://aws.amazon.com/wavelength/), or
+[AWS Local Zones](https://aws.amazon.com/about-aws/global-infrastructure/localzones/) to bring compute resources closer to your
+data sources, especially for applications requiring
+low-latency inference.
+- **Implement data caching
+strategies**. For frequently accessed data,
+implement caching solutions like
+[Amazon ElastiCache](https://aws.amazon.com/elasticache/) or
+[Amazon DynamoDB Accelerator (DAX)](https://aws.amazon.com/dynamodb/dax/) in the same Region as your
+compute resources to further reduce latency and data
+transfer costs.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [Replicating
+objects within and across Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html)
+- [AWS Data Transfer Pricing](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer)
+- [AWS Local Zones](https://aws.amazon.com/about-aws/global-infrastructure/localzones/)
+- [AWS Outposts](https://aws.amazon.com/outposts/)
+- [Regions
+and Zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)
+- [AWS Global Infrastructure](https://aws.amazon.com/about-aws/global-infrastructure/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp13.html*
+
+---
+
+# MLCOST04-BP14 Select optimal algorithms
+
+Selecting optimal algorithms for machine learning (ML) workloads is
+crucial for balancing cost efficiency and performance. By
+identifying appropriate ML paradigms and carefully evaluating
+algorithmic choices, you can optimize both technical performance and
+business outcomes while managing costs.
+
+**Desired outcome:** You are able to
+identify the most suitable ML algorithm for your specific use case
+that balances accuracy, explainability, computational requirements,
+and cost efficiency. You can conduct effective trade-off analyses
+between different approaches and use AWS services to optimize
+algorithm selection, training, and deployment.
+
+**Common anti-patterns:**
+
+- Using complex deep learning solutions without first exploring
+simpler algorithms.
+- Ignoring the explainability requirements of the business use
+case.
+- Failing to consider data constraints when selecting algorithms.
+- Not evaluating computational and maintenance costs alongside
+accuracy metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced computational costs by using algorithms appropriate for
+the specific problem.
+- Improved model performance through systematic comparison of
+algorithm options.
+- Enhanced model explainability when required by business
+stakeholders.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Selecting the optimal algorithm requires understanding your
+specific ML problem type and the business constraints around it.
+Begin by categorizing your problem into basic ML paradigms:
+supervised learning (for labeled data), unsupervised learning (for
+unlabeled data), or reinforcement learning (for sequential
+decision problems). Consider what matters most for your use case,
+whether it's prediction accuracy, model explainability, inference
+speed, or a balance of these factors.
+
+Algorithm selection significantly impacts both the performance and
+cost efficiency of your ML solutions. A computationally expensive
+algorithm might deliver marginally better accuracy but at
+substantially higher operational costs. Similarly, a complex but
+highly accurate algorithm might sacrifice the explainability
+needed for regulatory adherence or business transparency. Finding
+the right balance requires systematic experimentation and
+evaluation against your business requirements.
+
+AWS provides various services test, compare, and optimize
+algorithms, allowing you to make data-driven decisions about which
+approach delivers the best value for your specific use case.
+
+### Implementation steps
+
+- **Define your machine learning problem
+type**. Categorize your problem as supervised
+learning (classification, regression), unsupervised learning
+(clustering, dimensionality reduction), or reinforcement
+learning. This initial classification narrows down the
+appropriate algorithms to consider.
+- **Determine business requirements and
+constraints**. Document specific accuracy targets,
+explainability needs, inference time requirements, and
+budget constraints. These requirements will serve as
+criteria for evaluating algorithm options.
+- **Start with simple algorithms
+first**. Begin experimentation with simpler
+algorithms like linear or logistic regression, decision
+trees, or k-means clustering before moving to more complex
+approaches. These algorithms are computationally efficient,
+simpler to interpret, and establish important baselines for
+performance comparison.
+- **Conduct structured
+experimentation**. Use
+[Amazon SageMaker AI Experiments](https://docs.aws.amazon.com/sagemaker/latest/dg/experiments.html) to track different algorithm
+trials, hyperparameter configurations, and their results.
+This creates reproducibility and facilitates comparison
+between approaches.
+- **Perform comprehensive trade-off
+analysis**. When comparing algorithms, consider
+multiple dimensions beyond accuracy:
+
+Data requirements (amount needed for training)
+- Computational resources required for training and
+inference
+- Model explainability and interpretability
+- Deployment complexity and operational overhead
+- Long-term maintenance costs
+
+- **Use AWS optimized algorithms and
+frameworks**. Use
+[Amazon SageMaker AI built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) that are optimized for
+performance and cost-efficiency on AWS infrastructure. AWS
+also provides optimized versions of popular frameworks like
+TensorFlow, PyTorch, and MXNet that include performance
+enhancements for training across
+[Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html) instance families.
+- **Consider automated ML
+approaches**. For exploratory projects or when
+seeking optimal performance with minimal manual tuning, use
+SageMaker AI Canvas for rapid algorithm prototyping with the
+ability to export generated code to notebooks for further
+customization.
+- **Explore pre-trained
+models**. Search AWS Marketplace for pre-trained
+models that can accelerate development through transfer
+learning or direct deployment. Pre-trained models can
+significantly reduce computational costs and development
+time.
+- **Implement continuous
+evaluation**. As new algorithms and model versions
+emerge, periodically reassess whether your chosen approach
+remains optimal. Business requirements and available
+technologies evolve over time.
+- **Document algorithm selection
+rationale**. Create clear documentation explaining
+why specific algorithms were selected, what trade-offs were
+accepted, and how these decisions align with business
+requirements.
+- **For generative AI projects, consider
+foundation models from
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for natural language processing, image
+generation, and other tasks where these models can provide
+state-of-the-art performance with lower development
+costs.** Use techniques like prompt engineering and
+fine-tuning to adapt foundation models to your specific
+business needs while avoiding the computational expense of
+training from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [Built-in
+algorithms and pretrained models in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html#mlflow-tracking)
+- [How
+custom models work](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-build-model.html)
+- [Types
+of Algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algorithms-choose.html)
+- [SageMaker AI
+JumpStart pretrained Models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp14.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLCOST05.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLCOST05.md
@@ -1,0 +1,517 @@
+# MLCOST05
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLCOST05-BP01 Use an appropriate deployment option
+
+Use the right deployment option for your machine learning models to
+optimize cost and performance based on your specific use case
+requirements. Select real-time inference for low latency
+applications, batch transform for large datasets, or edge deployment
+for applications that require local processing.
+
+**Desired outcome:** You have an
+optimized model deployment strategy that balances performance and
+cost efficiency. You can choose the appropriate deployment option
+based on your specific use case requirements, whether that's
+real-time inference for low-latency applications, batch processing
+for large datasets, or edge deployment for scenarios requiring local
+processing.
+
+**Common anti-patterns:**
+
+- Using real-time endpoints for deployment scenarios regardless of
+traffic patterns.
+- Overlooking serverless or asynchronous options when they would
+be more cost-effective.
+- Deploying separate endpoints for each model when multiple models
+could be hosted more efficiently together.
+- Running inference in the cloud when edge deployment would be
+more efficient for local data processing.
+- Overprovisioning compute resources for inference endpoints.
+
+**Benefits of establishing this best
+practice:**
+
+- Cost optimization through selection of the most efficient
+deployment option for each use case.
+- Improved performance by matching deployment options to specific
+latency requirements.
+- Increased operational efficiency through managed inference
+services.
+- Flexibility to handle varying inference workloads and traffic
+patterns.
+- Simplified ML model management across cloud and edge
+environments.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When deploying machine learning models, selecting the right
+deployment option is crucial for achieving optimal performance and
+cost efficiency. Amazon SageMaker AI provides multiple deployment
+options that can be tailored to your specific use case
+requirements. Real-time inference is ideal for applications
+requiring low latency responses, such as real-time recommendations
+or fraud detection. Batch transform is better suited for
+processing large datasets in offline mode, such as document
+processing or periodic scoring jobs. Edge deployment brings
+inference capabilities directly to edge devices, reducing latency
+and bandwidth requirements while enabling offline processing.
+
+Consider the pattern of requests your application needs to handle.
+If you need consistent, low-latency responses for interactive
+applications with steady traffic, real-time inference is
+appropriate. If you process data in batches without immediate
+response requirements, batch transform offers cost efficiency. For
+applications with unpredictable or bursty traffic patterns,
+serverless inference can automatically scale to match demand while
+minimizing costs during idle periods. For workloads with large
+payloads or long processing times, asynchronous inference provides
+a queuing mechanism that improves efficiency.
+
+Also consider resource utilization. Multi-model endpoints and
+multi-container endpoints enable you to optimize costs by sharing
+resources across multiple models or containers. This approach is
+particularly valuable when you have many models with variable
+usage patterns or complementary resource requirements.
+
+### Implementation steps
+
+- **Evaluate your inference
+requirements**. Determine your application's needs
+for latency, throughput, payload size, and traffic patterns.
+Consider whether your application requires real-time
+responses or can process data in batches. Assess if your
+models should run in the cloud or at the edge based on
+connectivity, latency requirements, and data privacy
+considerations.
+- **Use Amazon SageMaker AI for model
+deployment**.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) offers a comprehensive set of deployment
+options to optimize price-performance for most use cases.
+It's a fully managed service that integrates with MLOps
+tools for effective model management in production with
+reduced operational burden.
+- **Select the appropriate inference
+option based on your use case**. Choose from
+several SageMaker AI inference options:
+
+[Amazon SageMaker AI Real-time Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html) for low-latency,
+interactive applications requiring immediate responses
+- [Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) for workloads with
+intermittent or unpredictable traffic patterns
+- [Amazon SageMaker AI Asynchronous Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html) for large
+payload sizes, long processing times, or when immediate
+responses aren't required
+- [Amazon SageMaker AI Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html) for offline processing
+of large datasets
+
+- **Implement multi-model endpoints for
+cost optimization**. Use
+[Amazon SageMaker AI Multi-Model Endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html) to deploy multiple
+models on a single endpoint with shared container resources.
+This approach improves endpoint utilization and reduces
+hosting costs compared to single-model endpoints. SageMaker AI
+manages the loading of models into memory and scales them
+based on traffic patterns.
+- **Deploy multiple containers on a
+single endpoint**. Implement
+[SageMaker AI
+multi-container endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html) to deploy multiple
+containers using different models or frameworks on a single
+endpoint. Run containers in sequence as an inference
+pipeline or access each container individually through
+direct invocation to improve endpoint utilization and
+optimize costs.
+- **Automate endpoint changes through a
+pipeline**. Use
+[Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) to automate the model deployment
+process. Create CI/CD pipelines that handle model training,
+evaluation, and deployment, enabling consistent and
+repeatable deployment processes.
+- **Monitor and optimize your
+deployment**. Implement continuous monitoring of
+your inference endpoints to track performance metrics, cost,
+and resource utilization. Use this data to fine-tune your
+deployment strategy and make adjustments as needed to
+optimize for cost efficiency and performance.
+- **Use AI-powered code generation for
+deployment automation**. Use AI-powered development
+tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+deployment scripts, automate infrastructure configuration,
+and accelerate the implementation of optimal deployment
+strategies.
+- **For generative AI workloads,
+consider deployment options for foundation
+models**. Evaluate specialized deployment options
+like
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for fully managed foundation models or
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart.html) for pre-trained models with optimized
+deployment configurations.
+
+## Resources
+
+**Related documents:**
+
+- [Deploy
+models for inference](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-model.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Batch
+transform for inference with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)
+- [Hosting
+options](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-options.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Model
+deployment at the edge with SageMaker AI Edge Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/edge.html)
+- [Inference
+pipelines in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Serverless Inference Walkthrough](https://github.com/aws/amazon-sagemaker-examples/blob/main/serverless-inference/Serverless-Inference-Walkthrough.ipynb)
+- [SageMaker AI
+Edge Manager Workshop](https://github.com/aws-samples/amazon-sagemaker-edge-manager-workshop)
+- [SageMaker AI
+Asynchronous Inference Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/async-inference)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost05-bp01.html*
+
+---
+
+# MLCOST05-BP02 Explore cost effective hardware options
+
+Machine learning models that power AI applications are becoming
+increasingly complex resulting in rising underlying compute
+infrastructure costs. Up to 90% of the infrastructure spend for
+developing and running ML applications is often on inference. Look
+for cost-effective infrastructure solutions for deploying their ML
+applications in production.
+
+**Desired outcome:** You achieve
+significant cost savings while maintaining or improving the
+performance of your machine learning inference workloads. By
+implementing cost-effective hardware options, you optimize your
+infrastructure spend, reduce operational costs, and can allocate
+resources more efficiently across your ML applications. Your ML
+models run on purpose-built hardware that provides the right balance
+of performance and cost for your specific use case.
+
+**Common anti-patterns:**
+
+- Using general-purpose compute instances for ML workloads without
+considering specialized hardware options.
+- Over-provisioning inference resources to handle peak loads
+without implementing scaling strategies.
+- Ignoring model optimization opportunities before deploying to
+production.
+- Selecting hardware based solely on performance metrics without
+considering cost-efficiency.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced infrastructure costs for ML model inference.
+- Improved inference throughput and latency.
+- More efficient use of computational resources.
+- Lower total cost of ownership for AI applications.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning inference costs represent a significant portion
+of the total expenses associated with running ML workloads in
+production. As models become more complex, their computational
+requirements increase, which can lead to higher infrastructure
+costs. Selecting the right hardware for your ML workloads is
+crucial for maintaining cost efficiency without sacrificing
+performance.
+
+AWS offers multiple options to optimize the cost and performance
+of your ML inference workloads. These include services that
+optimize models for specific hardware targets, instances that
+provide cost-effective acceleration for inference workloads, and
+deployment options that match your specific latency and throughput
+requirements.
+
+Evaluating your specific workload requirements is essential before
+selecting hardware options. Consider factors such as latency
+requirements, throughput needs, model complexity, batch size
+capabilities, and budget constraints. This evaluation will assist
+you to determine the most appropriate hardware solution for your
+use case.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI Neo for model
+optimization**. Amazon SageMaker AI Neo automatically
+optimizes machine learning models for inference on cloud
+instances and edge devices. For inference in the cloud,
+SageMaker AI Neo speeds up inference and saves cost by creating
+an inference optimized container in SageMaker AI hosting. For
+inference at the edge, SageMaker AI Neo saves developers months
+of manual tuning by automatically tuning the model for the
+selected operating system and processor hardware. Neo
+optimizes models trained in TensorFlow, PyTorch, MXNet, and
+other frameworks for deployment on ARM, Intel, and NVIDIA
+processors.
+- **Deploy on Amazon EC2 Inf2
+Instances**. Amazon EC2 Inf1 instances deliver
+high-performance ML inference at the lowest cost in the
+cloud. They deliver up to 2.3-times higher throughput and up
+to 70% lower cost per inference than comparable current
+generation GPU-based Amazon EC2 instances. Inf1 instances
+are built from the ground up to support machine learning
+inference applications. They feature up to 16 AWS Inferentia
+chips, high-performance machine learning inference chips
+designed and built by AWS. Additionally, Inf1 instances
+include second generation Intel Xeon Scalable processors and
+up to 100 Gbps networking to deliver high throughput
+inference.
+- **Explore Amazon EC2 Inf2
+Instances**. The second generation of AWS
+Inferentia-based instances, EC2 Inf2 instances, offer even
+greater performance improvements over previous generations.
+These instances are powered by AWS Inferentia2 chips and
+provide up to 4x higher throughput and up to 10x lower
+latency than Inf1 instances. They're ideal for more complex
+generative AI models and large language models (LLMs) that
+require high performance and cost-effective inference
+solutions.
+- **Consider Amazon SageMaker AI serverless
+inference**. SageMaker AI serverless inference is a
+purpose-built inference option that automatically
+provisions, scales, and shuts down compute capacity based on
+your workload needs. This pay-per-use model can reduce costs
+by avoiding the need to continuously run instances when
+there are no inference requests, making it ideal for
+workloads with intermittent traffic patterns.
+- **Evaluate batch and asynchronous
+inference options**. For non-real-time inference
+requirements, consider using SageMaker AI batch transform for
+offline inference processing or SageMaker AI asynchronous
+inference for workloads that can tolerate higher latency.
+These options often allow for more efficient resource
+utilization and lower costs compared to real-time inference
+endpoints.
+- **Implement automated scaling
+policies**. Configure auto-scaling for your
+SageMaker AI endpoints to dynamically adjust the number of
+instances based on workload demands. This way, you can pay
+for the resources you need while maintaining performance
+requirements during peak usage periods.
+- **Use enhanced SageMaker AI Inference
+Recommender**. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) with enhanced algorithms and
+support for multi-model endpoints to get sophisticated cost
+optimization recommendations for your specific workloads.
+- **Regularly monitor and analyze
+inference costs**. Use AWS Cost Explorer and Amazon CloudWatch metrics to track your inference costs and
+performance metrics. Regularly review this data to identify
+optimization opportunities and adjust your hardware strategy
+accordingly.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [Amazon EC2 Inf2 Instances](https://aws.amazon.com/ec2/instance-types/inf2/)
+- [AWS Inferentia](https://aws.amazon.com/machine-learning/inferentia/)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Deploy
+models for inference](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-model.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+
+**Related examples:**
+
+- [AWS Neuron SDK Examples for Inferentia and Trainium
+instances](https://github.com/aws-neuron/aws-neuron-sdk)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost05-bp02.html*
+
+---
+
+# MLCOST05-BP03 Right-size the model hosting instance fleet
+
+Use efficient compute resources to run models in production. In many
+cases, up to 90% of the infrastructure spend for developing and
+running an ML application is on inference, making it critical to use
+high-performance, cost-effective ML inference infrastructure.
+Selecting the right way to host and the right type of instance can
+have a large impact on the total cost of ML projects. Use automatic
+scaling for your hosted models. Auto scaling dynamically adjusts the
+number of instances provisioned for a model in response to changes
+in your workload.
+
+**Desired outcome:** You optimize
+your ML infrastructure costs while maintaining performance by using
+the right instance types and quantities for your model deployments.
+You use automated tools to recommend the most cost-effective
+configurations and implement dynamic scaling that adjusts capacity
+based on actual demand patterns, resulting in significant cost
+savings and consistent performance.
+
+**Common anti-patterns:**
+
+- Using the same instance types for each model regardless of their
+specific requirements.
+- Maintaining static instance counts rather than scaling with
+workload demands.
+- Selecting instance types based solely on performance without
+considering cost implications.
+- Not distributing model instances across multiple availability
+zones for resilience.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced ML infrastructure costs by up to 90% through optimal
+instance selection.
+- Improved model performance through use of appropriately sized
+resources.
+- Enhanced reliability through automatic scaling and multi-AZ
+deployment.
+- Better handling of variable workloads without performance
+degradation.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Optimizing ML inference costs requires a careful balance between
+performance and cost. When selecting compute resources for model
+hosting, consider both the model's specific requirements and the
+expected workload patterns. CPU instances may be sufficient for
+many traditional ML models, while GPU instances deliver better
+performance for deep learning models but at a higher cost. The key
+is using the right resource for the specific workload.
+
+Amazon SageMaker AI provides tools that can automatically select
+the optimal instance type and size for your models. By testing
+different configurations, you can find the sweet spot that
+delivers the required performance at the lowest possible cost.
+Additionally, implementing auto scaling assists in verifying that
+your deployment can handle varying loads efficiently, scaling up
+during peak demand and down during quiet periods to avoid
+unnecessary costs.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI Inference
+Recommender for instance selection**. Amazon SageMaker AI Inference Recommender automatically selects the
+right compute instance type, instance count, container
+parameters, and model optimizations for inference to
+maximize performance and minimize cost. You can use
+SageMaker AI Inference Recommender from SageMaker AI Studio,
+the AWS Command Line Interface (AWS CLI), or the AWS SDK,
+and within minutes, get recommendations to deploy your ML
+model. You can then deploy your model to one of the
+recommended instances or run a fully managed load test on a
+set of instance types you choose without worrying about
+testing infrastructure. You can review the results of the
+load test in SageMaker AI Studio and evaluate the tradeoffs
+between latency, throughput, and cost to select the most
+optimal deployment configuration.
+- **Configure auto scaling for SageMaker AI
+endpoints**. Amazon SageMaker AI supports an auto
+scaling feature that monitors your workloads and dynamically
+adjusts the capacity to maintain steady and predictable
+performance at the lowest possible cost. When the workload
+increases, auto scaling brings more instances online. When
+the workload decreases, auto scaling removes unnecessary
+instances, which can reduce your compute cost. SageMaker AI
+automatically attempts to distribute your instances across
+Availability Zones. So, we strongly recommend that you
+deploy multiple instances for each production endpoint for
+high availability. If you're using a VPC, configure at least
+two subnets in different Availability Zones so Amazon SageMaker AI can distribute your instances across those
+Availability Zones.
+- **Implement proper scaling
+policies**. Define appropriate scaling policies
+based on your model's performance characteristics and usage
+patterns. Set scaling metrics such as CPU utilization, GPU
+utilization, model latency, or custom metrics that reflect
+your workload's needs. Define appropriate target values and
+cooldown periods to avoid rapid scaling oscillations.
+- **Consider serverless inference
+options**. For workloads with unpredictable or
+intermittent traffic patterns, evaluate
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html), which automatically
+provisions and scales compute capacity based on traffic.
+This option reduces the need to select instance types or
+manage scaling policies while providing pay-per-use pricing.
+- **Regularly review and optimize
+deployments**. Set up a process to periodically
+review your model deployments' performance and cost metrics.
+As your models evolve and usage patterns change, rerun
+Inference Recommender tests to keep your infrastructure
+optimized. Look for opportunities to consolidate models or
+use multi-model endpoints where appropriate.
+- **Use SageMaker AI Training Plans for
+predictable access**. Use
+[SageMaker AI
+Training Plans](https://aws.amazon.com/sagemaker/pricing/) as a compute reservation system for
+predictable access to high-demand GPU resources, managing
+large-scale AI training workloads more efficiently with
+better resource planning and scheduling capabilities.
+- **Use model optimization
+techniques**. For large language models and other
+generative AI workloads, consider techniques like
+quantization, distillation, or pruning to reduce model size
+and computational requirements. Amazon SageMaker AI supports
+optimization techniques through
+[SageMaker AI
+Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) and integration with
+[AWS Neuron](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/) for optimized inference on AWS Inferentia and
+Trainium chips.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+
+**Related examples:**
+
+- [SageMaker AI Inference Recommender](https://github.com/aws/amazon-sagemaker-examples/blob/main/sagemaker-inference-recommender/inference-recommender.ipynb)
+- [Right-sizing
+your Amazon SageMaker AI Endpoints](https://github.com/aws-samples/aws-marketplace-machine-learning/blob/master/right_size_your_sagemaker_endpoints/Right-sizing%20your%20Amazon%20SageMaker AI%20Endpoints.ipynb)
+- [SageMaker AI
+Serverless Inference Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/serverless-inference)
+- [Automatically
+Scale Amazon SageMaker AI Models](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/endpoint-auto-scaling.md)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost05-bp03.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLCOST06.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLCOST06.md
@@ -1,0 +1,709 @@
+# MLCOST06
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLCOST06-BP01 Monitor usage and cost by ML activity
+
+Use cloud resource tagging to manage, identify, organize, search
+for, and filter resources. Tags categorize resources by purpose,
+owner, environment, or other criteria. Associate costs with
+resources using ML activity categories, such as re-training and
+hosting, by using tagging to manage and optimize cost in deployment
+phases. Tagging can be useful for generating billing reports with
+breakdown of cost by associated resources.
+
+**Desired outcome:** You gain
+visibility into your machine learning costs by activity type,
+allowing for better allocation, forecasting, and optimization of ML
+resources. You can track expenses across different phases of the ML
+lifecycle including development, training, and deployment. This
+enables data-driven decisions about resource allocation and
+identifies cost-saving opportunities while maintaining performance.
+
+**Common anti-patterns:**
+
+- Using default AWS account structure without proper tagging
+strategy for ML resources.
+- Not separating costs between development, training, and
+production environments.
+- Failing to automate tagging as part of resource provisioning.
+- Overlooking unused or idle resources that continue to incur
+costs.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear visibility into costs associated with different ML
+activities.
+- Ability to allocate costs to appropriate business units or
+projects.
+- Improved forecasting and budgeting for ML initiatives.
+- Identification of cost-saving opportunities across the ML
+lifecycle.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Monitoring and optimizing costs for machine learning workloads
+requires a systematic approach to resource tagging and usage
+tracking. ML workloads typically have distinct phases—development,
+training, inference, and experimentation—each with different
+resource requirements and cost profiles. By implementing a
+comprehensive tagging strategy, you can track and attribute costs
+to specific ML activities, making it more straightforward to
+understand where your cloud spend is going and identify
+opportunities for optimization.
+
+AWS provides various tools and services to implement cost
+monitoring for ML workloads. With proper tagging, you can generate
+detailed cost reports, set up budgets with alerts, and make
+data-driven decisions about resource allocation. This practice is
+particularly important for ML workloads, which can be
+compute-intensive and potentially costly if not properly managed.
+
+### Implementation steps
+
+- **Establish a tagging strategy for ML
+resources**. Create a consistent tagging schema
+that captures relevant dimensions for ML activities. Include
+tags for project name, environment (development, testing,
+and production), ML phase (training, inference, and
+experiment), owner, and cost center. Document this strategy
+and verify that your team members understand and follow it
+when creating resources.
+- **Implement AWS tagging**. A
+[tag](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+is a label that you or AWS assigns to an AWS resource. Each
+tag consists of a key and a value. For each resource, each
+tag key must be unique, and each tag key can have only one
+value. You can use tags to organize your resources, and cost
+allocation tags to track your AWS costs on a detailed level.
+AWS uses the cost allocation tags to organize your resource
+costs on your cost allocation report. This streamlines
+categorizing and tracking your AWS costs. AWS provides two
+types of cost allocation tags, an AWS-generated tag and
+user-defined tags.
+- **Activate cost allocation
+tags**. After creating your tags, you need to
+activate them for cost tracking in the AWS Billing and Cost Management and Cost
+Management console. Note that it can take up to 24 hours for
+new tags to appear in your billing reports.
+- **Automate resource
+tagging**. Use AWS CloudFormation templates, AWS CDK, or Terraform to automate the application of tags when
+provisioning resources. For SageMaker AI resources, implement
+tagging in your deployment pipelines and notebook
+initialization scripts. Consider using AWS Tag Editor for
+bulk tagging operations on existing resources.
+- **Use AWS Budgets to keep track of
+cost**. AWS Budgets can track your Amazon SageMaker AI cost, including development, training, and hosting. You
+can also set alerts and get a notification when your cost or
+usage exceeds (or is forecasted to exceed) your budgeted
+amount. After you create your budget, you can track the
+progress on the AWS Budgets console.
+- **Implement cost monitoring and
+reporting**. Use AWS Cost Explorer to visualize and
+analyze your ML costs across different dimensions. Create
+custom reports filtered by your ML activity tags to
+understand spending patterns. Schedule regular exports of
+cost reports for stakeholders review.
+- **Establish cost optimization
+processes**. Regularly review resource utilization
+and costs to identify optimization opportunities. Implement
+automated shutdown of idle resources such as SageMaker AI
+notebooks when not in use. Consider using SageMaker AI Managed
+Spot Training to reduce training costs by up to 90%.
+- **Create governance for
+tagging**. Use AWS Config Rules or AWS CloudFormation Hooks to enforce tagging policies. Implement
+processes to review and correct untagged or incorrectly
+tagged resources. Consider using AWS Organizations Tag
+Policies to standardize tags across multiple accounts.
+- **Implement enhanced cost tracking
+with improved tagging**. Use enhanced AWS tagging
+capabilities with better automation and governance features
+to make your cost allocation more consistent across ML
+workloads and improve your visibility into spending
+patterns.
+- **Use cost optimization
+services**. Use AWS Cost Anomaly Detection to
+identify unusual spending patterns in your ML workloads.
+Consider AWS Compute Optimizer for recommendations on
+right-sizing your ML compute resources based on historical
+utilization data.
+
+## Resources
+
+**Related documents:**
+
+- [Organizing
+and tracking costs using AWS cost allocation tags](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
+- [Managing
+your costs with AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [Getting
+started with AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html)
+- [What
+is Tag Editor?](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+- [Best
+Practices for Tagging AWS Resources](https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/tagging-best-practices.html)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 1: Overview](https://aws.amazon.com/blogs/machine-learning/part-1-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-1/)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 4: Training jobs](https://aws.amazon.com/blogs/machine-learning/part-4-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-4-training-jobs/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp01.html*
+
+---
+
+# MLCOST06-BP02 Monitor return on investment for ML models
+
+Once a model is deployed into production, establish a reporting
+capability to track the value which is being delivered. For example:
+
+- **If a model is used to support customer
+acquisition:** How many new customers are acquired and what
+is their spend when the model's advice is used compared with a
+baseline?
+- **If a model is used to predict
+when maintenance is needed:** What savings are being made
+by optimizing the maintenance cycle?
+
+Effective reporting compares the value delivered by an ML model
+against the ongoing runtime cost and to take appropriate action. If
+the ROI is substantially positive, are there ways in which this
+might be scaled to similar challenges, for example. If the ROI is
+negative, could this be addressed by remedial action, such as
+reducing the model latency by using serverless inference, or
+reducing the run time cost by changing the compromise between model
+accuracy and model complexity, or layering in an additional simpler
+model to triage or filter the cases that are submitted to the full
+model.
+
+**Desired outcome:** By implementing
+this practice, you establish a clear line of sight between your ML
+investments and business outcomes. You can continuously track the
+value delivered by your ML models in terms of measurable business
+KPIs, enabling data-driven decisions about scaling successful
+models, optimizing underperforming ones, or sunsetting those with
+negative ROI. Your organization has transparency into the
+cost-effectiveness of ML initiatives and can strategically allocate
+resources based on proven business value.
+
+**Common anti-patterns:**
+
+- Deploying ML models without defining success metrics or business
+KPIs.
+- Focusing only on technical metrics like accuracy without linking
+to business outcomes.
+- Measuring ROI only once after initial deployment rather than
+continuously.
+- Failing to account for the full costs of ML model operation in
+ROI calculations.
+- Ignoring opportunities to scale successful models to similar
+business challenges.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear visibility into the business value generated by ML
+investments.
+- Ability to make data-driven decisions about model optimization
+or retirement.
+- Improved accountability for ML investments across the
+organization.
+- Better allocation of ML resources to high-impact use cases.
+- Enhanced stakeholder confidence in ML initiatives through
+transparent reporting.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Monitoring the return on investment for your ML models requires an
+intentional approach that connects technical model performance
+with tangible business outcomes. You need to establish a
+continuous feedback loop between model operations and business
+metrics to understand the true value being generated. This means
+going beyond traditional ML metrics like accuracy or precision and
+focusing on how the model's predictions translate into business
+results.
+
+Start by defining clear business KPIs that your model is expected
+to influence before deployment. These KPIs should be measurable
+and directly tied to business objectives, such as increased
+revenue, reduced costs, or improved customer satisfaction. For
+customer acquisition models, track metrics like conversion rates,
+customer lifetime value, and acquisition costs. For predictive
+maintenance models, measure metrics like maintenance cost savings,
+reduced downtime, and extended equipment lifespan.
+
+Once deployed, collect data on both the model's performance and
+these business metrics to establish correlation between the two.
+Use A/B testing where possible to compare outcomes with and
+without the model's influence. This can isolate the specific
+impact of your ML investment against other factors that might
+affect business outcomes.
+
+Regularly review the ROI of your models and be prepared to take
+action based on the findings. For models with strong positive ROI,
+explore opportunities to scale the approach to similar business
+problems or increase the scope of the current implementation. For
+models with marginal or negative ROI, consider optimization
+strategies like reducing inference costs through more efficient
+infrastructure, simplifying model complexity while maintaining
+acceptable accuracy, or implementing a multi-tiered approach where
+simpler models handle routine cases and complex models only
+process edge cases.
+
+### Implementation steps
+
+- **Define business-oriented success
+metrics.** Before deploying your ML model, clearly
+define the business KPIs that will be used to measure its
+impact. Work with business stakeholders to connect these
+metrics directly to business outcomes and measure them
+practically. For example, for a customer churn prediction
+model, success metrics might include reduction in churn
+rate, increase in retention-driven revenue, and decreased
+cost of retention campaigns.
+- **Establish baseline
+performance.** Measure and document the current
+performance on your defined KPIs before implementing the ML
+model. This baseline is essential for determining the
+incremental value the model delivers. Consider using A/B
+testing approaches where feasible, sending some cases
+through the ML-driven process and others through the
+traditional approach.
+- **Implement data collection
+pipelines.** Set up automated data collection for
+both model metrics and business outcomes. Use AWS services
+like
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor technical aspects of your model
+and
+[Amazon Kinesis](https://aws.amazon.com/kinesis/) to capture business event data. Store this
+data in [Amazon S3](https://aws.amazon.com/s3/) or
+[Amazon Redshift](https://aws.amazon.com/redshift/) for further analysis.
+- **Create ROI dashboards using Quick.** Develop business-focused dashboards
+in
+[Quick](https://aws.amazon.com/quicksight/) that visualize the relationship between
+model performance and business outcomes. Include metrics
+that show both the value generated (increased revenue, cost
+savings) and costs incurred (infrastructure, maintenance,
+human review). Use QuickSight's ML Insights to automatically
+identify trends and anomalies in your ROI data.
+- **Schedule regular ROI
+reviews.** Establish a cadence for reviewing model
+ROI with both technical and business stakeholders. These
+reviews should assess whether the model continues to deliver
+positive business impact and identify opportunities for
+optimization. Use these sessions to make data-driven
+decisions about continuing investment, scaling successful
+approaches, or adjusting underperforming models.
+- **Optimize underperforming
+models.** For models not meeting ROI targets,
+implement strategic improvements. Consider
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) Serverless Inference to reduce costs for
+infrequent or variable workloads. Explore model compression
+techniques like
+[SageMaker AI
+Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to improve inference efficiency without
+sacrificing accuracy. Implement tiered prediction approaches
+where simple, low-cost models filter cases before routing to
+more complex models.
+- **Scale successful models.**
+When models demonstrate strong positive ROI, look for
+opportunities to expand their impact. Apply similar modeling
+approaches to related business problems, increase the scope
+of existing models, or integrate the model with additional
+business processes to maximize value creation.
+- **Use enhanced QuickSight capabilities
+for ROI analysis**. Use improved
+[Quick](https://aws.amazon.com/quicksight/) with generative AI insights and natural
+language query capabilities to automatically identify
+trends, anomalies, and optimization opportunities in your
+ROI data.
+- **Use generative AI for enhanced
+insights.** Use generative AI capabilities through
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to analyze patterns in your ROI data and
+suggest optimization strategies. Generative AI can identify
+non-obvious correlations between model configurations and
+business outcomes, leading to better ROI optimization
+decisions.
+
+## Resources
+
+**Related documents:**
+
+- [What
+is Quick?](https://docs.aws.amazon.com/quicksight/latest/user/welcome.html)
+- [Publish
+custom metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [What
+are AWS Cost and Usage Reports?](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html)
+- [Quick](https://aws.amazon.com/quicksight/)
+- [Cost
+Optimization Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp02.html*
+
+---
+
+# MLCOST06-BP03 Monitor endpoint usage and right-size the instance fleet
+
+Use efficient compute resources to run models in production. Monitor
+your endpoint usage and right-size the instance fleet. Use automatic
+scaling (auto scaling) for your hosted models. *Auto
+scaling* dynamically adjusts the number of instances
+provisioned for a model in response to changes in your workload.
+
+**Desired outcome:** You have
+optimized SageMaker AI endpoints that automatically adjust to workload
+demands while maintaining performance and minimizing costs. Your
+model deployment uses appropriately sized instances that are neither
+over-provisioned nor under-provisioned, and you have continuous
+monitoring in place to inform scaling decisions.
+
+**Common anti-patterns:**
+
+- Provisioning static endpoint configurations that remain
+unchanged regardless of workload fluctuations.
+- Over-provisioning instances "just to be safe"
+without analyzing actual resource utilization.
+- Ignoring endpoint metrics and failing to adjust resource
+allocation based on usage patterns.
+- Deploying resources across different Availability Zones without
+consideration for data transfer costs.
+- Using default instance types without evaluating performance
+requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced compute costs by reducing over-provisioned resources.
+- Improved performance during peak usage periods through automatic
+scaling.
+- Higher resource utilization through right-sizing.
+- Increased availability by distributing instances across
+Availability Zones.
+- Better understanding of model usage patterns to inform future
+optimizations.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Monitoring and optimizing your SageMaker AI endpoints is essential
+for maintaining cost-efficiency while providing high availability
+and performance. By implementing CloudWatch monitoring and auto
+scaling, your deployments use only the resources they needs when
+they need them. Start by establishing baseline metrics for your
+endpoints to understand typical usage patterns and resource
+requirements. Then implement auto scaling policies based on these
+metrics to automatically adjust capacity in response to changing
+workloads.
+
+For production environments, distribute your endpoint deployment
+across multiple Availability Zones to maintain high availability.
+Consider the placement of related resources, such as data storage
+solutions like FSx for Lustre, to minimize cross-AZ data transfer
+costs and optimize performance. Regular review of your metrics and
+scaling configurations assists you to continuously refine your
+deployment for optimal cost and performance.
+
+### Implementation steps
+
+- **Monitor Amazon SageMaker AI endpoints
+with Amazon CloudWatch**. You can monitor Amazon SageMaker AI using
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), which collects raw data and processes it
+into readable, near real-time metrics. Use metrics such as
+CPUUtilization, GPUUtilization, MemoryUtilization, and
+DiskUtilization to view your endpoint's resource utilization
+and make informed decisions about right-sizing your endpoint
+instances. Set up CloudWatch dashboards to visualize these
+metrics over time and identify patterns in resource usage.
+- **Implement CloudWatch alarms for
+proactive monitoring**. Configure alarms for key
+metrics that can indicate when an endpoint is
+under-provisioned or over-provisioned. For example, set up
+alarms that go off when CPU utilization consistently exceeds
+80% (indicating potential under-provisioning) or remains
+below 20% (indicating over-provisioning). These alarms can
+notify your team to take action or run automated responses
+through AWS Lambda functions.
+- **Configure auto scaling for SageMaker AI
+endpoints**.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) supports auto scaling that monitors your
+workloads and dynamically adjusts capacity to maintain
+steady performance at the lowest possible cost. When
+workload increases, auto scaling brings more instances
+online. When workload decreases, auto scaling removes
+unnecessary instances, which can reduce compute costs.
+Define appropriate scaling policies based on your
+application's requirements, including minimum and maximum
+instance counts, target metrics, and scale-in and scale-out
+cooldown periods.
+- **Distribute instances across
+Availability Zones**. SageMaker AI automatically
+attempts to distribute your instances across Availability
+Zones, so deploy multiple instances for each production
+endpoint to provide high availability. If you're using a
+VPC, configure at least two subnets in different
+Availability Zones to allow SageMaker AI to distribute your
+instances across those zones, providing resilience against
+zone failures.
+- **Optimize resource placement for data
+access**. When using
+[Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) as an input data source for SageMaker AI,
+deploy FSx for Lustre and SageMaker AI in the same Availability
+Zone to avoid cross-AZ data transfer costs. This
+configuration removes the initial Amazon S3 download step,
+accelerating ML training jobs while minimizing costs.
+Consider similar placement strategies for other related
+resources to optimize performance and cost.
+- **Regularly review and adjust instance
+types**. Periodically evaluate whether your
+selected instance types are appropriate for your workload.
+SageMaker AI offers a variety of
+[instance
+types](https://aws.amazon.com/sagemaker/pricing/) optimized for different workload
+characteristics. Analyze your CloudWatch metrics to
+determine if you could achieve better price-performance by
+switching to a different instance family, such as
+compute-optimized, memory-optimized, or GPU instances.
+- **Use inference optimization
+techniques**. Implement model optimization
+techniques such as
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize models for
+your target hardware, improving performance and potentially
+allowing you to use smaller instance types. Consider
+techniques like model compression, quantization, and
+batching to improve inference efficiency and throughput.
+- **Use enhanced SageMaker AI Inference
+Recommender**. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) with enhanced algorithms and
+support for multi-model endpoints to get sophisticated
+instance selection and cost optimization recommendations.
+- **Implement specialized instance types
+for generative AI models**. For large language
+models and other generative AI workloads, use specialized
+instances like
+[AWS Inferentia](https://aws.amazon.com/machine-learning/inferentia/) or
+[AWS Trainium](https://aws.amazon.com/machine-learning/trainium/), which are designed specifically for machine
+learning inference and training. These instances can provide
+significant cost savings compared to general-purpose GPU
+instances when running transformer-based models. Consider
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for fully managed generative AI capabilities
+with built-in scaling.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI metrics in Amazon CloudWatch](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html)
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [AWS Inferentia](https://aws.amazon.com/machine-learning/inferentia/)
+- [Best
+practices for deploying models on SageMaker AI Hosting
+Services](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp03.html*
+
+---
+
+# MLCOST06-BP04 Enable debugging and logging
+
+Implementing comprehensive logging and debugging capabilities for
+your machine learning workflows assists you to understand resource
+consumption patterns and identify optimization opportunities. By
+collecting and analyzing runtime metrics, you can reduce costs and
+enhance the efficiency of your ML training operations.
+
+**Desired outcome:** You gain
+visibility into training jobs through metrics and logs that reveal
+resource consumption patterns. This practice identifies optimization
+opportunities, reduces costs, and improves ML model training
+performance. You implement monitoring systems to track compute and
+storage utilization, and instrument code to record key metrics.
+
+**Common anti-patterns:**
+
+- Training ML models without performance visibility.
+- Ignoring resource consumption data until costs become
+problematic.
+- Deploying ML solutions without adequate logging infrastructure.
+- Using manual methods to track performance metrics.
+- Waiting for issues to arise before implementing monitoring.
+
+**Benefits of establishing this best
+practice:**
+
+- Early identification of model training inefficiencies.
+- Reduced compute and storage costs through resource optimization.
+- Faster troubleshooting of training job issues.
+- Enhanced visibility into ML pipelines.
+- Data-driven decisions for infrastructure provisioning.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Proper debugging and logging are crucial for cost management in
+machine learning workflows. As ML models grow in complexity, the
+computational resources required for training also increase. By
+implementing comprehensive monitoring, you can identify
+inefficiencies, optimize resource allocation, and reduce overall
+costs.
+
+Effective logging and debugging require instrumentation at
+multiple levels, from the ML code itself to the underlying
+infrastructure. This visibility provides an understanding of how
+resources are being utilized during training jobs and identifies
+bottlenecks so that you can make data-driven decisions about when
+and how to scale resources. The metrics and logs collected can
+reveal patterns of inefficient resource utilization that might
+otherwise go unnoticed.
+
+Additionally, monitoring storage consumption is important as data
+preparation and feature engineering can generate large
+intermediate datasets. By tracking both compute and storage
+metrics, you can identify opportunities for optimization across
+your entire ML pipeline.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI
+Debugger**.
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) captures training job states at
+regular intervals, providing visibility into the ML training
+process. It monitors, records, and analyzes data during
+training, enabling you to:
+
+Track model parameters, gradients, and tensor values
+- Identify training issues like vanishing gradients or
+tensor explosions
+- Receive automated alerts for common training problems
+- Visualize and analyze captured data interactively
+
+- **Implement CloudWatch
+logging**. Integrate
+[Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html) with your SageMaker AI training jobs to
+centralize and analyze log data. Configure CloudWatch to:
+
+Collect standard output and error logs from training
+jobs
+- Encrypt log data using an
+[AWS KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html) for security
+- Set up custom log groups and streams for different ML
+workflows
+- Create log retention policies to manage storage costs
+
+- **Instrument ML code for metrics
+collection**. Add instrumentation code to your ML
+training scripts to capture performance metrics and resource
+utilization data:
+
+Track timing information for different training phases
+- Monitor memory usage during training operations
+- Record batch processing statistics and convergence
+metrics
+- Log hyperparameter values and their impact on training
+performance
+
+- **Configure resource
+monitoring**. Set up monitoring for compute and
+storage resources used by your ML workflows:
+
+Use CloudWatch metrics to track instance utilization
+- Monitor data transfer volumes between storage and
+compute resources
+- Set up alerts for abnormal resource consumption patterns
+- Create dashboards to visualize resource utilization
+trends
+
+- **Implement automated
+alerting**. Configure notification systems to alert
+you when resource consumption exceeds expected thresholds:
+
+Set up CloudWatch alarms for high CPU, memory, or GPU
+utilization
+- Create alerts for extended training job durations
+- Configure notifications for storage capacity issues
+- Establish alerting for debugging rule violations in
+SageMaker AI Debugger
+
+- **Analyze and optimize training
+jobs**. Use the collected metrics and logs to
+identify optimization opportunities:
+
+Review resource utilization patterns to identify
+right-sizing opportunities
+- Analyze training job logs for inefficient code paths
+- Examine data loading and preprocessing bottlenecks
+- Optimize hyperparameters based on performance metrics
+
+- **Use enhanced debugging
+capabilities**. Use improved SageMaker AI Studio
+debugging and monitoring capabilities with better
+integration to popular ML frameworks and enhanced
+visualization tools for more efficient troubleshooting.
+- **Use generative AI for log
+analysis**. Use generative AI capabilities to
+analyze and extract insights from ML training logs. Utilize
+Q Diagnostics integrated into the console or your preferred
+IDE for log analysis.
+
+Implement natural language processing to summarize log
+patterns
+- Use Amazon Bedrock to build intelligent log analysis
+assistants
+- Deploy ML models that can predict resource needs based
+on historical data
+- Create automated reports of cost optimization
+opportunities from log data
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html)
+- [What
+is Amazon CloudWatch Logs?](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
+- [Analyzing
+log data with CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html)
+- [Logging
+and Monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-incident-response.html)
+- [Logging
+Amazon ML API Calls with AWS CloudTrail](https://docs.aws.amazon.com/machine-learning/latest/dg/logging-using-cloudtrail.html)
+- [Amazon SageMaker AI Debugger API](https://sagemaker.readthedocs.io/en/stable/api/training/debugger.html)
+
+**Related examples:**
+
+- [Debugger
+example notebooks](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-debugger))
+- [SageMaker AI
+Debugger GitHub Repository](https://github.com/awslabs/sagemaker-debugger)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp04.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLOPS01.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLOPS01.md
@@ -1,0 +1,466 @@
+# MLOPS01
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLOPS01-BP01 Develop the right skills with accountability and empowerment
+
+Artificial intelligence (AI) has many different and growing
+branches, such as machine learning, deep learning, and computer
+vision. Given the complexity and fast-growing nature of ML
+technologies, plan to hire specialists with the understanding that
+additional training will be needed as ML evolves. Keep teams
+learning new skills, engaged, and motivated while encouraging
+accountability and empowerment. Building ML models is a complex and
+iterative process that can infuse bias or unfair predictions against
+a certain entity. It's important to promote and enforce the ethical
+use of AI across enterprises. AWS provides clear guidance to
+customers for
+[responsible
+AI practices](https://aws.amazon.com/ai/responsible-ai/).
+
+**Desired outcome:** You establish a
+skilled, ethically responsible ML workforce that continuously
+evolves with technology advancements. You create an environment
+where your teams are empowered to innovate with AI/ML while
+maintaining accountability for fair and unbiased AI solutions. Your
+organization develops a strong foundation in ML concepts, end-to-end
+lifecycle processes, and efficient use of AWS ML infrastructure and
+tools, enabling you to maximize business value through ethical and
+responsible AI implementation.
+
+**Common anti-patterns:**
+
+- Hiring ML specialists without a continuous learning plan.
+- Focusing only on technical skills while ignoring ethical
+considerations.
+- Creating siloed ML teams without cross-functional collaboration.
+- Assuming ML models are inherently unbiased and fair.
+
+**Benefits of establishing this best
+practice:**
+
+- Increased innovation through skilled and empowered ML teams.
+- Reduced risk of biased or unfair AI predictions.
+- Improved ability to adapt to rapidly evolving ML technologies.
+- Greater business value through responsible and ethical AI
+implementation.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Building a successful ML workforce requires a comprehensive
+approach that includes both technical and ethical skill
+development. Organizations must invest in continuous learning
+across various ML domains while also establishing clear
+accountability frameworks for responsible AI. By developing these
+capabilities together, you can maximize the benefits of ML while
+minimizing potential risks.
+
+Creating an environment that fosters innovation while maintaining
+ethical standards is essential for sustainable ML success. This
+includes establishing clear guidelines for model development,
+testing for bias, and providing explainability of AI decisions.
+Cross-functional teams that combine technical expertise with
+domain knowledge and ethical considerations will deliver the most
+robust ML solutions.
+
+As ML technologies evolve rapidly, your organization must remain
+adaptable and committed to ongoing skill development. This
+includes staying current with AWS's latest ML services, tools, and
+best practices while also keeping pace with advances in
+responsible AI methodologies.
+
+### Implementation steps
+
+- **Develop comprehensive ML skills
+training programs**. Create structured learning
+paths for different roles within your ML teams. Provide
+training on fundamental ML concepts and algorithms,
+end-to-end ML lifecycle processes, and efficient use of ML
+infrastructure with
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/). Include training on AI-assisted
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) for code generation and productivity
+enhancement. Incorporate specialized training in areas
+aligned with your business needs, such as computer vision,
+natural language processing (NLP), and reinforcement
+learning. Utilize resources like
+[AWS Skill Builder](https://aws.amazon.com/training/learn-about/), and
+[Amazon Machine Learning University](https://www.amazon.science/tag/machine-learning-university-mlu)
+- **Establish cross-functional ML
+teams**. Form diverse teams with specialists from
+multiple disciplines including data science, engineering,
+ethics, legal, and domain experts. This multidisciplinary
+approach provides a holistic perspective on ML
+implementation and identifies potential issues early in the
+development process. Encourage collaboration across teams to
+share knowledge, best practices, and lessons learned from ML
+initiatives.
+- **Implement bias detection and
+fairness protocols**. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) to detect and mitigate bias in your
+datasets and model predictions. Establish guidelines for
+evaluating models for fairness across different demographic
+groups and protected attributes. Create checkpoints
+throughout the ML lifecycle to assess and address potential
+bias before models are deployed into production
+environments.
+- **Create an ML ethics
+framework**. Develop clear guidelines and
+principles for ethical AI use within your organization.
+Establish an AI Ethics Board comprising representatives from
+legal, ethics, IT, data science, and key business units.
+Their responsibility should include creating policies for
+responsible AI implementation, providing guidance on complex
+ethical questions, and improving adherence to relevant
+regulations and industry standards.
+- **Foster accountability through
+documentation and governance**. Implement
+comprehensive documentation processes for each aspect of the
+ML lifecycle, including data sources, model development
+decisions, testing procedures, and deployment criteria.
+Create clear ownership and accountability structures for ML
+projects, with designated responsibilities for model
+performance, fairness, and explainability. Use
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model details,
+intended uses, limitations, and ethical considerations.
+- **Empower continuous learning and
+experimentation**. Create opportunities for teams
+to expand their ML knowledge through immersion days,
+hackathons, certification programs, and participation in the
+broader ML community. Establish sandboxed environments using
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) for integrated data and AI
+workflows where teams can experiment with new ML techniques
+and tools without risk to production systems.
+- **Measure and improve ML
+operations**. Implement metrics to evaluate the
+effectiveness of your ML teams and processes, including
+model performance, development efficiency, and ethics.
+Regularly review these metrics to identify areas for
+improvement and adjust your approach accordingly. Establish
+feedback loops that incorporate insights from model
+performance in production to continuously refine both
+technical implementations and team capabilities.
+- **Implement responsible generative AI
+practices**. As you explore generative AI
+capabilities, establish clear guardrails for using large
+language models and other generative technologies. Use
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to access foundation models through a single
+API with enterprise-grade security and compliance features.
+Implement content filtering, safety measures, and human
+review processes for generative AI outputs to align with
+your organization's values and ethical standards.
+
+## Resources
+
+**Related documents:**
+
+- [AWS ML Certification Paths](https://aws.amazon.com/certification/certified-machine-learning-specialty/)
+- [AWS Ramp-Up Guides for Machine Learning](https://aws.amazon.com/training/ramp-up-guides/)
+- [Create
+a model card](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards-create.html)
+- [Configure
+a SageMaker AI Clarify Processing Job](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-configure-parameters.html)
+- [Responsible
+use of Artificial Intelligence and Machine Learning](https://aws.amazon.com/ai/responsible-ai/)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [Building
+ML excellence: A practical training guide for Amazon SageMaker AI](https://aws.amazon.com/blogs/training-and-certification/building-ml-excellence-a-practical-training-guide-for-amazon-sagemaker-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops01-bp01.html*
+
+---
+
+# MLOPS01-BP02 Discuss and agree on the level of model explainability
+
+Establish clear expectations with business stakeholders about the
+level of model explainability needed for your machine learning use
+case. Explainability provides an understanding of how and why a
+model makes predictions, which builds trust, enables auditing, and
+supports adherence to regulatory requirements.
+
+**Desired outcome:** You establish
+explainability requirements early in your machine learning project
+lifecycle. You implement appropriate methods to provide the agreed
+level of model explainability, building stakeholder trust and
+improving your adherence to regulations. You use explainability
+metrics in your evaluations and tradeoff analyses, verifying that
+the model meets business needs while remaining interpretable.
+
+**Common anti-patterns:**
+
+- Treating explainability as an afterthought rather than a core
+requirement.
+- Choosing the most complex model without considering
+explainability requirements.
+- Failing to establish explainability metrics before model
+development.
+- Neglecting to communicate model decisions in terms
+understandable to business stakeholders.
+
+**Benefits of establishing this best
+practice:**
+
+- Increased stakeholder trust in model predictions.
+- Better ability to troubleshoot and improve models.
+- Enhanced ability to detect and address model biases.
+- Improved model adoption by users who understand how decisions
+are made.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When implementing machine learning models, you need to balance
+prediction accuracy with explainability. Highly complex models
+like deep neural networks might provide superior predictive
+performance but often function as an opaque system, making their
+decision-making processes difficult to interpret. In contrast,
+simpler models like decision trees offer greater transparency but
+may sacrifice some accuracy.
+
+The appropriate level of explainability depends on your specific
+use case. In regulated industries like healthcare, finance, or
+insurance, high explainability might be mandatory for
+compliance-aligned reasons. For applications where human safety or
+significant financial decisions are involved, understanding why a
+model made a specific prediction becomes critical.
+
+Work with your business stakeholders to understand their
+explainability requirements before selecting modeling approaches.
+Consider both technical and non-technical aspects of
+explainability - technical stakeholders may need detailed feature
+importance measures, while business users might need simple,
+intuitive explanations of model decisions.
+
+### Implementation steps
+
+- **Understand business requirements for
+explainability**. Meet with stakeholders to
+determine how much transparency is needed based on use case,
+industry regulations, and business objectives. In regulated
+industries like healthcare and finance, regulations often
+mandate that automated decisions be explainable to affected
+individuals.
+- **Evaluate model types based on
+explainability needs**. Consider inherently
+interpretable models (linear regression, decision trees) for
+high explainability requirements, or more complex models
+with following explanation techniques when higher accuracy
+is the priority.
+- **Set up SageMaker AI
+Clarify**. Implement Amazon SageMaker AI Clarify to
+create explainability reports and detect potential biases in
+your datasets or models. Clarify includes enhanced bias
+detection and new fairness metrics for more comprehensive
+explainability analysis. SageMaker AI Clarify integrates
+with SageMaker AI's model building, training, and deployment
+capabilities.
+- **Choose appropriate SHAP
+baselines**. Shapley Additive exPlanations (SHAP)
+values determine how each feature contributes to
+predictions. Configure appropriate baselines in SageMaker AI
+Clarify based on your data characteristics. You can choose
+baselines with "low information content" (for
+example, average values from the training dataset) or high
+information content (representing a specific class of
+interest).
+- **Generate and interpret feature
+attribution reports**. Use SageMaker AI Clarify to
+generate feature attribution reports showing which features
+most influenced model predictions and how they did so.
+Review these reports with stakeholders to verify that they
+provide the required level of understanding.
+- **Create user-friendly explanation
+interfaces**. Develop appropriate visualization
+tools or explanation interfaces that present model insights
+in ways that are meaningful to various stakeholders, from
+data scientists to business users.
+- **Implement continuous explainability
+monitoring**. Set up ongoing monitoring of model
+explanations to detect drift in feature importance or
+unexpected behavior patterns over time.
+- **Apply responsible AI principles to
+generative models**. For generative AI
+applications, implement additional explainability measures
+such as prompt transparency, citation of sources, and
+confidence scores to assist users in understanding how
+outputs were generated.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Configure
+a SageMaker AI Clarify Processing Job](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-configure-parameters.html)
+- [SHAP
+Baselines for Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-feature-attribute-shap-baselines.html)
+- [Explain
+text classification model predictions using Amazon SageMaker AI
+Clarify](https://aws.amazon.com/blogs/machine-learning/explain-text-classification-model-predictions-using-amazon-sagemaker-clarify/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops01-bp02.html*
+
+---
+
+# MLOPS01-BP03 Monitor model adherence to business requirements
+
+Machine learning models degrade over time due to changes in the real
+world, such as *data drift* and *concept
+drift*. If not monitored, these changes could lead to
+models becoming inaccurate or even obsolete over time. It's
+important to have a periodic monitoring process in place to make
+sure that your ML models continue to comply to your business
+requirements and that deviations are captured and acted upon
+promptly.
+
+**Desired outcome:** You implement a
+robust model monitoring framework that continuously evaluates model
+performance against your business requirements. This enables early
+detection of model drift, keeping your ML models accurate and
+effective over time. You establish clear metrics tied to business
+outcomes and have automated processes to respond to detected drifts,
+minimizing potential negative impacts.
+
+**Common anti-patterns:**
+
+- Implementing monitoring without clear metrics tied to business
+requirements.
+- Focusing only on technical metrics while ignoring business
+impact metrics.
+- Lacking a clear action plan for when drift is detected.
+- Monitoring models infrequently or irregularly.
+- Not establishing thresholds for acceptable levels of drift.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation.
+- Maintained alignment between model outputs and business goals.
+- Reduced risk of financial or operational impact from degraded
+models.
+- Increased stakeholder confidence in deployed ML systems.
+- Improved model lifecycle management.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model monitoring is a critical aspect of maintaining ML systems
+that continue to deliver business value over time. As real-world
+conditions evolve, your models can experience both data drift
+(changes in the distribution of input data) and concept drift
+(changes in the relationship between inputs and outputs). These
+drifts can significantly impact model accuracy and reliability.
+
+To effectively monitor model adherence to business requirements,
+establish a comprehensive monitoring strategy that bridges
+technical metrics with business outcomes. This involves defining
+clear thresholds for acceptable performance, implementing
+automated monitoring solutions, and creating response plans for
+different drift scenarios.
+
+Amazon SageMaker AI Model Monitor provides capabilities to
+automatically monitor models in production and detect deviations
+from the baseline. By using these capabilities, you can
+proactively address potential issues before they impact your
+business operations.
+
+### Implementation steps
+
+- **Define relevant metrics aligned with
+business objectives.** Begin by clearly
+establishing the metrics that are most relevant to your
+business outcomes. Include both technical metrics (like
+accuracy, precision, and recall) and business metrics (like
+revenue impact and customer satisfaction). Make sure these
+metrics directly relate to the business requirements the
+model is expected to fulfill.
+- **Establish baseline performance and
+thresholds.** Create a performance baseline using
+your validation dataset. Using Amazon SageMaker AI Model
+Monitor, you can automatically generate statistics and
+constraints from your baseline data that define normal
+behavior. Set appropriate thresholds that will alert when
+model performance deviates beyond acceptable limits.
+- **Implement automated data quality
+monitoring.** Configure SageMaker AI Model Monitor to
+regularly check the quality of input data against the
+baseline. This can detect data drift that could affect model
+performance. Monitor features for statistical changes in
+distributions, missing values, or other quality issues.
+- **Configure model quality
+monitoring.** Set up monitoring for model outputs
+and quality metrics. SageMaker AI Model Monitor can track
+prediction distributions and performance metrics over time,
+alerting you when they deviate from expected patterns.
+- **Set up bias drift
+detection.** Use SageMaker AI Clarify integration with
+Model Monitor to detect changes in bias metrics over time.
+This keeps your model fair and unbiased as production data
+evolves.
+- **Create visualization
+dashboards.** Implement dashboards using Amazon CloudWatch, Amazon Managed Grafana, or use
+[Quick with GenBI capabilities](https://aws.amazon.com/quicksight/generative-bi/) to automatically
+generate monitoring dashboards. These dashboards should
+present both technical and business metrics in an
+understandable format for stakeholders.
+- **Develop response protocols for drift
+detection.** Create clear action plans for
+different types and severities of detected drift. These
+might include automated retraining pipelines, manual
+reviews, or temporary fallback strategies depending on the
+scenario.
+- **Implement alert
+mechanisms.** Configure alerts using Amazon CloudWatch to notify appropriate team members when metrics
+exceed thresholds. Check that your alerts provide actionable
+information about the nature and potential impact of the
+drift.
+- **Establish regular review
+processes.** Schedule periodic reviews of
+monitoring results even when no alerts go off. This can
+identify gradual drifts that might not immediately alert but
+could impact performance over time.
+- **Document monitoring systems and
+processes.** Maintain comprehensive documentation
+of your monitoring setup, including metrics definitions,
+thresholds, alert configurations, and response protocols to
+preserve organizational knowledge.
+- **Leverage generative AI for root
+cause analysis.** Use generative AI capabilities to
+analyze complex patterns in your monitoring data and provide
+human-readable explanations of potential drift causes. Tools
+like
+[Amazon
+Bedrock Knowledge Bases](https://aws.amazon.com/bedrock/knowledge-bases/) can interpret changes in
+model behavior and suggest remediation approaches.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Schema
+for Violations (constraint_violations.json file)](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-interpreting-violations.html)
+- [Amazon SageMaker AI metrics in Amazon CloudWatch](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html)
+- [What
+is Amazon CloudWatch?](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html)
+- [Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/)
+- [Amazon SageMaker AI ML Governance](https://aws.amazon.com/sagemaker/ml-governance/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops01-bp03.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLOPS02.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLOPS02.md
@@ -1,0 +1,1118 @@
+# MLOPS02
+
+**Pillar**: Unknown  
+**Best Practices**: 6
+
+---
+
+# MLOPS02-BP01 Establish ML roles and responsibilities
+
+Clearly defining roles, responsibilities, and team interactions in
+machine learning projects creates an efficient operational framework
+that maximizes overall effectiveness. By understanding who does what
+and how teams collaborate, organizations can streamline their ML
+initiatives and deliver better business outcomes.
+
+**Desired outcome:** You establish
+well-defined roles and responsibilities across your ML teams,
+enabling proper collaboration and accountability. You have
+mechanisms to efficiently manage access controls for various ML
+functions, providing your team members access to the tools and
+resources they need while maintaining appropriate security
+boundaries. This creates a foundation for successful ML operations
+that supports both innovation and governance.
+
+**Common anti-patterns:**
+
+- Undefined or overlapping responsibilities causing confusion
+among team members.
+- Relying on a single person to perform ML-related tasks rather
+than building specialized expertise.
+- Over-privileged access controls that compromise security.
+- Manual, one-time processes for managing user permissions that
+don't scale.
+- Siloed teams with poor communication channels between technical
+and business stakeholders.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear accountability and ownership throughout the ML lifecycle.
+- Improved collaboration between technical and business teams.
+- Streamlined decision-making processes and faster project
+initiation.
+- Better governance and risk management through proper access
+controls.
+- Enhanced ability to scale ML operations across the organization.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing clear ML roles and responsibilities requires
+thoughtful planning about how teams will work together throughout
+the entire ML lifecycle. Machine learning projects span multiple
+domains including business expertise, data engineering, model
+development, and operations, each requiring specialized skills.
+Without clearly defined roles, projects often face delays, quality
+issues, or governance challenges.
+
+Begin by identifying which functions are critical for your
+organization's ML initiatives. Consider your business objectives,
+technical requirements, and regulatory constraints. Develop a team
+structure that balances specialization with collaboration,
+allowing for efficient workflows while maintaining appropriate
+separation of duties for governance purposes.
+
+For enterprise-grade ML solutions, establish cross-functional
+teams with clear responsibilities for each role. Consider how
+these roles interact throughout the ML lifecycle and create
+communication channels to facilitate collaboration. Pay special
+attention to governance responsibilities, as these are often
+overlooked in early ML initiatives but become critical as projects
+move into production.
+
+### Implementation steps
+
+- **Map ML functions to organizational
+needs**. Begin by identifying the ML capabilities
+required to support your business objectives. Consider the
+entire ML lifecycle from problem definition through to
+production monitoring. Review your current organizational
+structure and identify gaps in skills or functions that need
+to be addressed. Create a matrix showing the relationship
+between ML functions and existing teams or roles.
+- **Establish cross-functional teams
+with defined roles**. Create a formal structure for
+your ML organization with clear roles and responsibilities
+for each team member. Gather representation from both
+technical and business domains to maintain alignment with
+business outcomes. The following roles should be considered:
+
+**Domain expert:**
+Provides functional knowledge about the business problem
+and validates ML approaches against real-world
+requirements.
+- **Data engineer:**
+Transforms raw data into formats suitable for analysis
+and model training.
+- **Data scientist:**
+Applies statistical modeling and machine learning
+techniques to derive insights from data.
+- **ML engineer:** Converts
+data science prototypes into production-ready software
+systems.
+- **MLOps engineer:**
+Builds automation pipelines for model training, testing,
+and deployment.
+- **IT auditor:** Analyzes
+system access, identifies anomalies, and recommends
+remediations.
+- **Model risk manager:**
+Checks that models meet internal and external control
+requirements.
+- **Cloud security
+engineer:** Configures and manages cloud
+resources with appropriate security controls.
+- **Prompt engineer:**
+Designs effective interactions with foundation models
+for generative AI applications.
+
+- **Implement role-based access
+control**. Design a permissions framework that
+follows the principle of least privilege while enabling
+teams to be productive. Avoid one-time methods for managing
+access policies that don't scale. Instead, use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to efficiently control
+access based on pre-defined templates aligned with your
+organizational roles. This allows administrators to quickly
+create appropriate access policies within minutes, reducing
+the time and effort required to onboard users and manage
+permissions over time.
+- **Establish governance
+processes**. Create clear processes for model
+lifecycle management, including approval workflows,
+validation requirements, and regulatory checks. Document who
+is responsible for key decisions at each stage of
+development. Implement model monitoring mechanisms to track
+performance and alert when intervention is needed. Use
+[Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) to maintain visibility
+across your model inventory and track performance metrics.
+- **Develop collaboration
+frameworks**. Establish standard communication
+channels and collaboration tools to facilitate interaction
+between different roles. Create documentation templates that
+promote knowledge sharing and make handoffs between teams
+more efficient. Schedule regular cross-functional reviews to
+gain alignment throughout the ML lifecycle. Consider using
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) as a collaborative
+environment that unifies data and AI workflows where data
+scientists and engineers can work together.
+- **Train teams on responsibilities and
+interfaces**. Provide training to verify that your
+team members understand not only their own responsibilities
+but also how their work impacts others in the ML lifecycle.
+Create reference materials that clarify handoff points and
+dependencies between different roles. Consider establishing
+a center of excellence or community of practice to share
+knowledge and best practices across teams.
+- **Adapt roles for generative AI
+initiatives**. When implementing generative AI
+projects, consider how traditional ML roles need to adapt.
+Prompt engineers may be needed to design effective
+interactions with foundation models. Ethical AI specialists
+can address concerns around bias, transparency, and
+responsible use. Integration engineers may be required to
+connect foundation models from services like
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) with enterprise applications and data
+sources.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Personas
+for an ML platform](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/personas-for-an-ml-platform.html)
+- [ML
+Learning Paths](https://aws.amazon.com/training/learning-paths/machine-learning/)
+- [Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html)
+- [Why
+should you use MLOps?](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects-why.html)
+- [Amazon SageMaker AI ML Governance](https://aws.amazon.com/sagemaker/ml-governance/)
+- [Define
+customized permissions in minutes with Amazon SageMaker AI
+Role Manager](https://aws.amazon.com/blogs/machine-learning/define-customized-permissions-in-minutes-with-amazon-sagemaker-role-manager/)
+- [New
+ML Governance Tools for Amazon SageMaker AI – Simplify Access
+Control and Enhance Transparency Over Your ML Projects](https://aws.amazon.com/blogs/aws/new-ml-governance-tools-for-amazon-sagemaker-simplify-access-control-and-enhance-transparency-over-your-ml-projects/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp01.html*
+
+---
+
+# MLOPS02-BP02 Prepare an ML profile template
+
+Creating an ML profile template allows you to systematically capture
+machine learning workload characteristics across different lifecycle
+phases. Use this template to evaluate your ML workload's current
+maturity status and strategically plan for improvements that align
+with your business requirements.
+
+**Desired outcome:** You gain a
+comprehensive understanding of your ML workload's deployment
+characteristics by creating templated profiles that capture critical
+metrics and thresholds. By maintaining current and target profiles,
+you can effectively track your ML workload maturity journey and make
+data-driven decisions about architecture, resources, and deployment
+options that best align with your business needs.
+
+**Common anti-patterns:**
+
+- Creating ML profiles without clear thresholds or maturity
+rankings.
+- Failing to document rationale for architectural and deployment
+choices.
+- Focusing on technical metrics without connecting to business
+requirements.
+- Not considering future state or alternative deployment options.
+- Ignoring cost implications of different deployment scenarios.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables objective assessment of ML workload maturity status.
+- Provides a structured approach to planning ML workload
+improvements.
+- Creates alignment between technical implementation and business
+requirements.
+- Facilitates better resource planning and cost optimization.
+- Supports strategic decision-making with documented rationale.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning workloads have unique characteristics that impact
+their deployment architecture, infrastructure requirements, and
+operational management. Create a standardized ML profile template
+to document these characteristics systematically across the stages
+of the ML lifecycle. By capturing key metrics and establishing
+thresholds, you can objectively assess the maturity level of your
+ML workloads and identify areas for improvement.
+
+For each ML workload, you should maintain at least two profiles:
+one representing the current state and another representing the
+target or future state. This approach creates a clear path for
+improvement while documenting the rationale behind architectural
+and deployment decisions.
+
+When developing your ML profile template, focus on the most
+impactful characteristics that influence infrastructure choices,
+deployment options, and operational considerations. Include
+metrics that span model characteristics, architectural decisions,
+and operational requirements. For each characteristic, establish a
+spectrum from lower to higher ranges to position your workload on
+a maturity scale.
+
+### Implementation steps
+
+- **Capture ML workload deployment
+characteristics**. Identify and document the most
+impactful deployment characteristics of your ML workload.
+These characteristics can determine optimal deployment
+architecture, computing requirements, and instance sizing.
+Use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html), which includes more
+sophisticated instance selection algorithms and support for
+multi-model endpoints, to optimize instance selection based
+on your model's performance and cost requirements.
+- **Document model deployment
+characteristics**. Record key metrics about your ML
+models, including:
+
+Model size (model.tar.gz) in bytes
+- Number of models deployed per endpoint
+- Instance size (for example,
+r5dn.4x.large) as suggested by the
+inference recommender
+- Retraining and model endpoint update frequency (hourly,
+daily, weekly, monthly, or per-event)
+- Model deployment location (on premises, Amazon EC2,
+container, serverless, or edge)
+
+- **Map architectural deployment
+characteristics**. Capture information about the
+internal architecture of your ML solution:
+
+Inference pipeline architecture (single endpoint or
+chained endpoints)
+- Neural architecture (single framework like Scikit-learn
+or multi-framework like PyTorch, Scikit-learn,
+TensorFlow)
+- Containers (SageMaker AI prebuilt container, bring your
+own container)
+- Location of containers and models (on premises, cloud,
+or hybrid)
+- Serverless inferencing (pay as you go) options like
+Amazon SageMaker AI Serverless Inference
+- [Inference
+Components](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html) for modular inference pipeline
+architecture (mix and match pre-processing, model
+serving, and post-processing components)
+
+- **Define traffic pattern
+characteristics**. Document how your ML model will
+be used:
+
+Traffic pattern (steady or spiky)
+- Input size (number of bytes)
+- Latency requirements (low, medium, high, or batch)
+- Concurrency needs (single thread or multi-thread)
+
+- **Determine cold start
+tolerance**. Document the acceptable latency for
+cold starts in milliseconds, as this impacts the choice
+between always-on and serverless deployment options.
+- **Evaluate network deployment
+characteristics**. Assess and document
+network-related requirements, including AWS KMS encryption
+needs, multi-variant endpoints, network isolation
+requirements, and use of third-party Docker repositories.
+- **Analyze cost
+considerations**. Document cost considerations for
+different deployment options, including the potential use of
+Amazon EC2 Spot Instances for non-critical workloads, Amazon SageMaker AI Serverless Inference for pay-per-use models, or
+multi-model endpoints for cost sharing.
+- **Create a provisioning
+matrix**. Develop a matrix of expected capacity
+requirements across different environments (development,
+staging, production) and regions. This should include the
+number and types of instances needed for training, batch
+inference, real-time inference, and development notebooks.
+- **Map workload characteristics across
+maturity spectrum**. For each characteristic in
+your profile, establish a spectrum from lower to higher
+maturity. This spectrum positions your current
+implementation and defines targets for improvement.
+- **Document rationale for target
+profile**. Provide clear justification for the
+values selected in your target profile, linking them to
+specific business requirements and expected outcomes.
+- **Evaluate and update profiles
+regularly**. Revisit your ML profiles periodically
+to check that they remain aligned with evolving business
+requirements and to incorporate learnings from production
+experience.
+- **Foundation model deployment
+considerations**. For generative AI workloads,
+include additional profile characteristics such as model
+quantization level, context window requirements, token
+processing speed, and memory footprint using
+[optimized
+foundation model containers](https://docs.aws.amazon.com/sagemaker/latest/dg/large-model-inference.html) to properly size
+infrastructure for these resource-intensive models.
+
+## Resources
+
+**Related documents:**
+
+- [SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [AWS Pricing Calculator - SageMaker AI](https://calculator.aws/#/addService/SageMaker AI)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Amazon EC2 Instance Types](https://aws.amazon.com/ec2/instance-types/)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [Improved
+ML model deployment using Amazon SageMaker AI Inference
+Recommender](https://aws.amazon.com/blogs/machine-learning/improved-ml-model-deployment-using-amazon-sagemaker-inference-recommender/)
+- [Unlock
+cost savings with the new scale down to zero feature in
+SageMaker AI Inference](https://aws.amazon.com/blogs/machine-learning/unlock-cost-savings-with-the-new-scale-down-to-zero-feature-in-amazon-sagemaker-inference/)
+- [Beyond
+the basics: A comprehensive foundation model selection
+framework for generative AI](https://aws.amazon.com/blogs/machine-learning/beyond-the-basics-a-comprehensive-foundation-model-selection-framework-for-generative-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp02.html*
+
+---
+
+# MLOPS02-BP03 Establish model improvement strategies
+
+Planning improvement drivers for optimizing machine learning model
+performance is essential before development begins. By establishing
+a clear strategy for model enhancement, you can systematically
+improve your ML models through techniques like data collection,
+cross-validation, feature engineering, hyperparameter tuning, and
+ensemble methods.
+
+**Desired outcome:** By implementing
+this best practice, you establish a systematic approach for
+improving your machine learning models. You create a structured
+methodology for experimentation that allows you to progressively
+enhance model performance by testing different improvement
+strategies. You gain visibility into which approaches yield the best
+results for your specific use case, enabling you to make data-driven
+decisions about model development and optimization.
+
+**Common anti-patterns:**
+
+- Starting with overly complex models without establishing a
+baseline performance.
+- Ignoring data quality issues and focusing solely on model
+complexity.
+- Making arbitrary hyperparameter changes without systematic
+experimentation.
+- Neglecting to document experimental results and configurations.
+- Implementing advanced techniques without understanding
+fundamental model performance issues.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables structured experimentation and measurable model
+improvements.
+- Provides clarity on which improvement strategies deliver the
+best results.
+- Reduces time spent on ineffective optimization approaches.
+- Creates a systematic pathway from simple to more advanced
+modeling techniques.
+- Identifies the most important features and data for your
+specific business problem.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Effective model improvement requires a structured approach that
+follows a progression from simple to complex. Begin by
+establishing clear performance metrics tied to your business
+objectives, as these will guide your improvement efforts. Develop
+a baseline model using straightforward algorithms and minimal
+feature engineering to set initial performance benchmarks.
+
+Organizing your experiments systematically is crucial. Document
+your approach, model configurations, and results to track
+improvements and understand the impact of different strategies.
+This documentation serves as institutional knowledge that can
+guide future model development and improvement efforts.
+
+Work closely with domain experts who understand the business
+context. Their insights can identify key features, validate model
+outputs, and align your improvements with business objectives.
+Remember that model improvement is an iterative process requiring
+patience and methodical experimentation.
+
+### Implementation steps
+
+- **Create a baseline model with minimal
+complexity**. Start with minimal data cleaning and
+the most obvious data features. Train simple classical
+models using algorithms like linear regression or logistic
+regression for classification tasks. This establishes a
+performance benchmark against which you can measure
+improvements. Use
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to quickly develop these baseline models.
+- **Organize and track experiments using
+MLFlow on Amazon SageMaker AI**. Use
+[Amazon SageMaker AI MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to organize and track multiple
+tests comparing different configurations and algorithms.
+This allows you to maintain a structured approach to
+experimentation and compare results across different model
+versions so you can identify which changes lead to
+meaningful improvements.
+- **Implement effective feature
+selection**. Collaborate with subject matter
+experts to identify the most significant features related to
+target values. Iteratively add more complex features and
+remove less important ones to improve model accuracy and
+robustness. Test different feature engineering techniques
+such as one-hot encoding, normalization, and dimensionality
+reduction to understand their impact on model performance.
+- **Consider deep learning for complex
+patterns**. When you have large volumes of training
+data, consider deep learning models to discover previously
+unknown features and improve model accuracy.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides built-in algorithms for deep
+learning and supports popular frameworks like TensorFlow and
+PyTorch, making it simpler to experiment with neural network
+architectures.
+- **Explore ensemble methods**.
+Ensemble methods can provide further accuracy improvements
+by combining the best characteristics of various algorithms.
+Consider techniques like random forests, gradient boosting,
+or stacking different models. Be aware of the tradeoffs with
+computational performance and maintenance complexity,
+evaluating whether these approaches align with your specific
+business use case.
+- **Apply automatic machine learning
+(AutoML)**. Use
+[Amazon SageMaker AI Canvas](https://aws.amazon.com/sagemaker/canvas/) for no-code/low-code ML model
+development with natural language support for data
+exploration and preparation. Canvas includes
+[Amazon Q integration](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-q-integration.html) for conversational data analysis and
+can directly deploy models to production.
+- **Optimize hyperparameters
+systematically**. Fine-tune hyperparameters for
+each algorithm to obtain optimal performance. Use
+[Amazon SageMaker AI Hyperparameter Optimization](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-how-it-works.html) to automate
+this process through techniques like Bayesian optimization,
+grid search, or random search to find the most effective
+parameter combinations.
+- **Integrate experiments into automated
+workflows**.
+[Automate
+your experimental trials using SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-experiments.html) by
+using the integration with experiments. This fosters
+reproducibility and creates a systematic approach to model
+improvement that can be incorporated into your ML operations
+workflow.
+- **Use generative AI for synthetic data
+creation**. For scenarios with limited training
+data, use generative AI techniques like generative
+adversarial networks (GANs) to create synthetic data that
+can expand your training dataset.
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) provides an expanded library of
+pre-built generative AI models and more industry-specific
+solutions, while
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) offers foundation models that can augment
+your training data, especially for scenarios with limited or
+imbalanced datasets.
+- **For generative AI workloads, apply
+foundation models with RAG for knowledge-intensive
+tasks**. For tasks requiring domain knowledge,
+implement retrieval-augmented generation (RAG) using
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) to enhance foundation models with your
+organization's specific information, combining the power of
+large language models with your proprietary data.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Experiments in Studio Classic](https://docs.aws.amazon.com/sagemaker/latest/dg/experiments.html)
+- [Accelerate
+generative AI development using managed MLFlow on SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Amazon SageMaker AI Experiments Integration](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-experiments.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [LLM
+experimentation at scale using Amazon SageMaker AI Pipelines and
+MLFlow](https://aws.amazon.com/blogs/machine-learning/llm-experimentation-at-scale-using-amazon-sagemaker-pipelines-and-mlflow/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Experiments Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-experiments)
+- [Hyperparameter
+Tuning Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/hyperparameter_tuning)
+- [Ensemble
+Predictions from Multiple Models](https://sagemaker-examples.readthedocs.io/en/latest/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.html)
+- [Amazon SageMaker AI Autopilot Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/autopilot)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp03.html*
+
+---
+
+# MLOPS02-BP04 Establish a lineage tracker system
+
+Maintain a system that tracks changes for each release to enable
+reproducibility, speed up problem diagnosis, and improve regulatory
+adherence. Tracking lineage for model development includes changes
+in documentation, environment, model, data, code, and
+infrastructure.
+
+**Desired outcome:** You have a
+comprehensive lineage tracking system that records the history of
+artifacts involved in your ML model development and deployment
+lifecycle. This system enables you to reproduce previous model
+versions, diagnose issues quickly, roll back to stable versions when
+needed, and improve your regulatory adherence. Your organization can
+trace model results back to their originating data sources, code
+versions, and infrastructure configurations.
+
+**Common anti-patterns:**
+
+- Manually tracking changes in spreadsheets or documents.
+- Not capturing all dependent artifacts necessary for model
+reproduction.
+- Inconsistent tracking practices across teams.
+- Lacking integration between different components of the ML
+pipeline.
+- Failing to track infrastructure and environment configurations.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables reproducibility of model versions for debugging.
+- Accelerates problem diagnosis and resolution when issues arise.
+- Supports regulatory adherence and audit requirements.
+- Facilitates rollback to previous stable versions when needed.
+- Improves collaboration among team members with transparent
+tracking.
+- Enhances model governance and responsible AI practices.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Implementing a comprehensive lineage tracker system is essential
+for maintaining the traceability and reproducibility of your
+machine learning models. Without proper lineage tracking, your
+organization may struggle to debug issues, comply with
+regulations, or reproduce previous model versions when needed. The
+lineage tracker should capture information about components that
+influence your model's behavior, including the data used for
+training, preprocessing steps, hyperparameters, model
+architecture, evaluation metrics, and deployment environment.
+
+A robust lineage tracking system starts with identifying the key
+artifacts that need to be tracked throughout the ML lifecycle.
+Once identified, you can use AWS services like SageMaker AI ML
+Lineage Tracking to automatically record and store the
+relationships between these artifacts. This information becomes
+invaluable when you need to audit your models, reproduce results,
+or diagnose issues in production.
+
+For example, if a model suddenly begins producing unexpected
+results in production, your lineage tracking system should allow
+you to trace back to the exact version of the model, the data it
+was trained on, the code used to train it, and the infrastructure
+configuration at the time of deployment. This comprehensive
+tracking enables faster problem resolution and maintains trust in
+your ML systems.
+
+### Implementation steps
+
+- **Identify artifacts needed for
+tracking**. Begin by identifying artifacts that
+contribute to your model's development and deployment. This
+includes raw data, processed data, feature sets, model
+parameters, code versions, training environments, and
+deployment configurations. Understanding what needs to be
+tracked is essential for meeting regulatory requirements and
+enabling reproducibility. Refer to
+[Data
+and artifacts lineage tracking](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/data-and-artifacts-lineage-tracking.html) for guidance on the
+artifacts to include.
+- **Implement SageMaker AI ML Lineage
+Tracking**. Use
+[Amazon SageMaker AI ML Lineage Tracking](https://docs.aws.amazon.com/sagemaker/latest/dg/lineage-tracking-entities.html) to automatically record
+information about the steps in your ML workflow. SageMaker AI
+tracks relationships between datasets, algorithms, training
+jobs, and model artifacts, enabling you to reproduce
+workflows, track model and dataset lineage, and establish
+governance standards. The service creates entities for your
+ML workflow components and stores their relationships,
+making it more straightforward to audit and verify model
+provenance.
+- **Set up SageMaker AI Unified
+Studio**. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) as your integrated
+development environment that unifies data and AI workflows.
+SageMaker AI Unified Studio provides enhanced collaborative
+features, team sharing capabilities, and visual tools to
+track the lineage of your ML pipelines, making it more
+straightforward to understand the relationships between
+different components across data and AI personas.
+- **Configure SageMaker AI Feature
+Store**. Implement
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to create a centralized
+repository for storing, sharing, and managing features with
+enhanced feature management capabilities. This purpose-built
+repository enables you to organize features in a consistent
+way, making them easily accessible across teams. SageMaker AI
+Feature Store fosters feature consistency between training
+and inference phases without requiring additional code, and
+maintains a record of feature versions over time.
+- **Use SageMaker AI Model
+Registry**. Implement
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog models for
+production, manage model versions, and associate metadata
+with models. The Model Registry enables lineage tracking by
+maintaining a history of model versions, approval status,
+and deployment details. This creates a centralized
+repository for managing model lifecycles, which facilitates
+governance and improves adherence to regulations.
+- **Build ML pipelines with SageMaker AI
+Pipelines**. Create reproducible ML workflows using
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to automate and standardize the
+steps in your ML process. SageMaker AI Pipelines allows you to
+track data history within the pipeline and integrates with
+SageMaker AI ML Lineage Tracking to analyze input data, its
+sources, and generated outputs. This integration creates
+comprehensive lineage tracking across your entire ML
+workflow.
+- **Implement version control
+practices**. Use version control systems like Git
+for code, model configurations, and pipeline definitions.
+Integrate these systems with your lineage tracking to
+properly link code changes to model versions and training
+runs. This practice maintains a complete history of how your
+models have evolved over time.
+- **Establish model attributes for
+training runs**. Use model attributes in SageMaker AI
+to track specific details about your training runs. This
+allows you to compare different experiments, understand
+which parameters led to better model performance, and
+maintain records of training decisions. For more detail, see
+[Using
+model attributes to track your training runs on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/amazon-sagemaker-now-comes-with-new-capabilities-for-accelerating-machine-learning-experimentation/).
+- **Implement access controls and
+auditing**. Set up appropriate access controls for
+your lineage data and implement auditing capabilities to
+track who accesses or modifies lineage information. Use
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) with SageMaker AI Studio to control and
+audit data exploration activities, as demonstrated in this
+[example](https://github.com/aws-samples/amazon-sagemaker-studio-audit).
+- **Develop regular verification
+processes**. Establish procedures to regularly
+verify that your lineage tracking system is capturing
+necessary information for compliance-aligned purposes.
+Create automated reports that demonstrate the completeness
+of your lineage tracking to adhere to regulatory
+requirements.
+- **Foundation model lineage
+tracking**. Consider implementing
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) for tracking lineage in generative AI
+applications. With foundation models becoming increasingly
+important, tracking prompt engineering changes, model
+parameters, and fine-tuning datasets is critical for
+reproducibility and governance of generative AI systems. Use
+Amazon Bedrock's governance features to maintain
+comprehensive lineage tracking when working with foundation
+models.
+
+## Resources
+
+**Related documents:**
+
+- [Lineage
+Tracking Entities](https://docs.aws.amazon.com/sagemaker/latest/dg/lineage-tracking-entities.html)
+- [Track
+the lineage of a pipeline](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-lineage-tracking.html)
+- [MLOps
+Automation With SageMaker AI Projects](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects.html)
+- [Data
+and artifacts lineage tracking](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/data-and-artifacts-lineage-tracking.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+
+**Related examples:**
+
+- [End-to-End
+MLOps with Amazon SageMaker AI](https://github.com/aws-samples/amazon-sagemaker-mlops-workshop)
+- [Controlling
+and auditing data exploration activities with SageMaker AI Studio
+and AWS Lake Formation](https://github.com/aws-samples/amazon-sagemaker-studio-audit)
+- [SageMaker AI
+Feature Store Examples](https://github.com/aws/amazon-sagemaker-examples/tree/master/sagemaker-featurestore)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp04.html*
+
+---
+
+# MLOPS02-BP05 Establish feedback loops across ML lifecycle phases
+
+Establishing feedback loops across machine learning (ML) lifecycle
+phases is essential for continuous improvement of ML workloads. By
+implementing robust mechanisms to share successful experiments,
+analyze failures, and document operational activities, you can
+enhance model performance and adapt to changing data patterns over
+time. Feedback loops can identify model drifts and enable
+practitioners to refine monitoring and retraining strategies,
+allowing for experimentation with data augmentation and different
+algorithms until optimal outcomes are achieved.
+
+**Desired outcome:** You have
+established comprehensive feedback mechanisms across your ML
+lifecycle that facilitate continuous learning and improvement. Your
+organization can detect model drift early, automatically initiate
+retraining when needed, and incorporate human review when
+appropriate. This creates a culture of experimentation where
+successes and failures contribute equally to knowledge advancement,
+improving both model quality and operational efficiency over time.
+
+**Common anti-patterns:**
+
+- Treating model deployment as the final step without ongoing
+evaluation.
+- Failing to document experiments and operational learnings.
+- Ignoring model drift until it significantly impacts performance.
+- Working in silos without sharing insights across ML teams.
+- Lacking automated processes to respond to detected model issues.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation.
+- Reduced manual effort through automated monitoring and
+retraining.
+- Improved model quality through systematic experimentation.
+- Knowledge retention and sharing across teams.
+- Enhanced ability to adapt to changing data patterns.
+- Accelerated innovation through documented learnings.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Feedback loops are crucial to maintaining the effectiveness of ML
+models over time. As real-world data evolves, the performance of
+deployed models can deteriorate due to concept drift or model
+drift. By establishing systematic feedback mechanisms, you can
+monitor these changes, learn from them, and adapt your models
+accordingly.
+
+A comprehensive feedback loop strategy begins with monitoring
+model performance metrics and comparing them against baseline
+expectations. When deviations occur, automated alerts can notify
+teams or run retraining pipelines. The results of these actions
+should be documented to inform future development decisions. This
+creates a continuous cycle of learning where each iteration builds
+upon previous insights.
+
+For example, a financial services company deployed a fraud
+detection model that began showing decreased accuracy after six
+months. Their established feedback system detected this drift,
+automatically started a retraining pipeline using recent data, and
+documented the patterns that caused the drift. Data scientists can
+use this information to improve feature engineering in subsequent
+model versions, resulting in more resilient performance.
+
+Human review is also an essential component of feedback loops,
+especially for sensitive applications. Including human validation
+through tools like Amazon A2I provides ground truth data that can
+be used to further refine models and build trust in automated
+decisions.
+
+### Implementation steps
+
+- **Establish comprehensive model
+monitoring with SageMaker AI Model Monitor**.
+Amazon SageMaker AI Model Monitor provides capabilities to
+continuously monitor the quality of machine learning models
+in production. Configure it to detect data and concept drift
+by comparing production data statistics against the
+baseline. SageMaker AI Model Monitor supports monitoring data
+quality, model quality, bias drift, and feature attribution
+drift, providing a complete view of your model's performance
+over time.
+- **Configure CloudWatch alerts and
+notifications**. Set up
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor metrics generated by SageMaker AI
+Model Monitor and create custom dashboards to visualize
+model performance. Configure CloudWatch Alarms to send
+notifications when thresholds are exceeded, indicating
+potential model drift. These notifications can be delivered
+using SNS topics to email, SMS, or other channels for prompt
+attention.
+- **Implement the SageMaker AI Model
+Dashboard**. Use the
+[SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) as the central interface for
+tracking models and their performance. The dashboard
+provides a comprehensive view of deployed models, their
+endpoints, monitoring schedules, and historical behavior.
+This allows teams to quickly identify issues and understand
+performance trends across multiple models.
+- **Automate retraining
+pipelines**. Create automated retraining workflows
+using
+[AWS Step Functions](https://aws.amazon.com/step-functions/) and
+[SageMaker AI
+Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html). Configure
+[EventBridge
+Events](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html) rules to run these pipelines when SageMaker AI
+Model Monitor detects drift or anomalies. This verifies that
+models are retrained with fresh data when performance begins
+to degrade, maintaining high accuracy with minimal manual
+intervention.
+- **Incorporate human review with Amazon
+A2I**. Implement
+[Amazon
+Augmented AI (A2I)](https://aws.amazon.com/augmented-ai/) to route predictions with low
+confidence scores to human reviewers. This creates a
+human-in-the-loop feedback mechanism where reviewers can
+validate model outputs and provide corrections. The reviewed
+data becomes valuable ground truth that can be used to
+improve model performance in future iterations.
+- **Document and share
+learnings**. Create a knowledge repository using
+services like
+[Quick with GenBI capabilities](https://aws.amazon.com/quicksight/generative-bi/) to automatically
+generate visualizations and dashboards, and
+[Amazon S3](https://aws.amazon.com/s3/) for storing experiment results and operational
+reports. This documentation should include successful
+approaches, failed experiments, and operational insights to
+facilitate knowledge sharing across teams.
+- **Establish regular feedback review
+sessions**. Schedule recurring meetings with
+stakeholders to review monitoring results, discuss model
+performance, and prioritize improvements. These sessions
+should include data scientists, ML engineers, and business
+stakeholders to align between technical improvements and
+business outcomes.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html)
+- [Amazon
+Augmented AI (A2I)](https://aws.amazon.com/augmented-ai/)
+- [Train
+a machine learning model using Amazon SageMaker AI](https://docs.aws.amazon.com/step-functions/latest/dg/sample-train-model.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Creating
+rules that react to events in Amazon EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule.html)
+- [Monitoring
+Amazon ML with Amazon CloudWatch Metrics](https://docs.aws.amazon.com/machine-learning/latest/dg/cw-doc.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp05.html*
+
+---
+
+# MLOPS02-BP06 Review fairness and explainability
+
+Evaluating model fairness and explainability verifies that your
+machine learning solutions are ethical, transparent, and equitable
+across user groups. By systematically addressing these concerns
+throughout the ML lifecycle, you build trust with stakeholders and
+reduce the risk of harmful bias in your models.
+
+**Desired outcome:** You implement a
+comprehensive approach to fairness and explainability across your
+machine learning lifecycle. You can identify potential biases in
+data and models, explain model predictions to stakeholders, and know
+that your AI systems make equitable decisions across user segments.
+Your ML systems are continuously monitored for fairness, comply with
+relevant regulations, and maintain transparency that builds trust
+with users and stakeholders.
+
+**Common anti-patterns:**
+
+- Treating fairness as an afterthought rather than integrating it
+throughout the ML lifecycle.
+- Focusing solely on model accuracy without considering ethical
+implications.
+- Using non-representative training data that leads to biased
+outcomes.
+- Deploying complex, opaque models when explainability is
+required.
+- Failing to monitor models in production for drift in fairness
+metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Builds trust with customers and stakeholders through transparent
+AI systems.
+- Reduces the risk of regulatory issues related to algorithmic
+fairness.
+- Identifies and mitigates harmful biases before models enter
+production.
+- Enables better understanding of model decisions through
+explainability techniques.
+- Creates more inclusive AI systems that work equitably for user
+groups.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Fairness and explainability should be considered fundamental
+components of your machine learning development process rather
+than optional add-ons. Approaching these concerns proactively can
+verify that your models work equitably for your users while
+providing transparency into how decisions are made.
+
+Start by assessing the ethical implications of your ML solution
+during problem framing. Consider whether an algorithm is the
+appropriate approach and what impacts it might have on different
+user groups. For data management, analyze whether your training
+data adequately represents the diversity of your user population,
+and check for existing biases in labels or features that could be
+perpetuated by your model.
+
+During training and evaluation, consider incorporating fairness
+constraints directly into your optimization functions. Evaluate
+models using appropriate fairness metrics alongside traditional
+performance measures. When deploying models, carefully assess
+whether the deployment context matches the training conditions,
+especially regarding population characteristics. Finally,
+implement robust monitoring systems to track fairness metrics over
+time and detect emerging bias.
+
+Amazon SageMaker AI Clarify provides comprehensive tools for
+addressing fairness and explainability throughout the ML
+lifecycle. It offers bias detection capabilities for both data and
+models, along with explainability features through SHAP (Shapley
+Additive Explanations) values that provide an understanding of how
+individual features contribute to predictions.
+
+### Implementation steps
+
+- **Assess ethical implications during
+problem framing**. Before building an ML model,
+evaluate whether an algorithmic approach is ethical for your
+specific use case. Consider potential unintended
+consequences and whether the benefits outweigh potential
+risks. Document your assessment and decision-making process
+for transparency.
+- **Evaluate and prepare representative
+training data**. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) with enhanced bias detection and
+new fairness metrics to analyze your training data for
+potential biases, particularly regarding protected
+attributes or sensitive groups. Verify that your data
+accurately represents the population on which the model will
+be deployed. Apply appropriate sampling or augmentation
+techniques to address identified representation gaps.
+- **Implement bias detection in the
+model development process**. Configure SageMaker AI
+Clarify to evaluate pre-training bias metrics that assess
+imbalances in your training data. These metrics can identify
+issues like class imbalance, label imbalance across groups,
+or feature distribution disparities that could lead to
+unfair outcomes.
+- **Select appropriate fairness metrics
+for evaluation**. Depending on your specific use
+case, choose relevant fairness metrics such as disparate
+impact, difference in positive proportions, or equal
+opportunity difference. These metrics quantify whether your
+model treats different groups equitably and should be
+tracked alongside traditional performance metrics.
+- **Apply explainability techniques to
+understand model decisions**. Implement
+[SHAP
+(Shapley Additive Explanations)](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html) through SageMaker AI
+Clarify to understand feature importance and how different
+features influence model predictions. This can identify
+whether protected attributes or proxies for them are
+disproportionately influencing outcomes.
+- **Consider model complexity tradeoffs
+with explainability requirements**. If
+explainability is a critical requirement, consider using
+simpler model architectures (like linear models or decision
+trees) that are inherently more interpretable. For complex
+models like deep neural networks, implement robust
+explainability tools.
+- **Implement bias monitoring in
+production environments**. Configure
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously track fairness metrics
+for deployed models. Set up alerts for drift in fairness
+metrics that might indicate emerging bias issues requiring
+intervention.
+- **Establish governance processes for
+addressing detected bias**. Create clear procedures
+for when bias is detected, including who is responsible for
+review, what remediation steps should be taken, and how
+stakeholders should be informed. Document these processes to
+verify that they are consistently applied.
+- **Train teams on fairness and
+explainability concepts**. Verify that data
+scientists, ML engineers, and other stakeholders understand
+fairness concepts, bias mitigation techniques, and how to
+interpret explainability outputs. Regular training sessions
+build organizational capacity for responsible AI.
+- **Document fairness and explainability
+considerations**. Maintain comprehensive
+documentation of fairness evaluations, explainability
+analyses, and mitigation strategies applied. This
+documentation supports transparency, aids regulatory
+adherence efforts, and communicates your responsible AI
+approach to stakeholders.
+- **Foundation model fairness
+considerations**. Use foundation models and
+generative AI to enhance fairness and explainability efforts
+by generating diverse synthetic data to address
+representation gaps, creating plain-language explanations of
+complex model decisions for different stakeholder groups,
+and automating the generation of comprehensive documentation
+about model fairness evaluations and mitigations.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Feature
+Attributions that Use Shapley Values](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/)
+- [Responsible
+AI Practices](https://aws.amazon.com/ai/responsible-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp06.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLOPS03.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLOPS03.md
@@ -1,0 +1,326 @@
+# MLOPS03
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLOPS03-BP01 Profile data to improve quality
+
+Data profiling is essential for understanding data characteristics
+such as distribution, descriptive statistics, data types, and
+patterns. By systematically reviewing source data for content and
+quality, you can filter out or correct problematic data, leading to
+significant quality improvements in your machine learning workflows.
+
+**Desired outcome:** You gain
+comprehensive insights into your data's characteristics, enabling
+you to identify and remediate quality issues before they impact your
+machine learning models. Through systematic profiling, you establish
+a robust data preprocessing pipeline that provides high-quality,
+consistent data flows to your ML models, resulting in more accurate
+predictions and better business outcomes.
+
+**Common anti-patterns:**
+
+- Skipping data profiling and moving directly to model training.
+- Manually reviewing data without automated profiling tools.
+- Performing one-time data quality checks without continuous
+monitoring.
+- Ignoring data distribution shifts between training and inference
+data.
+- Failing to document data quality issues and their resolutions.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model performance through higher quality training data.
+- Earlier detection of data anomalies and inconsistencies.
+- Enhanced understanding of data characteristics and limitations.
+- Reduced time spent debugging model issues caused by data
+problems.
+- More transparent and reproducible machine learning workflows.
+- Increased stakeholder confidence in model outputs.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data profiling is a critical step in the machine learning
+workflow. By thoroughly examining your data before model training,
+you gain valuable insights that improve data quality and
+ultimately lead to better model performance. Data profiling
+involves analyzing the statistical properties, distributions, and
+patterns within your dataset to identify anomalies, missing
+values, outliers, and other quality issues.
+
+Effective data profiling requires both automated tools and human
+judgment. While tools can quickly generate statistical summaries
+and visualizations, subject matter experts should interpret these
+findings to determine appropriate actions for data cleaning and
+transformation. For instance, you might discover that a numerical
+feature has an unexpected distribution that requires
+normalization, or that categorical variables contain inconsistent
+values requiring standardization.
+
+Consider a retail company building a customer churn prediction
+model. Through data profiling, they discover that 15% of customer
+records have missing age values, 5% have impossibly high
+transaction amounts, and several categorical fields contain
+inconsistent formatting. By addressing these issues early, they
+can significantly improve their model's performance.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Unified
+Studio for visual data review**. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) with enhanced collaborative
+features and team sharing capabilities to visually review
+data characteristics and remediate data-quality problems
+directly in your integrated environment. The unified
+solution provides improved debugging and monitoring
+capabilities for data processing workflows, automatically
+generating charts to identify data quality issues and
+suggesting transformations to fix common problems.
+- **Implement Amazon SageMaker AI Data
+Wrangler for comprehensive data preparation**.
+Import, prepare, transform, visualize, and analyze data with
+[SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/) with
+[Q
+integration for interactive analysis](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-q-integration.html). You can
+integrate Data Wrangler into your ML workflows to simplify
+and streamline data pre-processing and feature engineering
+with little to no coding. Import data from
+[Amazon S3](https://aws.amazon.com/s3/),
+[Amazon Redshift](https://aws.amazon.com/redshift/), or other data sources, and then query the
+data using
+[Amazon Athena](https://aws.amazon.com/athena/). Use Data Wrangler's built-in and custom data
+transformations and analysis features, including feature
+target leakage detection and quick modeling, to create
+sophisticated machine learning data preparation workflows.
+- **Build an automatic data profile and
+reporting system**. Use
+[AWS Glue Crawler](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html) to crawl your data sources and
+automatically create a data schema. The crawler detects the
+schema of your data and registers tables in the
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/populate-data-catalog.html), providing a comprehensive listing
+of tables and schemas. Use
+[Amazon Athena](https://aws.amazon.com/athena/) for serverless SQL querying to constantly
+profile your data, and create
+[Quick](https://aws.amazon.com/quicksight/) dashboards for data visualization and
+monitoring.
+- **Create a baseline dataset with
+SageMaker AI Model Monitor**. The training dataset
+used to train your model typically serves as a good baseline
+dataset. Verify that the training dataset schema and the
+inference dataset schema exactly match (the number and order
+of the features). With
+[SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-create-baseline.html), you can automatically detect
+concept drift in deployed models by comparing production
+data against this baseline.
+- **Implement continuous data quality
+monitoring**. Set up automated checks that
+continuously monitor data quality metrics like completeness,
+uniqueness, consistency, and validity. Configure alerts to
+notify relevant stakeholders when data quality issues arise,
+enabling prompt intervention and resolution. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to create dashboards and set up alerts for
+key data quality metrics.
+- **Document data profiling insights and
+transformations**. Maintain comprehensive
+documentation of data profiling findings, quality issues
+discovered, and the transformations applied to address them.
+This documentation promotes transparency, facilitates
+knowledge sharing across teams, and supports regulatory
+adherence in regulated industries.
+- **Use generative AI for enhanced data
+profiling**. Use large language models in
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) or
+[Amazon
+Nova](https://aws.amazon.com/ai/generative-ai/nova/) to automatically extract and enrich metadata,
+identify patterns in your data, and generate natural
+language summaries of data quality issues. Generative AI can
+analyze unstructured data fields and provide insights that
+traditional data profiling tools might miss, though you
+should validate AI-generated suggestions before
+implementation.
+
+## Resources
+
+**Related documents:**
+
+- [Prepare
+ML Data with Amazon SageMaker AI Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler.html)
+- [Get
+Started with Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-getting-started.html)
+- [Data
+quality](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-data-quality.html)
+- [Create
+a Baseline](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-create-baseline.html)
+- [AWS Glue Data Quality](https://docs.aws.amazon.com/glue/latest/dg/glue-data-quality.html)
+- [Data
+discovery and cataloging in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html)
+- [Amazon SageMaker AI notebooks](https://aws.amazon.com/sagemaker/notebooks/)
+- [What
+is Amazon Athena?](https://docs.aws.amazon.com/athena/latest/ug/what-is.html)
+- [What
+is Amazon Quick Suite?](https://docs.aws.amazon.com/quicksight/latest/user/welcome.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops03-bp01.html*
+
+---
+
+# MLOPS03-BP02 Create tracking and version control mechanisms
+
+Machine learning model development requires robust tracking and
+version control mechanisms due to its iterative and exploratory
+nature. By implementing proper tracking systems, you can maintain
+visibility of your experiments, data processing techniques, and
+model versions while enabling reproducibility and collaboration.
+
+**Desired outcome:** You have
+comprehensive tracking of ML model development with experiment
+tracking capabilities, version-controlled data processing code, and
+a model registry that enables you to identify the best performing
+models. Your development processes are reproducible, collaborative,
+and automated with CI/CD pipelines for model deployment.
+
+**Common anti-patterns:**
+
+- Manually tracking experiments in spreadsheets or documents.
+- Not documenting data processing steps or model configurations.
+- Keeping models and datasets in local environments without
+version control.
+- Starting new experiments from scratch instead of building on
+previous work.
+
+**Benefits of establishing this best
+practice:**
+
+- Enhanced reproducibility of experiments and model training.
+- Improved collaboration among data science teams.
+- Better visibility into the performance of different model
+iterations.
+- Faster identification of the best performing models.
+- Ability to roll back to previous model versions if needed.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning development involves experimenting with multiple
+combinations of data, algorithms, and parameters while observing
+how incremental changes impact model accuracy. Without proper
+tracking and version control, you risk losing valuable insights
+and the ability to reproduce successful experiments.
+
+To address these challenges, you need a systematic approach to
+track experiments, version control your code and data processing
+techniques, and manage model deployment. AWS SageMaker AI provides
+integrated tools for experiment tracking, version control, and
+model registry that can streamline your machine learning
+operations.
+
+By implementing proper tracking and versioning mechanisms, you can
+document your model development journey, track performance metrics
+across experiments, and reliability reproduce and deploy your
+models. This creates a foundation for continuous improvement of
+your machine learning applications.
+
+### Implementation steps
+
+- **Track your ML experiments with
+SageMaker AI Experiments**. Use Amazon SageMaker AI
+Experiments to you create, manage, analyze, and compare your
+machine learning experiments. SageMaker AI Experiments
+automatically tracks inputs, parameters, configurations, and
+results of your iterations as runs. You can assign, group,
+and organize these runs into experiments. SageMaker AI
+Experiments integrates with Amazon SageMaker AI Studio,
+providing a visual interface to browse active and past
+experiments, compare runs on key performance metrics, and
+identify the best-performing models.
+- **Process data with SageMaker AI
+Processing**. For analyzing data, documenting
+processing, and evaluating ML models, use
+[Amazon SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html). This capability can be used for
+feature engineering, data validation, model evaluation, and
+model interpretation. SageMaker AI Processing provides a
+standardized way to run your data processing workloads,
+fostering consistency and reproducibility.
+- **Use SageMaker AI Unified Studio for
+enhanced collaboration**. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) with enhanced collaborative
+features and team sharing capabilities for integrated data
+and AI workflows. The unified solution provides improved
+debugging and monitoring capabilities, VS Code server
+integration, and enhanced project sharing. This approach
+keeps your data processing code and documentation accessible
+while facilitating better collaboration and version tracking
+across teams.
+- **Use SageMaker AI Model
+Registry**. Catalog, manage, and deploy models
+using SageMaker AI Model Registry. Create a model group and,
+for each run of your ML pipeline, create a model version
+that you register in the model group. The Model Registry
+provides a centralized repository for model versions, making
+it more straightforward to track model lineage, compare
+model performance, and promote models to production.
+- **Implement CI/CD for model
+deployment**. Automate your model deployment
+process using CI/CD pipelines for consistent and reliable
+deployments. SageMaker AI Pipelines can be used to create
+end-to-end workflows that include model building,
+evaluation, and deployment steps. Implement CI/CD for model
+deployment to thoroughly test your models before they are
+deployed to production, reducing the risk of
+deployment-related issues.
+- **Integrate data version
+control**. Use tools like Data Version Control
+(DVC) in conjunction with SageMaker AI Experiments to track
+both your model code and the datasets used for training and
+evaluation. With these tools, you can completely reproduce
+your machine learning experiments.
+- **Create model cards for
+documentation**. For each model version in your
+registry, create comprehensive
+[SageMaker AI
+Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) with enhanced documentation and
+governance capabilities that document the model's purpose,
+training data, performance metrics, limitations, and usage
+guidelines. This documentation helps users understand when
+and how to use specific model versions and supports improved
+model governance.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Experiments in Studio Classic](https://docs.aws.amazon.com/sagemaker/latest/dg/experiments.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Git
+repositories with SageMaker AI Notebook Instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-git-repo.html)
+- [MLOps
+Automation With SageMaker AI Projects](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects.html)
+- [Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Experiment Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-experiments)
+- [SageMaker AI
+Model Registry Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-pipelines)
+- [Amazon SageMaker AI processing](https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_processing.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops03-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLOPS04.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLOPS04.md
@@ -1,0 +1,332 @@
+# MLOPS04
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLOPS04-BP01 Automate operations through MLOps and CI/CD
+
+Automate ML workload operations using infrastructure as code (IaC)
+and configuration as code (CaC). Select appropriate MLOps mechanisms
+to orchestrate your ML workflows and integrate with CI/CD pipelines
+for automated deployments. This approach creates consistency across
+your staging and production deployment environments. Enable model
+observability and version control across your hosting
+infrastructure.
+
+**Desired outcome:** You establish
+automated ML operations through MLOps practices and CI/CD pipelines
+for repeatable, consistent deployments across environments. Your ML
+workflows are orchestrated through infrastructure as code, providing
+traceability, version control, and model observability. This enables
+your teams to deliver ML models faster, with higher quality, and
+maintain governance throughout the model lifecycle from development
+to production.
+
+**Common anti-patterns:**
+
+- Manually deploying ML models to production environments.
+- Using different tools and processes across development and
+production environments.
+- Not versioning infrastructure, configuration, or model
+artifacts.
+- Lacking automated testing for ML models before deployment.
+- Creating one-off scripts for deployment instead of reusable
+templates.
+
+**Benefits of establishing this best
+practice:**
+
+- Accelerated ML model development and deployment cycles.
+- Consistent, reproducible environments across development and
+production.
+- Improved collaboration between data scientists and operations
+teams.
+- Enhanced governance and traceability for model artifacts and
+infrastructure.
+- Improved rollbacks and version management.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+MLOps combines machine learning, DevOps practices, and data
+engineering to streamline and automate the end-to-end ML
+lifecycle. By implementing infrastructure as code and
+configuration as code principles, you create consistent,
+reproducible environments while minimizing manual steps that can
+introduce errors. This approach makes ML operations more reliable,
+scalable, and maintainable.
+
+Creating automated CI/CD pipelines for ML workloads requires
+special consideration compared to traditional software
+applications. You need to track not only code changes but also
+data, model parameters, and training configurations. Using AWS
+services for MLOps provides integrated tools to manage these
+complexities while maintaining proper governance and
+observability.
+
+When implementing MLOps practices, start by defining your workflow
+patterns and choosing appropriate orchestration tools based on
+your specific requirements. AWS offers multiple options for ML
+workflow orchestration, from purpose-built services like SageMaker AI
+Pipelines to more general workflow engines like AWS Step Functions. Each provides different levels of abstraction, control,
+and integration capabilities.
+
+Model observability is crucial for ML systems in production,
+allowing you to monitor model performance, detect drift, and run
+retraining when necessary. Implementing comprehensive monitoring
+assists you to quickly identify and respond to changes in model
+behavior or data distributions.
+
+### Implementation steps
+
+- **Define your ML workflow
+architecture**. Begin by mapping out your
+end-to-end ML workflow, including data preparation, feature
+engineering, model training, evaluation, deployment, and
+monitoring stages. Identify which steps can be automated and
+which require human intervention. Determine the appropriate
+level of separation between development, testing, and
+production environments based on your requirements.
+- **Select an infrastructure as code
+approach**. Choose either AWS CloudFormation or AWS CDK to define your infrastructure.
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) enables you to create and provision
+AWS deployments predictably and repeatedly using template
+files. For teams more comfortable with programming
+languages,
+[AWS Cloud Development Kit (AWS CDK) (AWS CDK)](https://aws.amazon.com/cdk/) allows you to define cloud
+resources using familiar languages like Python, TypeScript,
+or Java.
+- **Implement version control for
+assets**. Establish a version control strategy for
+ML assets including code, configurations, infrastructure
+definitions, and model artifacts. Use AWS CodeCommit or
+third-party repositories to store and version these assets.
+Implement branching strategies that allow for
+experimentation while maintaining stable production
+environments. Version control enables you to track changes,
+collaborate effectively, and roll back to previous versions
+when needed.
+- **Choose an MLOps orchestration
+strategy**. Based on your workflow needs, select an
+appropriate orchestration mechanism:
+
+Use
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to create ML workflows with
+Python SDK, visualize, and manage them in Amazon SageMaker AI Studio. SageMaker AI Pipelines automatically logs
+every step, creating an audit trail of model components
+including training data, configurations, parameters, and
+learning gradients.
+- Use
+[AWS Step Functions Data Science SDK](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-python-sdk.html) to automate ML
+workflows with more complex orchestration requirements
+or when integrating with other AWS services beyond
+SageMaker AI.
+- Use third-party tools such as
+[Amazon
+Managed Workflows for Apache Airflow (MWAA)](https://aws.amazon.com/managed-workflows-for-apache-airflow/) to
+orchestrate workflows using Directed Acyclic Graphs
+(DAGs) written in Python, especially when you need to
+integrate with existing Apache Airflow deployments.
+
+- **Build CI/CD pipelines for ML
+models**. Implement CI/CD pipelines using
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) to automate the building, testing, and
+deployment of ML models. Include automated tests for data
+quality, model performance, and API functionality. Configure
+the pipeline to deploy to staging environments before
+production and implement approval gates where needed.
+Integrate model registration and versioning using Amazon SageMaker AI Model Registry.
+- **Set up model monitoring and
+observability**. Implement comprehensive monitoring
+for your deployed models using
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/). Configure data quality
+monitoring, model quality monitoring, bias drift monitoring,
+and feature attribution drift monitoring. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to create dashboards and alerts for model
+performance metrics.
+- **Establish automated rollback
+mechanisms**. Configure your deployment pipelines
+to support automated rollbacks when quality thresholds are
+not met. Implement canary or blue/green deployment
+strategies using
+[AWS CodeDeploy](https://aws.amazon.com/codedeploy/) to gradually shift traffic to new model
+versions while monitoring for issues. This minimizes the
+impact of problematic deployments and provides service
+continuity.
+- **Integrate security and governance
+controls**. Implement security checks throughout
+your MLOps pipeline. Use
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) to control access to
+resources and
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to log API calls for auditing. Configure
+[Amazon SageMaker AI Model Cards](https://aws.amazon.com/sagemaker/ml-governance/) to document model information,
+intended uses, limitations, and performance characteristics.
+- **Create environments for
+experimentation and testing**. Set up isolated
+environments for experimentation that don't impact
+production systems. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) to provide data scientists
+with self-service environments for exploration while
+maintaining governance through integrated data and AI
+workflows. Implement environment-specific configurations
+through parameter files or environment variables managed in
+your IaC templates.
+
+## Resources
+
+**Related documents:**
+
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [What
+is AWS CodePipeline?](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html)
+- [Amazon
+Managed Workflows for Apache Airflow (MWAA)](https://aws.amazon.com/managed-workflows-for-apache-airflow/)
+- [AWS CloudFormation Documentation](https://docs.aws.amazon.com/cloudformation/index.html)
+- [What
+is the AWS CDK?](https://docs.aws.amazon.com/cdk/latest/guide/home.html)
+- [Step
+Functions Data Science SDK](https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/)
+- [Infrastructure
+as code](https://docs.aws.amazon.com/whitepapers/latest/introduction-devops-aws/infrastructure-as-code.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+
+**Related videos:**
+
+- [AWS re:Invent 2024 - Accelerate ML workflows with Amazon SageMaker AI
+Studio](https://www.youtube.com/watch?v=SAeZMA0KaFA)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops04-bp01.html*
+
+---
+
+# MLOPS04-BP02 Establish reliable packaging patterns to access approved public libraries
+
+Establishing reliable packaging patterns enables data scientists to
+access approved public libraries efficiently and consistently. By
+implementing structured access to public libraries and creating
+separate kernels for common ML frameworks, organizations can have
+both flexibility and security in their machine learning development
+environments.
+
+**Desired outcome:** You create a
+streamlined workflow where your data scientists have reliable access
+to approved libraries through internal repositories. You maintain
+separate kernels for common ML frameworks like TensorFlow, PyTorch,
+Scikit-learn, and Keras. This approach improves development
+productivity while improving security and adherence with
+organizational requirements.
+
+**Common anti-patterns:**
+
+- Allowing uncontrolled direct downloads from public repositories.
+- Using inconsistent or undocumented container configurations.
+- Maintaining duplicate library versions across different
+environments.
+- Not having a centralized strategy for package management.
+- Failing to version control dependencies.
+
+**Benefits of establishing this best
+practice:**
+
+- Better security through controlled library usage.
+- Improved reproducibility of ML workloads.
+- Reduced dependency conflicts.
+- Simplified adherence with organizational security policies.
+- Faster onboarding of new data scientists.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Creating reliable packaging patterns is essential for maintaining
+consistent, secure, and efficient machine learning workflows. You
+need to establish infrastructure that gives data scientists access
+to the libraries they need while maintaining organizational
+control over those dependencies. Container technologies provide a
+portable, consistent way to package ML environments with required
+dependencies, making them ideal for this purpose. Internal
+artifact repositories allow for centralized management of approved
+packages so that team members use consistent, vetted versions.
+
+Your packaging strategy should balance flexibility for data
+scientists with security and regulatory requirements. This means
+establishing both infrastructure (containers, repositories) and
+processes (approval workflows, versioning policies) that work
+together to create a streamlined experience. The use of
+standardized environments with separate kernels for different ML
+frameworks enables isolation when needed while providing the
+specific tools required for different types of projects.
+
+### Implementation steps
+
+- **Set up container infrastructure for
+ML workloads**. Create a container strategy using
+[Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html) (Amazon ECR) to store and
+manage your ML container images. Containers provide
+consistent environments that package dependencies,
+libraries, and runtime components needed for ML workloads.
+- **Create base container images for
+common ML frameworks**. Build and maintain separate
+base container images for frameworks like TensorFlow,
+PyTorch, Scikit-learn, and Keras using
+[optimized
+foundation model containers](https://docs.aws.amazon.com/sagemaker/latest/dg/large-model-inference.html) for efficient training
+and inference. These images should include standard
+configurations and commonly used libraries for each
+framework, with support for frameworks like Hugging Face
+Transformers and quantization techniques, providing
+consistency across your organization.
+- **Implement versioning and tagging
+policies**. Establish clear policies for versioning
+containers and artifacts for reproducibility of ML
+experiments and models. Use semantic versioning and proper
+tagging to track container image changes and library
+updates.
+- **Develop automation for container
+builds and updates**. Implement CI/CD pipelines
+using
+[AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html) to automatically build, test, and deploy
+updated container images when dependencies need to be
+updated or security patches are required.
+- **Document usage patterns and
+onboarding procedures**. Create comprehensive
+documentation that explains how data scientists should use
+the established packaging patterns, including how to access
+approved libraries and work with containerized environments.
+
+## Resources
+
+**Related documents:**
+
+- [What
+is Amazon Elastic Container Registry?](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html)
+- [What
+are AWS Deep Learning Containers?](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html)
+- [Docker
+containers for training and deploying models](https://docs.aws.amazon.com/sagemaker/latest/dg/docker-containers.html)
+- [What
+is AWS CodePipeline?](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html)
+- ["Publish
+Docker image to an Amazon ECR image repository" sample
+for CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Custom Container Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/advanced_functionality/custom-training-containers)
+- [Deep
+Learning Container Examples](https://github.com/aws/deep-learning-containers/tree/master/examples)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops04-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLOPS05.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLOPS05.md
@@ -1,0 +1,200 @@
+# MLOPS05
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLOPS05-BP01 Establish deployment environment metrics
+
+Establish comprehensive monitoring of machine learning operations to
+gain visibility into your deployed ML environments. By measuring
+metrics such as memory, CPU/GPU usage, disk utilization, endpoint
+invocations, and latency, you can provide optimal performance and
+improve the reliability of your ML systems.
+
+**Desired outcome:** You gain
+real-time visibility into your ML deployment environments through
+systematic collection and analysis of performance metrics. You
+establish robust monitoring dashboards, alerting systems, and
+automated responses to potential issues. This enables you to
+proactively address performance bottlenecks, optimize resource
+utilization, and maintain reliable ML services while managing costs
+effectively.
+
+**Common anti-patterns:**
+
+- Implementing monitoring only after experiencing production
+issues.
+- Focusing only on basic system metrics while ignoring ML-specific
+performance indicators.
+- Creating monitoring dashboards without establishing
+corresponding alerts.
+- Setting static thresholds that don't account for typical usage
+patterns.
+- Collecting metrics without regular review or actionable response
+plans.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of performance issues before they impact end
+users.
+- Improved resource optimization and cost efficiency.
+- Enhanced ability to scale ML services based on actual usage
+patterns.
+- Faster troubleshooting and reduced mean time to resolution.
+- Data-driven capacity planning and infrastructure decisions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing effective deployment environment metrics requires a
+systematic approach to monitoring both infrastructure and
+application-specific ML metrics. You need to focus on both
+system-level metrics like CPU, memory, and disk usage, as well as
+ML-specific metrics such as inference latency, throughput, and
+model accuracy. By using AWS services like Amazon CloudWatch, you
+can centralize your monitoring approach and gain comprehensive
+visibility into your ML operations.
+
+Start by identifying the key performance indicators that matter
+most for your specific ML workloads. For inference endpoints,
+these typically include latency, throughput, and resource
+utilization. For batch processing jobs, focus on processing time,
+error rates, and resource efficiency. With these KPIs established,
+you can implement automated monitoring and alerting to quickly
+identify when your systems deviate from expected performance.
+
+Regular review of your metrics can identify trends and potential
+areas for optimization. For example, you might discover that
+certain models require more memory than originally allocated, or
+that specific types of inference requests consistently take longer
+to process. This information guides your infrastructure decisions
+and prioritizes optimization efforts.
+
+### Implementation steps
+
+- **Record performance-related
+metrics.** Use a monitoring and observability
+service like Amazon CloudWatch to record performance-related
+metrics. These metrics can include database transactions,
+slow queries, I/O latency, HTTP request throughput, service
+latency, and other key data. For SageMaker AI endpoints,
+collect metrics such as CPUUtilization, MemoryUtilization,
+DiskUtilization, and model-specific metrics like
+ModelLatency and InvocationsPerInstance.
+- **Analyze metrics when events or
+incidents occur.** Use monitoring dashboards and
+reports to understand and diagnose the impact of an event or
+incident. Amazon CloudWatch Dashboards provide insight into
+what portions of the workload are not performing as
+expected. Correlate metrics, logs, and traces to quickly
+identify root causes when issues arise.
+- **Establish key performance indicators
+(KPIs) to measure workload performance.** Identify
+the KPIs that indicate whether the workload is performing as
+intended. An API-based ML endpoint might use overall
+response latency as an indication of overall performance,
+while a batch processing job might track throughput metrics.
+For generative AI applications, monitor additional metrics
+like token usage, cost per request, prompt engineering
+effectiveness, and use
+[SageMaker AI
+Training Plans](https://aws.amazon.com/sagemaker/pricing/) for cost optimization of large-scale
+AI training workloads.
+- **Use monitoring to generate
+alarm-based notifications.** Monitor metrics for
+the defined KPIs and generate alarms automatically when the
+measurements are outside expected boundaries. Configure
+Amazon CloudWatch Alarms to send notifications using Amazon SNS when thresholds are breached, which provides for timely
+responses to potential issues.
+- **Review metrics at regular
+intervals.** As routine maintenance, or in response
+to events or incidents, review what metrics are collected
+and identify the metrics that were key in addressing issues.
+Identify additional metrics that can identify, address, or
+avoid issues. Schedule periodic reviews to keep your
+monitoring strategy effective as your ML applications
+evolve.
+- **Monitor and alarm
+proactively.** Use KPIs, combined with monitoring
+and alerting systems, to proactively address
+performance-related issues. Configure CloudWatch to initiate
+automated actions to remediate issues where possible.
+Escalate the alarm to those able to respond if an automated
+response is not possible. Use anomaly detection to predict
+expected KPI values, and generate alerts and automatically
+halt or roll back deployments if KPIs are outside of the
+expected values.
+- **Use Amazon CloudWatch for
+comprehensive monitoring.** Use Amazon CloudWatch
+metrics for SageMaker AI endpoints to determine the memory,
+CPU usage, and disk utilization. Set up CloudWatch
+Dashboards to visualize the environment metrics and
+establish CloudWatch alarms to initiate a notification
+through Amazon SNS (email, SMS, or webHook) to notify on
+events occurring in the runtime environment. For model
+performance monitoring, implement Amazon SageMaker AI Model
+Monitor to detect data drift and quality issues.
+- **Use Amazon EventBridge for automated
+workflows.** Define an automated workflow using
+Amazon EventBridge to respond automatically to events. These
+events can include training job status changes, endpoint
+status changes, and increasing the compute environment
+capacity after it crosses a defined threshold (such as CPU
+or disk utilization). Create event rules that run Lambda
+functions to scale resources, update configurations, or
+notify specific teams based on the event type.
+- **Use AWS Application Cost Profiler
+for cost allocation.** Implement AWS Application Cost Profiler to report the cost per tenant (model or user).
+This assists you in tracking resource usage at a granular
+level and enables accurate cost attribution across different
+ML models, teams, or business units. Use
+[SageMaker AI
+Training Plans](https://aws.amazon.com/sagemaker/pricing/) for compute reservation and better
+resource planning of high-demand GPU resources. Use these
+insights to optimize resource allocation and identify
+opportunities for cost savings.
+- **Implement SageMaker AI Model Monitor
+for data drift detection.** Configure SageMaker AI
+Model Monitor to continuously monitor the quality of your
+machine learning models in production. Set up automated
+quality checks to detect data drift, model drift, and bias
+drift in your production workloads. This enables you to
+maintain high quality standards and take corrective actions
+when models start to deviate from expected behavior.
+- **Use AWS X-Ray for distributed
+tracing.** Implement AWS X-Ray to trace requests
+through your ML application components. This provides
+visibility into request flows, latency bottlenecks, and
+error points in distributed systems. X-Ray provides an
+understanding of the dependencies between components so you
+can optimize end-to-end performance of your ML applications.
+- **Implement Amazon SageMaker AI Clarify
+for bias monitoring.** Use SageMaker AI Clarify to
+detect bias in your deployed models. Set up regular
+monitoring jobs to track bias metrics and alert when they
+exceed acceptable thresholds so that your ML systems
+continue to make fair and unbiased predictions in
+production.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Metrics
+in Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html)
+- [Using
+Amzon CloudWatch dashboards](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html)
+- [DevOps
+and AWS](https://aws.amazon.com/devops/?ref=wellarchitected-wp)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops05-bp01.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLOPS06.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLOPS06.md
@@ -1,0 +1,389 @@
+# MLOPS06
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLOPS06-BP01 Synchronize architecture and configuration, and check for skew across environments
+
+Synchronize your systems and configurations across development and
+deployment phases for consistent machine learning model inference
+results. By maintaining identical environments, you can avoid
+discrepancies that arise from architectural differences, leading to
+more reliable and predictable model performance.
+
+**Desired outcome:** You have
+established a systematic approach to foster architectural and
+configuration consistency across development, staging, and
+production environments for machine learning models. This includes
+automated infrastructure deployment, continuous model quality
+monitoring, and proactive detection of environmental skew. Your
+machine learning systems deliver the same range of accuracy
+regardless of which environment they run in, and you can quickly
+identify and address deviations.
+
+**Common anti-patterns:**
+
+- Manually configuring each environment, leading to
+inconsistencies.
+- Neglecting to validate model performance across different
+environments.
+- Assuming model behavior will be identical across environments
+without verification.
+- Using different hardware specifications or software versions
+between environments.
+- Making changes only when needed to production environments
+without documenting or replicating them in other environments.
+
+**Benefits of establishing this best
+practice:**
+
+- Consistent model performance across environments.
+- Reduced debugging time for environment-specific issues.
+- Improved reliability of machine learning applications.
+- Straightforward identification of the root causes of performance
+deviations.
+- Streamlined promotion process from development to production.
+- Enhanced confidence in deployed models.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Synchronizing your machine learning environments is critical for
+checking that a model trained in one environment behaves the same
+way when deployed in another. Differences in system architectures,
+software dependencies, or configuration settings can cause
+unexpected variations in model performance, leading to inaccurate
+predictions or even system failures.
+
+By treating your infrastructure as code and implementing automated
+monitoring, you can maintain consistency across environments and
+quickly detect deviations. This approach allows you to focus on
+improving your models rather than debugging environment-specific
+issues. It also provides a reliable foundation for continuous
+delivery of machine learning solutions.
+
+Environmental skew can occur in various ways, such as through
+differences in hardware capabilities, software versions, or system
+configurations. For example, a model trained on a development
+environment with specific CPU architecture might behave
+differently when deployed to a production environment with
+different specifications. Similarly, differences in underlying
+libraries or dependencies can lead to subtle variations in model
+behavior.
+
+Regular validation of model performance across environments should
+be part of your standard promotion process. This includes
+comparing not only the accuracy metrics but also the distribution
+of predictions and the model's behavior for edge cases.
+
+### Implementation steps
+
+- **Define infrastructure as code using
+AWS CloudFormation**. Create CloudFormation
+templates that define resources, configurations, and
+dependencies for your machine learning environments. With
+this strategy, each environment is provisioned consistently
+and can be recreated identically when needed. Include
+compute resources, networking configurations, security
+settings, and machine learning-specific components.
+- **Implement version control for
+infrastructure templates**. Store your
+CloudFormation templates in a version control system like
+AWS CodeCommit or GitHub. This allows you to track changes
+over time, roll back to previous configurations if needed,
+and verify that your environments are using the same version
+of the infrastructure definition.
+- **Set up CI/CD pipelines for
+infrastructure deployment**. Use AWS CodePipeline
+or AWS CodeBuild to automate the deployment of your
+infrastructure changes across environments. This reduces
+manual intervention and the potential for human error when
+updating environments.
+- **Configure Amazon SageMaker AI Model
+Monitor for continuous quality evaluation**. Set up
+Model Monitor to automatically track the quality of your
+models in production and compare the results with the
+baseline established during training. This can identify when
+model performance starts to drift due to environmental
+factors or data changes.
+- **Implement data quality
+monitoring**. Use SageMaker AI Model Monitor's data
+quality monitoring capability to detect changes in the
+statistical properties of your input data across
+environments. This capability provides similar input
+distributions to your models regardless of environment.
+- **Set up model quality
+monitoring**. Configure SageMaker AI Model Monitor to
+track model quality metrics such as accuracy, precision, and
+recall over time. Compare these metrics between your
+development, staging, and production environments to detect
+inconsistencies.
+- **Enable bias drift
+monitoring**. Use SageMaker AI Model Monitor's bias
+drift monitoring to detect if your models exhibit different
+biases in different environments, which could indicate
+environment-specific issues.
+- **Configure alerts for
+deviations**. Set up Amazon CloudWatch alarms to
+notify you when SageMaker AI Model Monitor detects significant
+deviations in model performance or data characteristics
+across environments. This allows for proactive intervention
+before small issues become major problems.
+- **Establish a promotion
+checklist**. Create a formal checklist that
+includes verifying model performance consistency across
+environments before promoting a model to the next stage.
+Document the acceptable thresholds for performance
+differences between environments.
+- **Implement regular cross-environment
+validation**. Schedule periodic validation of model
+performance across your environments, even when no changes
+are being made. Use this validation to catch gradual drift
+that might occur due to external factors.
+- **Create environment comparison
+dashboards**. Use
+[Quick with GenBI capabilities](https://aws.amazon.com/quicksight/generative-bi/) to automatically
+generate visualizations and dashboards for model performance
+metrics across different environments, making it more
+straightforward to spot discrepancies and track trends over
+time.
+- **Utilize foundation models for
+anomaly detection**. Implement
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) or
+[SageMaker AI
+JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) with expanded library of foundation models
+to analyze performance patterns and identify anomalous
+behavior that might indicate environmental inconsistencies,
+especially for complex ML systems where traditional
+monitoring might miss subtle differences.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [What
+is AWS CloudFormation?](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html)
+- [What
+is AWS Config?](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
+- [Detect
+unmanaged configuration changes to stacks and resources with
+drift detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html)
+- [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)
+- [Amazon SageMaker AI best practices](https://docs.aws.amazon.com/sagemaker/latest/dg/best-practices.html)
+
+**Related examples:**
+
+- [Introduction
+to Amazon SageMaker AI Model Monitor](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_model_monitor/introduction/SageMaker AI-ModelMonitoring.html)
+- [Model
+Monitor Visualization](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_model_monitor/visualization/SageMaker AI-Model-Monitor-Visualize.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops06-bp01.html*
+
+---
+
+# MLOPS06-BP02 Enable model observability and tracking
+
+Establish model monitoring mechanisms to identify and proactively
+avoid inference issues. ML models can degrade in performance over
+time due to drifts. Monitor metrics that are attributed to your
+model's performance. For real time inference endpoints, measure the
+operational health of the underlying compute resources hosting the
+endpoint and the health of endpoint responses. Establish lineage to
+trace hosted models back to versioned inputs and model artifacts for
+analysis.
+
+**Desired outcome:** You can
+continuously monitor your machine learning models in production to
+detect and avoid performance degradation over time. You have
+mechanisms in place to track model lineage, identify various types
+of drift, and receive alerts when models deviate from expected
+behavior. Your monitoring solution provides clear visibility into
+both the technical health of model endpoints and the business
+performance of the models themselves, enabling you to maintain
+high-quality predictions and make informed decisions about model
+updates.
+
+**Common anti-patterns:**
+
+- Deploying models without monitoring capabilities.
+- Failing to establish model lineage tracking for audit and
+governance.
+- Not monitoring for data drift or concept drift in production
+models.
+- Ignoring model bias and fairness considerations after
+deployment.
+- Lacking documentation of model information and performance
+metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation.
+- Improved model governance and adherence through comprehensive
+documentation.
+- Enhanced ability to explain model predictions and address bias
+concerns.
+- Reduced operational risk through proactive monitoring of model
+health.
+- Streamlined model updates and improvements based on real-world
+performance data.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model observability is critical for maintaining the reliability,
+fairness, and performance of machine learning systems in
+production. Without proper monitoring mechanisms, ML models can
+silently degrade over time as the data they process begins to
+differ from the data they were trained on, a phenomenon known as
+drift.
+
+You need to implement comprehensive monitoring across several
+dimensions: data quality to check that inputs remain consistent
+with training data, model quality to track performance metrics,
+bias detection to verify fairness, and explainability to
+understand model decisions. Additionally, model lineage tracking
+can trace issues back to specific model versions, training
+datasets, and hyperparameters.
+
+Amazon SageMaker AI provides integrated tools that make implementing
+these monitoring capabilities straightforward. SageMaker AI Model
+Monitor can automatically detect deviations in your model's data
+and performance characteristics, while SageMaker AI Clarify
+identifies bias and explains predictions. By setting up proper
+alerts, you can be notified when issues arise and take corrective
+action before they impact your business.
+
+Documentation is equally important for model governance. SageMaker AI
+Model Cards provide a centralized location to store important
+model information, including performance metrics, intended use
+cases, and potential limitations.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Model
+Monitor**. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automatically monitor the
+quality of your ML models in production. Create baseline
+statistics and constraints during model training, then
+monitor for deviations in production data. Set up the
+following types of monitoring:
+
+Data quality monitoring to detect changes in data
+distributions
+- Model quality monitoring to track accuracy and other
+performance metrics
+- Bias drift monitoring to detect changes in model
+fairness
+- Feature attribution drift monitoring to track changes in
+feature importance
+
+- **Integrate with Amazon CloudWatch**. SageMaker AI Model Monitor automatically
+sends metrics to
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), allowing you to track usage statistics
+for your ML models. Set up CloudWatch dashboards to
+visualize key metrics and create alarms that go off when
+metrics exceed predefined thresholds. Configure
+notifications through Amazon SNS to alert relevant teams
+when issues are detected.
+- **Implement SageMaker AI Model
+Dashboard**. Use the
+[SageMaker AI
+Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) to gain a centralized view of your
+models. From the SageMaker AI console, you can search, view,
+and explore your models in one place. Set up monitors to
+track the performance of models deployed on real-time
+inference endpoints and identify models that violate
+thresholds for data quality, model quality, bias, and
+explainability.
+- **Enable bias detection with SageMaker AI
+Clarify**. Deploy
+[SageMaker AI
+Clarify](https://aws.amazon.com/sagemaker/clarify/) to identify various types of bias that can
+emerge during model training or when the model is in
+production. Configure both pre-training and post-training
+bias metrics to understand how your model's predictions
+affect different segments of your user base. Use Clarify's
+monitoring capabilities to detect bias drift in production
+models.
+- **Implement model
+explainability**. Configure SageMaker AI Clarify's
+feature attribution capabilities to explain how your models
+make predictions. This builds trust with stakeholders and
+can identify potential issues with model logic. Set up
+monitoring to detect when feature attribution patterns drift
+from baseline, which could indicate underlying problems with
+the model.
+- **Establish ML lineage
+tracking**. Implement
+[SageMaker AI
+ML Lineage Tracking](https://sagemaker.readthedocs.io/en/v2.77.0/workflows/lineage/) to create and store information
+about each step in your machine learning workflow, from data
+preparation to model deployment. This creates a running
+history of your ML experiments and establishes model
+governance by tracking model lineage artifacts for auditing
+and adherence verification.
+- **Create Model Cards for
+documentation**. Use
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) with enhanced documentation and
+governance capabilities to document critical information
+about your models in a single location. Include business
+requirements, key decisions, observations during
+development, performance goals, risk ratings, and evaluation
+results. This streamlines documentation throughout a model's
+lifecycle and supports approval workflows, registration, and
+audits.
+- **Implement shadow testing for model
+validation**. Before deploying new model versions
+to production, use
+[Amazon SageMaker AI Shadow Testing](https://docs.aws.amazon.com/sagemaker/latest/dg/shadow-tests.html) to compare the performance
+of new models against production models using real-world
+inference request data. Configure SageMaker AI to route copies
+of production inference requests to the new model variant
+and generate dashboards displaying performance differences
+across key metrics in real-time.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html)
+- [Shadow
+tests](https://docs.aws.amazon.com/sagemaker/latest/dg/shadow-tests.html)
+- [Lineage
+Tracking Entities](https://docs.aws.amazon.com/sagemaker/latest/dg/lineage-tracking-entities.html)
+- [Using
+CloudWatch outlier detection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html)
+- [Monitoring
+Amazon ML with Amazon CloudWatch Metrics](https://docs.aws.amazon.com/machine-learning/latest/dg/cw-doc.html)
+- [New
+for Amazon SageMaker AI – Perform Shadow Tests to Compare
+Inference Performance Between ML Model Variants](https://aws.amazon.com/blogs/aws/new-for-amazon-sagemaker-perform-shadow-tests-to-compare-inference-performance-between-ml-model-variants/)
+- [Integrate
+Amazon SageMaker AI Model Cards with the model registr](https://aws.amazon.com/blogs/machine-learning/integrate-amazon-sagemaker-model-cards-with-the-model-registry/)
+- [Improve
+governance of your machine learning models with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/improve-governance-of-your-machine-learning-models-with-amazon-sagemaker/)
+
+**Related examples:**
+
+- [Monitoring
+bias drift and feature attribution drift with Amazon SageMaker AI
+Clarify](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_model_monitor/fairness_and_explainability/SageMaker AI-Model-Monitor-Fairness-and-Explainability.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops06-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLPERF01.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLPERF01.md
@@ -1,0 +1,162 @@
+# MLPERF01
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLPERF01-BP01 Determine key performance indicators
+
+Use guidance from business stakeholders to capture key performance
+indicators (KPIs) relevant to the business use case. The KPIs should
+be directly linked to business value to guide acceptable model
+performance. Consider that machine learning inferences are
+probabilistic and will not provide exact results. Identify a minimum
+acceptable accuracy and maximum acceptable error in the KPIs. This
+enables you to achieve the required business value and manage the
+risk of variable results.
+
+**Desired outcome:** By defining
+direct, measurable KPIs, ML initiatives deliver quantifiable
+business outcomes, such as cost savings, expanded scale, and faster
+response times. Clear performance thresholds set realistic
+stakeholder expectations and enable risk management based on the
+probabilistic nature of ML.
+
+**Common anti-patterns:**
+
+- Implementing ML solutions without defining clear
+business-oriented success metrics.
+- Focusing solely on technical metrics (like model accuracy)
+without connecting them to business outcomes.
+- Setting unrealistic expectations for ML performance without
+accounting for probabilistic results.
+- Failing to define acceptable error thresholds for critical
+business processes.
+- Neglecting to quantify the actual business value of ML
+implementations.
+
+**Benefits of establishing this best
+practice:**
+
+- Aligns machine learning (ML) outcomes with business objectives
+for measurable value.
+- Creates clear expectations about model performance that account
+for ML's probabilistic nature.
+- Enables objective evaluation of ML solution success based on
+business impact.
+- Improves prioritization of ML investments based on tangible
+results.
+- Accelerates decision-making by translating ML insights into
+business actions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Start by identifying business challenges ML aims to solve and how
+success translates into specific, quantifiable benefits. Engage
+stakeholders throughout KPI selection to verify that business
+priorities drive metric design. Use metrics that reflect business
+value—such as cost reduction, customer retention rate, or time
+savings—rather than technical measures alone.
+
+Regularly review KPIs to stay aligned with strategic shifts.
+Feedback from business results informs necessary adjustments to
+both models and evaluation metrics. Common pitfalls include
+proceeding without clear business KPIs, focusing only on technical
+metrics such as accuracy, or establishing unrealistic expectations
+that ignore the probabilistic nature of ML results. Failing to set
+acceptable error thresholds exposes critical business processes to
+unmanaged risk, and overlooking the business value of ML adoption
+makes it hard to measure impact or secure stakeholder support.
+
+### Implementation steps
+
+- **Quantify the value of machine
+learning for the business**. Consider measures of
+how machine learning and automation will impact the
+business:
+
+How much will machine learning reduce costs?
+- How many more users will be reached by increasing scale?
+- How much time will the business save by being able to
+respond faster to changes, such as in demand and supply
+disruptions?
+- How many hours of manual effort will be reduced by
+automating with machine learning?
+- How much will machine learning be able to change user
+behavior, such as reducing churn?
+
+- **Evaluate risks and the tolerance for
+error**. Quantify the impact of machine learning on
+the business. Rank order the value of impacts to identify
+the primary KPIs to optimize with machine learning. Define
+the cost of error for automated inferences that will be
+performed by ML models in the use case. Determine the
+tolerance of the business for error. For example, determine
+how far off a cost reduction estimate would have to be to
+negatively impact the business goals. Finally, evaluate the
+risks of machine learning for the business, and whether the
+benefits of ML solutions are of high enough value to
+outweigh those risks.
+- **Establish baseline
+metrics**. Before implementing ML solutions,
+document current performance metrics to create a baseline
+against which to measure improvements. Collect data on
+existing processes, including costs, time requirements,
+error rates, and other relevant performance indicators. This
+baseline will serve as a reference point for demonstrating
+the business value of your ML implementation.
+- **Define predictive and prescriptive
+KPIs**. Move beyond retrospective metrics to
+develop KPIs that offer predictive and prescriptive
+insights. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) and
+[Quick](https://aws.amazon.com/quicksight/) to create dashboards that visualize these
+forward-looking KPIs, making them accessible to business
+stakeholders.
+- **Create a KPI governance
+framework**. Develop a structured approach for
+monitoring, reviewing, and refining your KPIs over time.
+Gather executive alignment on metrics, establish consistent
+data collection processes, and define protocols for taking
+corrective actions when negative trends emerge. Regularly
+analyze trends and periodically refine KPIs to accurately
+gauge the business impact of ML implementations.
+- **Leverage advanced analytics for
+insights**. Enhance KPI discovery and accessibility
+by integrating advanced analytics services, such as
+[Amazon Q](https://aws.amazon.com/q/). These tools uncover hidden business patterns and
+translate complex results into conversational analytics for
+non-technical audiences.
+
+## Resources
+
+**Related documents:**
+
+- [Improve
+Business Outcomes with Machine Learning](https://aws.amazon.com/machine-learning/ml-use-cases/)
+- [AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html)
+- [Machine
+Learning (ML) Governance with Amazon SageMaker AI](https://aws.amazon.com/sagemaker/ai/ml-governance/)
+- [Amazon Q for
+Business Analytics](https://aws.amazon.com/q/)
+- [AI/ML
+| AWS Executive Insights](https://aws.amazon.com/executive-insights/generative-ai-ml/)
+- [Thought
+Leadership | Artificial Intelligence - AWS](https://aws.amazon.com/blogs/machine-learning/category/post-types/thought-leadership/)
+- [Keys
+to maximizing AI value](https://aws.amazon.com/isv/resources/keys-to-maximizing-generative-ai-value-in-software-companies/)
+
+**Related videos:**
+
+- [How
+to Drive Business Value with AI/ML](https://www.youtube.com/watch?v=W4Xd8mPqqKU)
+- [Creating
+Business Value with AWS AI/ML](https://www.youtube.com/watch?v=A2bIIznG-80)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf01-bp01.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLPERF02.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLPERF02.md
@@ -1,0 +1,420 @@
+# MLPERF02
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLPERF02-BP01 Define relevant evaluation metrics
+
+Establishing clear, meaningful evaluation metrics is essential for
+validating machine learning model performance against business
+objectives. By selecting metrics that directly relate to your key
+performance indicators (KPIs), you can verify that your ML solutions
+deliver measurable business value.
+
+**Desired outcome:** You have a
+comprehensive set of evaluation metrics that accurately reflect your
+business requirements and tolerance for errors. These metrics enable
+you to tune your models directly to business objectives, monitor
+performance in production, and make data-driven decisions about
+model improvements.
+
+**Common anti-patterns:**
+
+- Using the same generic metrics for each model type regardless of
+business context.
+- Focusing only on technical metrics without considering business
+impact.
+- Overlooking the cost implications of different types of errors
+(false positives and false negatives).
+- Failing to establish baseline performance metrics before
+deployment.
+- Neglecting continuous monitoring of metrics after model
+deployment.
+
+**Benefits of establishing this best
+practice:**
+
+- Alignment of ML models with business goals and objectives.
+- Better decision-making through quantifiable performance
+measurement.
+- Early detection of model degradation or concept drift.
+- Improved ROI from ML investments.
+- Clearer communication between technical teams and business
+stakeholders.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When developing machine learning solutions, establish evaluation
+metrics that directly connect to your business objectives. These
+metrics must reflect how well your model performs in the context
+of your specific use case rather than relying solely on generic
+technical measures.
+
+Avoid focusing only on technical metrics without considering
+business impact. Many organizations use the same metrics for each
+model type regardless of business context, overlook the cost
+implications of different types of errors, fail to establish
+baseline performance metrics before deployment, and neglect
+continuous monitoring after deployment.
+
+For example, in a predictive maintenance scenario, the business
+impact of false positives (unnecessarily replacing functioning
+equipment) differs from false negatives (missing actual failures).
+Understand these business implications to select appropriate
+metrics like precision (minimizing false positives) or recall
+(minimizing false negatives) based on which error type is more
+costly to your business.
+
+Different ML problem types require different evaluation
+approaches. Classification models benefit from confusion matrices
+that break down performance by class, while regression models need
+error measurements that quantify prediction deviations. Custom
+metrics can be developed when standard metrics don't adequately
+capture business requirements.
+
+Continuous monitoring of these metrics in production is crucial
+for detecting model drift and improving ongoing performance.
+Setting up automated alerts when metrics fall below thresholds
+allows for timely intervention and model updates.
+
+### Implementation steps
+
+- **Align metrics to business
+objectives**. Begin by clearly understanding the
+KPIs established during the business goal identification
+phase. Determine how ML model performance directly impacts
+these KPIs and identify which types of errors are most
+costly to the business. For example, in fraud detection,
+false negatives (missed fraudulent transactions) may be more
+costly than false positives.
+- **Select appropriate evaluation
+metrics**. Choose metrics based on your ML problem
+type:
+
+**For classification
+problems:** Implement confusion matrix
+derivatives (precision, recall, accuracy, F1 score),
+AUC, or log-loss as appropriate for your use case
+- **For regression
+problems:** Utilize RMSE, MAPE, or other error
+measures that align with business sensitivity to
+prediction errors
+- **For recommendation
+systems:** Consider metrics like Normalized
+Discounted Cumulative Gain (NDCG) or precision@k
+- **For time series
+forecasting:** Apply metrics like Mean Absolute
+Scaled Error (MASE) or symmetric Mean Absolute
+Percentage Error (sMAPE)
+
+- **Develop custom metrics if
+needed**. When standard metrics don't adequately
+capture business requirements, create custom evaluation
+metrics that better reflect the business objectives. Use
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to implement these custom metrics during
+model training and evaluation.
+- **Establish performance
+thresholds**. Calculate the maximum acceptable
+error probability required for the ML model based on
+business tolerance levels. Document these thresholds as
+acceptance criteria for model deployment.
+- **Implement comparative
+experimentation**. Use
+[Amazon SageMaker AI Managed MLFlow 3.0](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to organize, track, and
+compare different models trained with various
+hyperparameters and approaches. The enhanced MLFlow
+integration provides robust experiment management at scale
+for complex ML projects. This structured experimentation
+identifies models that optimize your selected metrics within
+acceptable bounds.
+- **Monitor metrics in
+production**. Deploy
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to track model and concept
+drift in real time. Configure alerts when metrics deviate
+from expected performance thresholds, enabling prompt
+remediation actions.
+- **Incorporate feedback
+loops**. Establish mechanisms to collect real-world
+performance data and incorporate it into your evaluation
+process. This feedback assists you to refine metrics and
+models over time to better align with evolving business
+needs.
+- **Balance competing
+metrics**. When multiple metrics are relevant,
+establish a weighting system that reflects their relative
+importance to business outcomes. Document this
+decision-making framework for consistency in model
+evaluation.
+- **Implement bias detection and model
+explainability**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) to detect bias in your models and
+provide explanations for model predictions. Your evaluation
+framework should include fairness and interpretability
+considerations alongside performance metrics.
+- **Establish automated model evaluation
+pipelines**. Create automated evaluation workflows
+that run consistently across different model versions and
+training iterations. Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) to standardize your evaluation processes
+and provide reproducible results.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon CloudWatch Metrics for Monitoring and Analyzing Training
+Jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/training-metrics.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Evaluate,
+explain, and detect bias in models](https://docs.aws.amazon.com/sagemaker/latest/dg/model-explainability.html)
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+
+**Related videos:**
+
+- [Organize,
+Track, and Evaluate ML Training Runs with Amazon SageMaker AI
+Managed MLFlow](https://www.youtube.com/watch?v=zLOMYKZGxK0)
+- [Foundation
+model evaluation with SageMaker AI Clarify](https://aws.amazon.com/awstv/watch/31248d9d747/)
+- [How
+to efficiently manage ML and Gen AI experiments](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+
+**Related examples:**
+
+- [Scikit-Learn
+Data Processing and Model Evaluation](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_processing/scikit_learn_data_processing_and_model_evaluation)
+- [Amazon SageMaker AI Model Monitor Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf02-bp01.html*
+
+---
+
+# MLPERF02-BP02 Use purpose-built AI and ML services and resources
+
+Consider how the workload could be handled by pre-built AI services
+or ML resources. Better performance can often be delivered more
+efficiently by using pre-optimized components included in AI and ML
+managed services. Select an optimal mix of bespoke and pre-built
+components to meet the workload requirements.
+
+**Desired outcome:** You achieve a
+balanced approach to your machine learning workloads by implementing
+purpose-built AI and ML services and resources. You leverage
+pre-built components where appropriate to accelerate development,
+reduce management overhead, and improve performance while
+maintaining the flexibility to create custom solutions where your
+business needs demand it. This approach optimizes both your team's
+productivity and the overall effectiveness of your AI/ML solutions.
+
+**Common anti-patterns:**
+
+- Building ML components from scratch when suitable pre-built
+solutions exist.
+- Failing to evaluate the full range of AWS AI and ML services
+before starting development.
+- Over-customizing solutions when standard services would
+adequately meet requirements.
+- Underutilizing AWS marketplace solutions and pre-trained models.
+- Not considering hybrid approaches that combine managed services
+with custom ML models.
+
+**Benefits of establishing this best
+practice:**
+
+- Accelerated time-to-market for ML solutions.
+- Reduced operational overhead for maintaining ML infrastructure.
+- Lower development costs through leveraging pre-built components.
+- Access to continuously improved and updated AI technologies.
+- Ability to focus resources on high-value business
+differentiators.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Implement purpose-built AI and ML services to focus on business
+outcomes rather than infrastructure management. AWS provides a
+comprehensive portfolio of AI services, ranging from ready-to-use
+APIs to fully customizable ML solutions. Each service addresses
+different levels of complexity and customization requirements.
+
+When evaluating your ML workloads, assess which components could
+benefit from managed services. Tasks like image classification,
+regression, clustering, or time series forecasting can often be
+accomplished with
+[SageMaker AI
+built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) without requiring custom algorithm
+development. For more specialized needs, you can leverage
+pre-trained models through services like
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) or develop custom models using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/).
+
+Resist the temptation to over-customize solutions when standard
+services would adequately meet requirements. Organizations often
+underutilize AWS marketplace solutions and pre-trained models,
+missing opportunities to accelerate development. The key is
+finding the right balance between using managed services for
+common ML tasks and building custom solutions for your unique
+business requirements. Consider hybrid approaches that combine
+managed services with custom ML models rather than pursuing an
+all-or-nothing strategy.
+
+Consider your team's capabilities when making these decisions. If
+you lack specialized ML expertise, starting with fully managed AI
+services provides immediate value while your team builds skills.
+As your team's capabilities grow, you can selectively add custom
+components where they provide strategic advantage.
+
+### Implementation steps
+
+- **Assess your ML use cases and
+requirements**. Begin by clearly defining your
+business use cases and understanding the ML capabilities
+needed. Evaluate whether your requirements can be met by
+pre-built services or require custom development. Consider
+factors like accuracy requirements, latency needs, and the
+availability of training data.
+- **Learn about AWS managed AI
+services**. Determine whether
+[AWS managed AI services](https://aws.amazon.com/machine-learning/ai-services/) are applicable to the business
+use case. Understand how managed AWS AI services can relieve
+the burden of training and maintaining an ML pipeline. Use
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to develop in the cloud and understand the
+roles and responsibilities needed to maintain the ML
+workload. Consider combining managed AI services with custom
+ML models built on Amazon SageMaker AI.
+- **Explore SageMaker AI built-in
+algorithms and automated ML capabilities**. Learn
+about
+[SageMaker AI
+built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) for supervised learning tasks
+like classification, regression, and forecasting. Consider
+[SageMaker AI
+Autopilot](https://docs.aws.amazon.com/sagemaker/latest/dg/autopilot-automate-model-development.html) for automated machine learning that handles
+data analysis, feature engineering, algorithm selection, and
+hyperparameter tuning. Explore
+[Amazon SageMaker AI JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) for pre-trained models across
+various ML domains, including
+[foundation
+models](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-foundation-models.html) that can be fine-tuned for your specific ML
+tasks. For enterprise environments, implement
+[SageMaker AI
+JumpStart Private Model Hubs](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html) to create curated
+repositories of both prebuilt and custom models with
+centralized governance and version management.
+- **Investigate marketplace
+solutions**. Learn about
+[SageMaker AI
+Algorithms and Models in AWS Marketplace](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-marketplace.html), a curated
+digital catalog that makes it simple for you to find, buy,
+deploy, and manage third-party software and services.
+Explore specialized algorithms or pre-trained models that
+might be relevant to your use case.
+- **Implement a hybrid approach where
+appropriate**. Design your ML architecture to
+leverage the most suitable services for each component. Use
+AWS managed services for standard ML tasks and focus custom
+development on business differentiators. This balanced
+approach optimizes both development efficiency and solution
+effectiveness.
+- **Establish a model evaluation
+framework**. Create a systematic process for
+evaluating pre-built models against your requirements.
+Define clear metrics for accuracy, latency, cost, and other
+relevant factors. Use this framework to make data-driven
+decisions about which components to build versus buy.
+- **Plan for operational
+integration**. Verify that your chosen ML services
+can integrate effectively with your existing systems and
+workflows. Design appropriate data pipelines, APIs, and
+monitoring systems to support your hybrid ML architecture.
+For development flexibility, leverage remote IDE
+connectivity to securely connect third-party developer
+environments such as VS Code to SageMaker AI Studio, enabling
+professional MLOps workflows while maintaining centralized
+governance. Consider security, regulatory adherence, and
+governance requirements when implementing these
+integrations.
+- **Optimize model performance and
+deployment**. Use
+[SageMaker AI
+model optimization](https://docs.aws.amazon.com/sagemaker/latest/dg/model-optimize.html) capabilities including
+quantization, compilation, and speculative decoding to
+improve inference performance. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to automatically benchmark and
+select optimal instance types, configurations, and
+parameters for your inference endpoints. Deploy using
+[SageMaker AI
+deployment options](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html) such as real-time hosting,
+serverless inference, or batch transform based on your
+latency and throughput requirements.
+- **Implement model monitoring and
+governance**. Establish monitoring for model
+performance, data drift, and model drift using
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html). Implement proper model versioning, A/B
+testing capabilities, and rollback procedures to maintain
+model quality and reliability in production environments.
+
+## Resources
+
+**Related documents:**
+
+- [Built-in
+algorithms and pretrained models in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html)
+- [SageMaker AI
+JumpStart Foundation Models](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-foundation-models.html)
+- [Private
+curated hubs for foundation model access control in
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html)
+- [Best
+practices for deploying models on SageMaker AI Hosting
+Services](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html)
+- [Inference
+optimization for Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/model-optimize.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Model
+deployment options in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html)
+- [Distributed
+training optimization](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training-optimize.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Machine
+Learning on AWS](https://aws.amazon.com/machine-learning/)
+- [Architecture
+Best Practices for Machine Learning](https://aws.amazon.com/architecture/machine-learning/)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [SageMaker AI
+Algorithms and Models in AWS Marketplace](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-marketplace.html)
+- [Docker
+containers for training and deploying models](https://docs.aws.amazon.com/sagemaker/latest/dg/docker-containers.html)
+- [Train
+a Model with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html)
+
+**Related videos:**
+
+- [Building
+and Deploying ML Models Fast with Amazon SageMaker AI
+JumpStart](https://www.youtube.com/watch?v=i4W7SfP6_38)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf02-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLPERF03.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLPERF03.md
@@ -1,0 +1,231 @@
+# MLPERF03
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLPERF03-BP01 Use a modern data architecture
+
+Get the best insights from exponentially growing data using a modern
+data architecture. This architecture enables movement of data
+between a data lake and purpose-built stores including a data
+warehouse, relational databases, non-relational databases, ML and
+big data processing, and log analytics. A data lake provides a
+single place to run analytics across mixed data structures collected
+from disparate sources. Purpose-built analytics services provide the
+speed required for specific use cases like real-time dashboards and
+log analytics.
+
+**Desired outcome:** You implement a
+modern data architecture that enables seamless data movement between
+storage systems, provides unified governance, and supports diverse
+ML workloads. This architecture accelerates data preparation,
+improves data quality, and enables efficient feature engineering for
+machine learning models.
+
+**Common anti-patterns:**
+
+- Creating isolated data silos where different teams manage
+separate data stores without coordination.
+- Building data architecture without establishing proper
+governance, access controls, or compliance-aligned frameworks.
+- Using one-size-fits-all storage solutions without considering
+specific workload requirements.
+- Relying on manual processes for data movement, transformation,
+and quality checks.
+- Neglecting to implement proper data cataloging and discovery
+mechanisms.
+
+**Benefits of establishing this best
+practice:**
+
+- Unified data governance and access control across data stores.
+- Reduced data preparation time through integrated data services.
+- Improved data quality and consistency for ML model training.
+- Enhanced scalability for growing data volumes and ML workloads.
+- Better cost optimization through purpose-built storage
+solutions.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When building machine learning solutions, you need a modern data
+architecture that can handle diverse data types, support various
+ML workloads, and provide unified governance across data stores.
+This architecture enables efficient data movement between storage
+systems while maintaining security, quality, and cost
+optimization.
+
+Avoid creating isolated data silos where different teams manage
+separate data stores without coordination. Many organizations
+struggle with inconsistent data governance policies across
+different storage systems, lack unified access controls for ML
+teams, fail to implement proper data cataloging and discovery
+mechanisms, and neglect to optimize storage costs based on access
+patterns. These issues create bottlenecks in ML workflows and
+increase operational complexity.
+
+For example, in a retail ML use case, you might need to combine
+customer transaction data from a data warehouse, real-time
+clickstream data from streaming services, and product catalog
+information from operational databases. A modern data architecture
+enables seamless access to these data sources while maintaining
+consistent security policies and enabling efficient feature
+engineering for recommendation models.
+
+Different ML workloads require different data access patterns.
+Batch training jobs benefit from optimized data lake storage with
+efficient querying capabilities, while real-time inference
+requires low-latency access to feature stores and streaming data
+pipelines. Custom data processing workflows can be developed when
+standard ETL processes don't adequately support your specific ML
+requirements.
+
+Continuous monitoring of data quality and pipeline performance is
+crucial for maintaining reliable ML systems. Setting up automated
+data quality checks and pipeline monitoring allows for early
+detection of data issues that could impact model performance.
+
+### Implementation steps
+
+- **Design your data lake
+foundation**. Begin by establishing a centralized
+data lake using
+[Amazon S3](https://aws.amazon.com/s3/) as the primary storage layer. Organize data using
+a logical structure that supports both current and future ML
+use cases, such as organizing by business domain, data
+source, and processing stage. Implement data partitioning
+strategies based on common query patterns to optimize
+performance and reduce costs. For example, partition
+time-series data by date and customer data by region to
+enable efficient querying for ML feature extraction.
+- **Implement unified data
+governance**. Use
+[AWS Lake Formation](https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html) to build a scalable and secure data
+lake with centralized governance. Establish consistent
+security policies, access controls, and audit trails across
+data stores. Apply fine-grained permissions that enable
+self-service access for ML practitioners while maintaining
+security and and addressing requirements. Create data
+stewardship roles and processes to improve ongoing data
+quality and governance.
+- **Integrate purpose-built analytics
+services**. Build a high-speed analytic layer with
+purpose-built services selected based on your specific ML
+workload requirements:
+
+Use
+[Amazon Redshift](https://aws.amazon.com/redshift/) for data warehousing and complex
+analytical queries
+- Implement
+[Amazon Kinesis](https://aws.amazon.com/kinesis/) for real-time streaming data processing
+- Deploy
+[Amazon Athena](https://aws.amazon.com/athena/) for interactive queries and ad-hoc
+analysis
+- Consider
+[Amazon DynamoDB](https://aws.amazon.com/dynamodb/) for high-performance operational
+workloads
+- Use
+[Amazon Timestream](https://aws.amazon.com/timestream/) for time-series data applications
+
+- **Enable seamless data
+integration**. Use
+[AWS Glue](https://aws.amazon.com/glue/) to integrate data across services and data
+stores. Implement automated data cataloging to maintain
+metadata and enable data discovery across your organization.
+Create ETL pipelines that prepare data for ML workloads
+while maintaining data lineage and enabling reproducibility.
+Design workflows that can handle both batch and streaming
+data processing requirements.
+- **Optimize for ML
+workloads**. Design data pipelines that support
+both batch and real-time ML training scenarios. Implement
+feature stores using services like
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to manage and share ML
+features across teams and models. Create standardized
+feature engineering processes that can be reused across
+different ML projects and provide consistent data
+transformations.
+- **Establish data quality
+monitoring**. Implement automated data quality
+checks and monitoring for data reliability for ML models.
+Use
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) for data profiling and quality
+assessment. Set up automated alerts for data quality issues
+such as missing values, schema changes, or statistical
+anomalies that could impact ML model performance.
+- **Implement cost optimization
+strategies**. Use appropriate storage classes in
+Amazon S3 based on data access patterns. Implement lifecycle
+policies to automatically transition data to lower-cost
+storage tiers such as S3 Infrequent Access or Amazon Glacier for
+archival data. Monitor and optimize query performance to
+control compute costs, and use reserved capacity where
+appropriate for predictable workloads.
+- **Enable real-time data
+processing**. For ML use cases requiring real-time
+inference, implement streaming data pipelines using Amazon Kinesis and
+[AWS Lambda](https://aws.amazon.com/lambda/) to process data as it arrives and update
+feature stores in near real-time. Design architectures that
+can handle varying data volumes and provide consistent
+low-latency access to features for real-time ML predictions.
+- **Implement data lineage and
+versioning**. Establish comprehensive data lineage
+tracking to understand data flow from source to ML models.
+Use versioning for both datasets and feature definitions to
+enable reproducible ML experiments and model rollbacks when
+necessary. This is crucial for improving regulatory
+adherence and debugging ML model issues.
+- **Create self-service data
+access**. Build data catalogs and discovery tools
+that enable ML practitioners to find and access relevant
+data without requiring deep technical knowledge of the
+underlying storage systems. Implement standardized APIs and
+interfaces that abstract the complexity of the data
+architecture while providing the flexibility needed for
+diverse ML workloads.
+
+## Resources
+
+**Related documents:**
+
+- [The
+lakehouse architecture of Amazon SageMaker AI](https://aws.amazon.com/sagemaker/lakehouse/)
+- [Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/)
+- [What
+is AWS Lake Formation?](https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html)
+- [AWS Lake Formation: How it works](https://docs.aws.amazon.com/lake-formation/latest/dg/how-it-works.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [What
+is AWS Glue?](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html)
+- [Modern
+Data Architecture on AWS](https://aws.amazon.com/big-data/datalakes-and-analytics/data-lake-house/)
+- [Amazon SageMaker AI Lakehouse | AWS Big Data
+Blog](https://aws.amazon.com/blogs/big-data/category/analytics/amazon-sagemaker-lakehouse/)moving-from-notebooks-to-automated-ml-pipelines-using-amazon-sagemaker-and-aws-glue/)
+- [Amazon SageMaker AI | AWS Big Data Blog](https://aws.amazon.com/blogs/big-data/category/artificial-intelligence/sagemaker/)
+
+**Related videos:**
+
+- [Understanding
+Amazon S3 Tables: Architecture, performance, and
+integration](https://www.youtube.com/watch?v=e1ypMWSHgsM)
+- [Accelerate
+your Analytics and AI with Amazon SageMaker AI LakeHouse](https://www.youtube.com/watch?v=qZTbS0xPN-U)
+- [Unifying
+data governance with Immuta and AWS Lake Formation](https://www.youtube.com/watch?v=X09-n2jJZKw)
+- [The
+lake house approach to data warehousing with Amazon Redshift](https://www.youtube.com/watch?v=35wXL0Q1Dcc)
+
+**Related services:**
+
+- [AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/)
+- [Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/data-streams/)
+- [Amazon Athena](https://aws.amazon.com/athena/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf03-bp01.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLPERF04.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLPERF04.md
@@ -1,0 +1,1041 @@
+# MLPERF04
+
+**Pillar**: Unknown  
+**Best Practices**: 6
+
+---
+
+# MLPERF04-BP01 Optimize training and inference instance types
+
+Selecting appropriate instance types for training and inference
+workloads provides optimal performance, reduced costs, and faster
+time-to-market for your machine learning models. By understanding
+your model's specific requirements and data characteristics, you can
+choose the right computational resources to maximize efficiency.
+
+**Desired outcome:** You achieve
+optimal performance and cost-effectiveness for your machine learning
+workloads by selecting appropriate instance types for both training
+and inference. You understand how model complexity and data
+characteristics influence hardware decisions, enabling you to
+accelerate model development, improve inference speeds, and manage
+resources efficiently.
+
+**Common anti-patterns:**
+
+- Using the same instance type for both training and inference
+workloads.
+- Overprovisioning resources just to be safe without performance
+testing.
+- Selecting expensive GPU instances for inference when CPU
+instances would suffice.
+- Ignoring model-specific hardware requirements when selecting
+instances.
+- Not scaling training across multiple instances for large
+datasets.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced training time and faster model iterations.
+- Lower operational costs through right-sized resources.
+- Improved inference latency and throughput.
+- Better utilization of available computational resources.
+- Enhanced scalability for varying workloads.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Understanding how your model type and data characteristics
+influence instance selection is essential for optimizing machine
+learning workloads. For training, the computational requirements
+depend largely on the model complexity, dataset size, and training
+approach. Deep learning models, particularly those processing
+image, video, or language data, often benefit from GPU-accelerated
+instances due to their parallel processing capabilities.
+Meanwhile, traditional machine learning algorithms may be
+efficiently trained on CPU instances.
+
+For inference, requirements vary based on deployment scenarios.
+Real-time applications with strict latency requirements might need
+powerful compute-optimized instances, while batch prediction
+workloads can use more cost-effective options. Generally, CPUs are
+sufficient for many inference scenarios, though complex models may
+still benefit from GPU acceleration.
+
+When evaluating instance options, consider memory requirements
+(especially for large models or datasets), network performance for
+distributed training, and storage I/O capabilities when working
+with large datasets. The right balance between performance and
+cost is key to sustainable machine learning operations.
+
+### Implementation steps
+
+- **Analyze your model and data
+requirements**. Begin by understanding the
+computational needs of your machine learning algorithm.
+Assess memory requirements, model complexity, and dataset
+size. For deep learning models processing image, video, or
+language data, GPU instances like P4, G4, or P3 typically
+offer the best performance. For traditional ML algorithms,
+CPU instances may be more cost-effective.
+- **Benchmark different instance types
+for training**. Run small-scale training jobs
+across various instance types in
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to measure performance and cost metrics.
+Compare training times, resource utilization, and overall
+costs to identify the optimal instance type for your model.
+Track
+[Experiments
+with Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to track and compare results.
+- **Implement distributed training for
+large datasets**. For large datasets or complex
+models, leverage distributed training across multiple
+instances to reduce training time. Use
+[SageMaker AI
+distributed training libraries](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training.html) to automatically
+partition data and optimize communication between nodes,
+which accelerates training for deep learning models.
+- **Optimize storage configuration for
+I/O performance**. Configure fast storage options
+to avoid I/O bottlenecks during training. Consider using
+[Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) for high-performance file systems or
+optimize your data pipeline to use
+[Amazon S3](https://aws.amazon.com/s3/) efficiently. Proper data formatting and efficient
+loading strategies can improve GPU utilization.
+- **Select appropriate inference
+instance types**. Evaluate latency and throughput
+requirements for your inference needs. For real-time
+inference with strict latency requirements, consider
+compute-optimized instances or GPU-accelerated instances for
+complex models. For batch inference, less expensive CPU
+instances often suffice. Use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to get automated
+recommendations for optimal deployment configurations.
+- **Monitor and optimize
+costs**. Implement continuous monitoring of
+resource utilization and costs. Use
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and
+[SageMaker AI
+Studio](https://aws.amazon.com/sagemaker/studio/) resource monitoring to identify
+inefficiencies. Consider using
+[Amazon SageMaker AI Savings Plans](https://aws.amazon.com/savingsplans/ml-pricing/) for frequently used instance
+types to reduce costs.
+- **Consider model optimization
+techniques**. Implement model optimization
+techniques like quantization, pruning, or knowledge
+distillation to reduce computational requirements for both
+training and inference. Explore using
+[SageMaker AI
+Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize models for target
+hardware.
+- **Explore serverless inference
+options**. For variable or unpredictable workloads,
+consider
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) to automatically scale
+resources based on traffic and avoid the need to choose
+instance types manually.
+- **Leverage specialized ML
+hardware**. For large-scale training and inference
+workloads, consider
+[AWS Trainium instances](https://docs.aws.amazon.com/dlami/latest/devguide/trainium.html) for training and AWS Inferentia
+instances for inference to achieve better price-performance
+ratios compared to traditional GPU instances.
+
+## Resources
+
+**Related documents:**
+
+- [Train
+a Model with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html)
+- [Deploy
+models for inference](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-model.html)
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Recommended
+Trainium Instances](https://docs.aws.amazon.com/dlami/latest/devguide/trainium.html)
+- [What
+are AWS Deep Learning Containers?](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html)
+- [Learn
+how to select ML instances on the fly in Amazon SageMaker AI
+Studio](https://aws.amazon.com/blogs/machine-learning/learn-how-to-select-ml-instances-on-the-fly-in-amazon-sagemaker-studio/)
+- [Ensure
+efficient compute resources on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/right-sizing-resources-and-avoiding-unnecessary-costs-in-amazon-sagemaker/)
+
+**Related videos:**
+
+- [How
+to choose the right instance type for ML inference](https://www.youtube.com/watch?v=0DSgXTN7ehg)
+- [The
+right instance type in Amazon SageMaker AI](https://www.youtube.com/watch?v=vRB9Uncsia8)
+
+**Related examples:**
+
+- [Amazon SageMaker AI End-to-End Example](https://github.com/aws/amazon-sagemaker-examples/tree/main/end_to_end)
+- [SageMaker AI
+Inference Recommender Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-inference-recommender)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp01.html*
+
+---
+
+# MLPERF04-BP02 Explore alternatives for performance improvement
+
+Benchmarking your machine learning models allows you to
+systematically improve performance by evaluating and comparing
+different algorithms, features, and architectural resources. Use
+this practice to identify the optimal combination and achieve your
+desired performance metrics.
+
+**Desired outcome:** You implement a
+systematic approach to improving your machine learning model's
+performance through benchmarking various techniques. You'll
+establish a baseline model and methodically explore alternatives
+including data volume increases, feature engineering, algorithm
+selection, ensemble methods, and hyperparameter tuning. This results
+in optimized models that provide higher accuracy and better business
+value.
+
+**Common anti-patterns:**
+
+- Selecting a complex algorithm without establishing a baseline.
+- Ignoring feature engineering in favor of only trying different
+algorithms.
+- Using more data without understanding its quality or relevance.
+- Focusing exclusively on accuracy while ignoring other important
+metrics.
+- Manually testing hyperparameters without a systematic approach.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model accuracy and performance.
+- Better understanding of which factors most influence model
+performance.
+- More efficient use of computational resources.
+- Systematic approach to model improvement instead of random
+experimentation.
+- Ability to document and reproduce experiments for future
+reference.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Performance improvement in machine learning requires a structured,
+iterative approach. Benchmarking assists you in systematically
+comparing different approaches and determining the most effective
+path to improved model performance. Start by establishing a
+baseline with simple algorithms and obvious features, then
+methodically explore alternatives to improve upon that baseline.
+
+You can explore multiple avenues for improving performance:
+increasing data volume, engineering better features, selecting
+more appropriate algorithms, combining models through ensemble
+methods, and tuning hyperparameters. Each approach provides unique
+benefits and may be more or less effective depending on your use
+case. The key is to follow a systematic process, measure results
+accurately, and document what you learn.
+
+### Implementation steps
+
+- **Establish a baseline
+model**. Start with a simple architecture, obvious
+features, and a straightforward algorithm to create your
+baseline. Use
+[Amazon SageMaker AI built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) to quickly develop this
+initial model. This gives you a reference point for
+comparing future experiments and improvements.
+- **Set up experiment
+tracking**. Use
+[Amazon SageMaker AI Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to organize, track, compare,
+and evaluate your machine learning experiments. Create a
+structured framework that tracks performance metrics,
+algorithm choices, features used, and hyperparameter
+settings so you can effectively compare results across
+different approaches.
+- **Test different
+algorithms**. Systematically test various
+algorithms, starting with simpler ones and progressively
+trying more complex options. SageMaker AI provides many
+built-in algorithms that you can compare. Document how each
+algorithm performs relative to your baseline and identify
+which ones show the most promise for your data and problem.
+- **Apply feature
+engineering**. Extract important signals in your
+data through feature engineering. This may include feature
+selection, transformation, creation of new features,
+normalization, and encoding techniques. Use
+[SageMaker AI
+Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-create-feature-group.html) to manage and share features across
+experiments and teams.
+- **Increase data volume and
+quality**. Evaluate whether adding more data or
+improving data quality could assist your model. More data
+often broadens the statistical range and improve model
+performance, but only if the additional data is relevant and
+of good quality.
+- **Implement ensemble
+methods**. Combine multiple models to leverage
+different strengths and compensate for individual
+weaknesses. Techniques like bagging, boosting, and stacking
+can often improve overall accuracy. SageMaker AI makes it
+simple to implement ensemble predictions from multiple
+models.
+- **Perform hyperparameter
+tuning**. Use
+[Amazon SageMaker AI Automatic Model Tuning](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html) to optimize your
+model's hyperparameters. This service automates the search
+through different hyperparameter combinations to find
+optimal values that improve model performance. You can run
+multiple HPO jobs in parallel to speed up the process.
+- **Evaluate improvements
+systematically**. For each change, rigorously
+evaluate whether performance has improved based on relevant
+metrics for your problem. Use SageMaker AI's evaluation tools
+to compare results across experiments and determine which
+approaches deliver the most gains.
+- **Optimize for production**.
+Once you've identified the best performing approach,
+optimize it for production deployment. Consider factors like
+inference latency, model size, and resource requirements
+alongside pure performance metrics.
+- **Document findings and
+methodology**. Create comprehensive documentation
+of your benchmarking process, including what worked, what
+didn't, and why. This provides valuable information for
+future model improvements and builds institutional
+knowledge.
+
+## Resources
+
+**Related documents:**
+
+- [Built-in
+algorithms and pretrained models in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [Use
+Feature Store with SDK for Python (Boto3)](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-create-feature-group.html)
+- [Feature
+Processing with Spark ML and Scikit-learn](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-mleap-scikit-learn-containers.html)
+- [Running
+multiple HPO jobs in parallel on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/running-multiple-hpo-jobs-in-parallel-on-amazon-sagemaker/)
+- [Optimizing
+portfolio value with Amazon SageMaker AI automatic model
+tuning](https://aws.amazon.com/blogs/machine-learning/optimizing-portfolio-value-with-amazon-sagemaker-automatic-model-tuning/)
+
+**Related videos:**
+
+- [How
+To Efficiently Manage ML experiments using Amazon SageMaker AI ML
+Flow](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+- [Train
+large models on Amazon SageMaker AI for scale and
+performance](https://www.youtube.com/watch?v=cryA1LFwS98)
+
+**Related examples:**
+
+- [Feature
+Engineering Immersion Day Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab1-feature-engineering)
+- [Ensemble
+Predictions From Multiple Models](https://sagemaker-examples.readthedocs.io/en/latest/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.html)
+- [Amazon SageMaker AI Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp02.html*
+
+---
+
+# MLPERF04-BP03 Establish a model performance evaluation pipeline
+
+Establish an end-to-end model performance evaluation pipeline that
+captures key metrics to evaluate your model's success, align with
+business KPIs, and automatically test performance when models or
+data are updated.
+
+**Desired outcome:** You can
+systematically evaluate model performance through automated
+pipelines that measure relevant metrics specific to your use case.
+Your evaluation process runs automatically whenever model or data
+updates occur, creating a continuous quality assessment. This
+assists you in maintaining high-performing models that deliver
+business value while providing transparency into model behavior and
+performance over time.
+
+**Common anti-patterns:**
+
+- Relying solely on training accuracy without considering
+real-world performance metrics.
+- Manual evaluation of models that leads to inconsistency.
+- Using generic metrics that don't align with business KPIs.
+- Waiting until deployment to evaluate model performance.
+- Not establishing automated evaluation triggers when models or
+data change.
+
+**Benefits of establishing this best
+practice:**
+
+- Verifies that models maintain expected performance levels over
+time.
+- Provides data-driven decision making for model selection and
+deployment.
+- Aligns machine learning outcomes with business objectives.
+- Enables faster identification and resolution of performance
+degradation.
+- Improves regulatory adherence through consistent evaluation
+protocols.
+- Increases stakeholder confidence through transparent performance
+reporting.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model performance evaluation is critical to verify that your
+machine learning solutions deliver on their intended business
+outcomes. By establishing a robust, automated evaluation pipeline,
+you can consistently assess how well your models perform against
+business KPIs and make data-driven decisions about deployment
+readiness.
+
+Avoid relying solely on training accuracy without considering
+real-world performance metrics. Many organizations use manual,
+ad-hoc evaluation of models that leads to inconsistency, use
+generic metrics that don't align with business KPIs, wait until
+deployment to evaluate model performance, and fail to establish
+automated evaluation runs when models or data change.
+
+Your evaluation pipeline should incorporate metrics specific to
+your use case. For regression problems, this might include Root
+Mean Squared Error (RMSE). For classification tasks, accuracy,
+precision, recall, F1 score, and area under the curve (AUC) are
+common metrics. These technical metrics should tie directly to
+business KPIs, helping stakeholders understand the model's
+contribution to business goals.
+
+Automating the evaluation process provides consistency and reduces
+manual errors. When new data arrives or models are updated, your
+pipeline should automatically run evaluations, providing
+continuous feedback on model performance and enabling rapid
+identification of any degradation issues.
+
+### Implementation steps
+
+- **Define business objectives and
+evaluation criteria**. Begin by clearly defining
+what success means for your machine learning use case.
+Identify relevant business KPIs and determine which
+technical metrics (like accuracy, precision, recall, F1
+score, RMSE, AUC) best align with these business goals.
+Document these metrics and their target values to establish
+clear evaluation criteria.
+- **Create an end-to-end workflow with
+Amazon SageMaker AI Pipelines**. Start with a workflow
+template to establish an initial infrastructure for model
+training and deployment.
+[SageMaker AI
+Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) can automate different steps of the ML
+workflow including data loading, data transformation,
+training, tuning, and deployment. Within SageMaker AI
+Pipelines, the
+[SageMaker AI
+Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) tracks model versions and respective
+artifacts, including metadata and lineage data collected
+throughout the model development lifecycle.
+- **Implement model evaluation
+components in your pipeline**. Design dedicated
+evaluation steps within your pipeline that calculate
+relevant metrics for your model. Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) jobs or custom Python scripts to perform
+evaluations on validation datasets. Store evaluation results
+in a central location for tracking performance over time.
+- **Set up automated prompts for
+evaluation**. Configure your pipeline to
+automatically initiate the evaluation process whenever
+there's a model update or new training data becomes
+available. This provides continuous quality assessment and
+identifies performance degradation early.
+- **Create visualization and reporting
+mechanisms**. Implement dashboards or reports that
+display model performance metrics in a straightforward
+format. Stakeholders can use visualizations to quickly
+assess model performance against business KPIs and make
+informed decisions about model deployment.
+- **Establish model approval
+workflows**. Define criteria for model approval
+based on evaluation results. Implement approval workflows in
+the SageMaker AI Model Registry that automatically promote
+models meeting performance thresholds to production, while
+flagging underperforming models for review.
+- **Implement A/B testing
+capabilities**. For production models, set up A/B
+testing infrastructure to compare performance of new models
+against baseline models using real-world data. This provides
+additional validation before fully deploying model updates.
+- **Monitor production model
+performance**. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously monitor
+deployed models for data drift, model drift, and performance
+degradation. Set up alerts when performance metrics fall
+below acceptable thresholds.
+- **Implement bias detection and
+fairness evaluation**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html) to detect bias in your models and
+check fairness across different demographic groups. Include
+bias metrics as part of your evaluation criteria.
+- **Create feedback loops for continuous
+improvement**. Design mechanisms to capture
+feedback from production model performance and incorporate
+these insights into future model iterations. This creates a
+cycle of continuous improvement based on real-world
+performance.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Define
+a pipeline](https://docs.aws.amazon.com/sagemaker/latest/dg/define-pipeline.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness
+and Explainability with SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html)
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Extend
+Amazon SageMaker AI Pipelines to include custom steps using
+callback steps](https://aws.amazon.com/blogs/machine-learning/extend-amazon-sagemaker-pipelines-to-include-custom-steps-using-callback-steps/)
+
+**Related videos:**
+
+- [Amazon SageMaker AI Pipelines](https://www.youtube.com/watch?v=Hvz2GGU3Z8g)
+- [How
+to create fully automated ML workflows with Amazon SageMaker AI
+Pipelines](https://www.youtube.com/watch?v=W7uabCTfLrg)
+
+**Related examples:**
+
+- [Orchestrate
+your build and train pipeline with SageMaker AI Pipelines](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab6-mlops/pipelines)
+- [SageMaker AI
+Model Evaluation Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-pipelines)
+- [MLOps
+with SageMaker AI Pipelines](https://github.com/aws-samples/amazon-sagemaker-mlops-workshop)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp03.html*
+
+---
+
+# MLPERF04-BP04 Establish feature statistics
+
+Establishing key statistics to measure changes in data that affect
+model outcomes is crucial for maintaining ML model performance. By
+analyzing feature importance and sensitivity, you can select the
+most critical features to monitor and detect when data drifts
+outside acceptable ranges so you can determine when model retraining
+is necessary.
+
+**Desired outcome:** You establish a
+robust monitoring system that tracks key statistics for the most
+influential features in your machine learning models. You can detect
+data drift that could impact model performance, allowing for timely
+model retraining decisions based on quantitative measures rather
+than intuition. Your monitoring system alerts you when important
+features drift outside their expected statistical ranges, providing
+continuous model reliability and performance.
+
+**Common anti-patterns:**
+
+- Monitoring features equally without considering their relative
+importance to model outcomes.
+- Failing to establish baseline statistics for important features
+before deploying models.
+- Not setting appropriate thresholds for data drift alerts.
+- Monitoring only model outputs without analyzing input feature
+distributions.
+- Neglecting to perform sensitivity analysis to understand model
+behavior at decision boundaries.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of data quality issues that could affect model
+performance.
+- Reduced model performance degradation through timely retraining.
+- Greater understanding of which features most impact model
+predictions.
+- Improved model reliability in production environments.
+- Enhanced ability to explain model behavior and decision
+boundaries to stakeholders.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing feature statistics is essential for maintaining model
+performance over time. As real-world data evolves, your model's
+predictive power can deteriorate if the data drift exceeds certain
+thresholds. By focusing on the most influential features and
+understanding your model's sensitivity to changes in these
+features, you can create an effective monitoring strategy.
+
+Start by analyzing which features have the greatest impact on your
+model's predictions through feature importance analysis. Then
+establish baseline statistics for these critical features using
+your training data. Monitor these statistics in production,
+comparing them to your baseline, and set up alerts when deviations
+occur. This approach allows you to proactively address potential
+model performance issues before they impact your business
+outcomes.
+
+### Implementation steps
+
+- **Analyze feature distributions with
+Data Wrangler**. Use
+[Amazon SageMaker AI Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-analyses.html) to perform exploratory data
+analysis on your dataset. Examine the distribution of each
+feature, identify outliers, and understand relationships
+between features. Data Wrangler provides visualizations such
+as histograms, scatter plots, and correlation matrices to
+understand your data's characteristics before training.
+- **Train your model with proper
+tracking**. When training your model, capture
+metadata about the training process using
+[SageMaker AI
+Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html). This can establish a baseline for
+comparison and enables reproducibility of your experiments.
+Track key metrics, parameters, and the training dataset
+version to maintain a complete record of model development.
+- **Determine feature
+importance**. After training your model, analyze
+which features have the greatest impact on predictions. Use
+built-in feature importance methods in SageMaker AI, such as
+SHAP (SHapley Additive exPlanations) values or permutation
+importance. Alternatively, use model-specific methods like
+feature importance in tree-based models or coefficient
+magnitudes in linear models.
+- **Perform sensitivity
+analysis**. Map out regions in feature space where
+predictions change abruptly or remain invariant. Focus
+particularly on features near decision boundaries where
+small changes can alter model outputs. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-data-bias.html) to analyze how variations in input
+features affect predictions and understand which features
+require the closest monitoring.
+- **Check for data bias**. Use
+Amazon SageMaker AI Clarify to analyze your dataset for
+potential biases. Imbalances or biases in your training data
+can lead to poor generalization and unfair predictions.
+Identify and address these issues before deploying your
+model to create ethical and reliable ML systems.
+- **Establish monitoring
+baseline**. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to create a baseline from
+your training data. This baseline captures the expected
+statistical properties of your features, including
+distributions, ranges, and relationships. SageMaker AI
+automatically analyzes and creates constraints for each
+feature based on the training data.
+- **Configure data quality
+monitoring**. Set up SageMaker AI Model Monitor to
+continuously evaluate production data against your
+established baseline. Configure monitoring schedules based
+on your application's requirements—hourly, daily, or weekly.
+Define thresholds for acceptable deviation from the baseline
+for each important feature.
+- **Implement data drift
+detection**. Configure alerts to notify you when
+important features drift outside their acceptable
+statistical ranges. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to set up alarms that run when drift
+metrics exceed thresholds. This enables timely intervention
+when data quality issues arise.
+- **Create model retraining
+prompts**. Establish criteria for when to retrain
+your model based on data drift metrics. For example, if
+multiple important features show drift, or if a single
+critical feature drifts beyond a certain threshold, run the
+model retraining process.
+- **Set up continuous feedback
+loop**. Implement a system to continuously gather
+new labeled data for model retraining. This verifies that
+your model can adapt to legitimate changes in data
+distribution over time. Use
+[AWS Step Functions](https://aws.amazon.com/step-functions/) to orchestrate workflows that include
+data collection, preprocessing, model training, and
+deployment.
+
+## Resources
+
+**Related documents:**
+
+- [Pre-training
+Data Bias](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-data-bias.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Data
+quality](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-data-quality.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+
+**Related videos:**
+
+- [Prepare
+data for machine learning with ease, speed, and
+accuracy](https://www.youtube.com/watch?v=Wi3eJxfX754)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Lab
+1. Feature Engineering](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab1-feature-engineering)
+- [SageMaker AI
+Model Monitor Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+- [SageMaker AI
+Clarify Explainability Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp04.html*
+
+---
+
+# MLPERF04-BP05 Perform a performance trade-off analysis
+
+Perform a trade-off analysis to identify optimal ML model
+configurations that balance competing requirements for your business
+needs. This practice enables you to maximize both model accuracy and
+overall business value.
+
+**Desired outcome:** You develop a
+structured approach to evaluate and select machine learning models
+based on multiple dimensions including accuracy, complexity, bias,
+fairness, and operational constraints. You'll be able to make
+informed decisions about model selection that align with your
+business requirements and ethical considerations.
+
+**Common anti-patterns:**
+
+- Focusing solely on model accuracy without considering other
+important factors like explainability, fairness, or inference
+speed.
+- Ignoring bias in training data that may lead to unfair model
+outcomes for certain groups.
+- Deploying overly complex models that are difficult to explain
+and maintain when simpler models could achieve adequate
+performance.
+- Not testing different model configurations against business
+requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Optimized machine learning models that balance performance with
+operational constraints.
+- Models that can be explained and trusted by stakeholders and end
+users.
+- Reduced risk of unfair or biased model outcomes.
+- Better alignment between model performance and business
+requirements.
+- More cost-effective model deployment and maintenance.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Performance trade-off analysis requires careful consideration of
+your use case and business requirements. You need to determine
+which aspects of model performance are most important for your
+application - whether that's accuracy, explainability, fairness,
+latency, or other factors. Different business contexts may
+prioritize these dimensions differently.
+
+For example, in a credit scoring application, fairness and
+explainability might be primary concerns due to regulatory
+requirements and the need to provide reasons for decisions. In
+contrast, a real-time product recommendation system might
+prioritize prediction speed and accuracy over explainability.
+Understanding these requirements upfront can guide your model
+development process.
+
+Trade-off analysis is not a one-time activity but should be
+incorporated throughout the machine learning lifecycle. As you
+gather more data, refine your models, and receive feedback from
+stakeholders, you should continually reassess these trade-offs to
+verify that your models continue to meet business needs.
+
+### Implementation steps
+
+- **Define performance metrics aligned
+with business goals**. Start by clearly defining
+what success looks like for your use case. Identify the key
+performance indicators (KPIs) that matter most to your
+business stakeholders. These might include technical metrics
+like precision, recall, or latency, as well as business
+metrics like conversion rate or cost reduction.
+- **Establish a baseline for trade-off
+analysis**. Create a simple model as a baseline to
+compare against more complex approaches. This provides a
+reference point for measuring improvements and understanding
+the minimum acceptable performance for your use case.
+Techniques like cross-validation can determine if your
+baseline is robust.
+- **Explore the accuracy versus
+complexity trade-off**. Test models with different
+levels of complexity, from simple linear models to more
+sophisticated deep learning approaches. Use
+[Amazon SageMaker AI Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to track different model
+architectures and their performance characteristics.
+Remember that simpler models are often more explainable and
+simpler to deploy, even if they sacrifice some accuracy.
+- **Analyze bias and fairness
+implications**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-fairness-and-explainability.html) to detect potential bias in your
+data and models. Identify sensitive attributes that might
+lead to unfair outcomes for certain groups. Implement
+mitigation strategies such as balanced datasets,
+regularization techniques, or fairness-aware algorithms to
+reduce bias while maintaining acceptable performance.
+- **Optimize the bias versus variance
+trade-off**. Address underfitting (high bias) and
+overfitting (high variance) through systematic
+experimentation. Techniques like cross-validation can
+identify the optimal model complexity for your data.
+Consider using more training data, implementing
+regularization techniques, or simplifying your model
+architecture depending on whether bias or variance is your
+primary concern.
+- **Evaluate precision versus recall
+trade-offs**. For classification problems,
+determine whether false positives or false negatives are
+more problematic for your use case. Use tools like
+precision-recall curves to visualize this trade-off and ROC
+curves to understand the relationship between true positive
+and false positive rates. Adjust classification thresholds
+based on the relative costs of different types of errors.
+- **Consider operational
+constraints**. Evaluate how models perform under
+real-world constraints like latency requirements, memory
+limitations, or compute availability. For edge deployment
+scenarios, use
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to optimize your models for hardware
+targets while maintaining accuracy. This is particularly
+important for applications that need to run in
+resource-constrained environments.
+- **Implement explainability
+techniques**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) to generate feature importance
+explanations and understand how your model makes
+predictions. This builds trust with stakeholders and may be
+necessary to address regulatory adherence in some
+industries. Consider the trade-off between model complexity
+and explainability when selecting your final model.
+- **Document trade-off
+decisions**. Create comprehensive documentation of
+your trade-off analysis, including the experiments
+performed, results observed, and the rationale behind your
+final model selection. This provides transparency for
+stakeholders and provides an understanding to future teams
+on why certain decisions were made.
+- **Establish continuous
+monitoring**. After deployment, use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to track model performance
+and detect drift in data or predictions. This allows you to
+identify when your trade-off assumptions may no longer be
+valid and when retraining might be necessary.
+
+## Resources
+
+**Related documents:**
+
+- [Evaluating
+ML Models](https://docs.aws.amazon.com/machine-learning/latest/dg/evaluating_models.html)
+- [AI
+Fairness and Explainability Whitepaper](https://pages.awscloud.com/rs/112-TZM-766/images/Amazon.AI.Fairness.and.Explainability.Whitepaper.pdf)
+- [Optimize
+model performance using Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Accelerating
+generative AI development with fully managed MLflow 3.0 on
+Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+- [Amazon SageMaker AI Clarify Detects Bias and Increases the Transparency
+of Machine Learning Models](https://aws.amazon.com/blogs/aws/new-amazon-sagemaker-clarify-detects-bias-and-increases-the-transparency-of-machine-learning-models/)
+- [Unlock
+near 3x performance gains with XGBoost and Amazon SageMaker AI
+Neo](https://aws.amazon.com/blogs/machine-learning/unlock-performance-gains-with-xgboost-amazon-sagemaker-neo-and-serverless-artillery/)
+
+**Related videos:**
+
+- [Building
+explainable AI models with Amazon SageMaker AI](https://www.youtube.com/watch?v=UbeyQmY1qCw)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp05.html*
+
+---
+
+# MLPERF04-BP06 Detect performance issues when using transfer learning
+
+Transfer learning can accelerate machine learning development by
+using pre-trained models for new tasks. Monitoring the performance
+of these transferred models verifies that they yield accurate
+results in new contexts and stops inherited weaknesses from
+affecting your solutions.
+
+**Desired outcome:** You can
+effectively identify and address hidden problems in transfer
+learning applications, which improves the reliability of your model
+predictions. By implementing proper monitoring and validation
+techniques, you gain confidence that inherited prediction weights
+perform as expected for your use case while minimizing risks
+associated with using pre-trained models.
+
+**Common anti-patterns:**
+
+- Assuming a pre-trained model will automatically perform well on
+your task without validation.
+- Neglecting to monitor prediction accuracy and model behavior
+after transfer learning implementation.
+- Failing to examine model predictions for subtle but
+consequential errors.
+- Overlooking the need to validate input preprocessing techniques
+for transferred models.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of performance issues that might otherwise
+remain hidden.
+- Improved model reliability and prediction accuracy.
+- Better understanding of what capabilities are truly inherited
+from pre-trained models.
+- Reduced risk of model failures in production environments.
+- More effective fine-tuning strategies based on identified
+weaknesses.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Transfer learning can dramatically reduce the time and
+computational resources needed to develop effective machine
+learning models by leveraging knowledge gained from solving one
+problem and applying it to a different but related problem.
+However, this approach comes with unique challenges that require
+careful monitoring and validation.
+
+When using transfer learning, it's essential to understand that
+the pre-trained model's performance characteristics may not
+directly translate to your use case. The underlying patterns and
+relationships learned by the original model might not fully align
+with your target domain, leading to subtle but potentially serious
+performance issues. These problems can be especially challenging
+to identify because they often don't manifest as obvious failures
+but rather as biased or suboptimal predictions.
+
+For effective transfer learning implementations, you need
+comprehensive monitoring and debugging strategies that can detect
+these hidden issues. This involves validating not just overall
+model performance but also examining individual predictions,
+understanding the inherited capabilities, and properly
+preprocessing the inputs.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Debugger for
+monitoring**. Configure
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) to monitor your transfer learning
+model during training and inference. This service can
+identify hidden issues that might otherwise go undetected by
+automatically analyzing tensors, tracking model convergence,
+and detecting anomalies.
+- **Examine model predictions for
+errors**. Analyze the outputs of your transfer
+learning model to identify patterns in prediction errors.
+Look beyond aggregate metrics like accuracy or F1 score to
+understand what types of inputs are causing the most
+confusion. Create confusion matrices and error distribution
+reports to visualize where your model's performance deviates
+from expectations.
+- **Validate model
+robustness**. Test your model's performance under
+various input conditions to determine how much of its
+robustness comes from the pre-trained weights versus your
+fine-tuning process. Perform adversarial testing by
+introducing slight variations to inputs and measuring how
+the predictions change. Use SageMaker AI Debugger's built-in
+rules to detect training anomalies, such as vanishing
+gradients or exploding tensors.
+- **Verify input preprocessing
+methods**. Align your data preprocessing pipeline
+with the expectations of the pre-trained model.
+Inconsistencies in normalization, tokenization, or feature
+engineering can impact performance. Document and validate
+the preprocessing steps to maintain consistency between
+training and inference stages.
+- **Implement continuous performance
+monitoring**. Deploy systems to continually monitor
+your model's performance after deployment. Configure
+automated alerts for deviations in key performance metrics
+to catch potential issues early. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) in conjunction with
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to set up comprehensive monitoring
+dashboards and alerting systems.
+- **Leverage foundation models with
+fine-tuning**. When using foundation models for
+transfer learning, implement
+[Amazon SageMaker AI JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) to access pre-trained models and
+fine-tune them for your tasks. Monitor the alignment between
+generated outputs and expected results, particularly for
+tasks requiring domain-specific knowledge.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Detecting
+data drift using SageMaker AI](https://aws.amazon.com/blogs/architecture/detecting-data-drift-using-amazon-sagemaker/)
+- [Detecting
+hidden but non-trivial problems in transfer learning models
+using Amazon SageMaker AI Debugger](https://aws.amazon.com/blogs/machine-learning/detecting-hidden-but-non-trivial-problems-in-transfer-learning-models-using-amazon-sagemaker-debugger/)
+
+**Related videos:**
+
+- [Introduction
+to Amazon SageMaker AI Debugger](https://www.youtube.com/watch?v=MqPdTj0Znwg)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp06.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLPERF05.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLPERF05.md
@@ -1,0 +1,317 @@
+# MLPERF05
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLPERF05-BP01 Evaluate cloud versus edge options for machine learning deployment
+
+Evaluate machine learning deployment options to determine if your
+application requires near-instantaneous inference results or needs
+to operate without network connectivity. When the lowest possible
+latency is essential, deploying inference directly on edge devices
+avoids costly roundtrips to cloud API endpoints. Edge deployments
+are particularly valuable for use cases like predictive maintenance
+in factories, where immediate local responses are critical.
+
+**Desired outcome:** You can make
+informed decisions about where to deploy your machine learning
+models based on your business requirements. You understand when to
+use cloud resources for training and when to deploy optimized models
+to edge devices for low-latency inference. Your edge deployments can
+operate autonomously when needed while maintaining security,
+performance, and the ability to update models as new data becomes
+available.
+
+**Common anti-patterns:**
+
+- Defaulting to cloud-based inference without evaluating latency
+requirements.
+- Deploying models to edge devices without proper optimization,
+resulting in poor performance.
+- Neglecting to establish a strategy for model updates and
+monitoring on edge devices.
+- Overlooking security considerations for models deployed at the
+edge.
+- Failing to evaluate hardware constraints of edge devices before
+deployment.
+
+**Benefits of establishing this best
+practice:**
+
+- Dramatically reduced inference latency for time-sensitive
+applications.
+- Ability to operate ML models in environments with limited or no
+connectivity.
+- Lower operational costs by reducing network traffic and cloud
+compute usage.
+- Enhanced privacy by keeping sensitive data local to edge
+devices.
+- Improved resilience against network outages.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning deployments require careful consideration of
+where inference should take place based on your use case
+requirements. While training complex models is computationally
+intensive and best suited for the cloud, inference operations
+require less computing power and can often be performed directly
+on edge devices.
+
+Avoid defaulting to cloud-based inference without evaluating
+latency requirements. Many organizations deploy models to edge
+devices without proper optimization, resulting in poor
+performance, neglect to establish a strategy for model updates and
+monitoring on edge devices, overlook security considerations for
+models deployed at the edge, and fail to evaluate hardware
+constraints of edge devices before deployment.
+
+When evaluating cloud versus edge deployment, consider factors
+like latency requirements, connectivity constraints, data privacy
+needs, and the computational capabilities of your edge devices.
+For applications requiring real-time responses, such as autonomous
+vehicles, industrial equipment monitoring, or smart security
+systems, edge deployment reduces network latency and provides
+continuous operation even during connectivity disruptions.
+
+AWS provides comprehensive tools to optimize models for edge
+deployment while maintaining the ability to train and manage those
+models in the cloud. This hybrid approach gives you the best of
+both worlds: powerful cloud resources for development and
+optimization, with efficient edge deployment for operational
+performance.
+
+### Implementation steps
+
+- **Assess your deployment
+requirements**. Begin by clearly defining your
+application's latency, connectivity, and privacy
+requirements. Determine if your use case needs
+millisecond-level response times, must function in
+environments with unreliable connectivity, or needs to
+process sensitive data locally. These factors will guide
+your decision between cloud and edge deployment options.
+- **Optimize models for edge
+deployment**. Training and optimizing machine
+learning models require massive computing resources, making
+cloud environments ideal for this phase.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides powerful tools for building and
+training models that can later be optimized for edge
+deployment. Consider the computational constraints of your
+target edge devices and select model architectures that
+balance accuracy with efficiency.
+- **Deploy with Amazon SageMaker AI Neo for
+cross-solution compatibility**.
+[Amazon SageMaker AI Neo](https://aws.amazon.com/sagemaker/neo/) enables ML models to be trained once
+and run anywhere in the cloud or at the edge. The Neo
+compiler reads models exported from various frameworks,
+converts them to framework-agnostic representations, and
+generates optimized binary code for target hardware. This
+process makes your models run faster without accuracy loss.
+- **Implement edge ML with AWS IoT Greengrass**.
+[AWS IoT Greengrass](https://aws.amazon.com/greengrass/ml/) provides a robust solution for running
+ML inferences on edge devices using cloud-trained models.
+These models can be built using Amazon SageMaker AI,
+[AWS Deep Learning AMIss](https://aws.amazon.com/machine-learning/amis/), or
+[AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/). Models are stored in
+[Amazon S3](https://aws.amazon.com/s3/) before deployment to edge devices.
+
+## Resources
+
+**Related documents:**
+
+- [AWS IoT Greengrass](https://aws.amazon.com/greengrass/ml/)
+- [Set
+up Neo on Edge Devices](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-getting-started-edge.html)
+- [AWS Internet of
+Things](https://aws.amazon.com/iot/)
+- [Optimize
+image classification on AWS IoT Greengrass using ONNX
+Runtime](https://aws.amazon.com/blogs/iot/optimize-image-classification-on-aws-iot-greengrass-using-onnx-runtime/)
+
+**Related videos:**
+
+- [Machine
+Learning at the Edge](https://www.youtube.com/watch?v=EAz-qAL5z2U)
+- [Getting
+Started Using Machine Learning at the Edge](https://pages.awscloud.com/Getting-Started-Using-Machine-Learning-at-the-Edge_2020_0202-IOT_OD.html)
+- [AWS IoT Greengrass and Machine Learning at the Edge](https://www.youtube.com/watch?v=keaq6sy46ek)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf05-bp01.html*
+
+---
+
+# MLPERF05-BP02 Choose an optimal deployment option in the cloud
+
+When deploying machine learning models in the cloud, selecting the
+right deployment option is crucial for performance efficiency. By
+matching your deployment method to your use case requirements for
+request frequency, latency, and runtime, you can optimize both
+performance and cost.
+
+**Desired outcome:** You can deploy
+your machine learning models in a way that meets your application's
+needs for throughput, response time, and cost efficiency. The
+selected deployment option provides the optimal balance between
+performance and resource utilization while accommodating your
+workload patterns.
+
+**Common anti-patterns:**
+
+- Deploying models on persistent endpoints regardless of traffic
+patterns or workload spikes.
+- Overlooking payload size and processing time requirements when
+selecting deployment options.
+- Using real-time inference for batch processing use cases that
+don't require immediate responses.
+- Failing to consider cost implications of different deployment
+options.
+- Not monitoring and optimizing deployment configurations after
+initial setup.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved cost efficiency by matching resources to actual usage
+patterns.
+- Enhanced performance through selection of appropriate deployment
+methods.
+- Better scalability to handle varying workloads.
+- Reduced operational overhead with managed deployment options.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Selecting the optimal deployment option for your machine learning
+models involves understanding your use case requirements and
+matching them to the capabilities of different AWS SageMaker AI
+deployment services. Consider factors such as request frequency,
+payload size, processing time, and response latency needs.
+
+Avoid deploying models on persistent endpoints regardless of
+traffic patterns or workload spikes. Many organizations overlook
+payload size and processing time requirements when selecting a
+deployment option, use real-time inference for batch processing
+use cases that don't require immediate responses, and fail to
+consider cost implications of different deployment options.
+
+For time-sensitive applications requiring immediate responses,
+real-time inference provides persistent endpoints, while workloads
+with inconsistent traffic patterns might benefit from serverless
+options that scale automatically. For larger payloads or longer
+processing times, asynchronous inference is appropriate, and for
+non-time-sensitive bulk processing, batch transformation offers an
+efficient option.
+
+Your deployment choice should align with your application's
+operational patterns to balance performance and cost efficiency. A
+chatbot requiring immediate responses would benefit from real-time
+inference, while overnight batch processing of transactions might
+use batch transform.
+
+### Implementation steps
+
+- **Evaluate your model deployment
+requirements**. Begin by clearly defining your
+application's requirements for inference frequency, latency
+needs, payload sizes, and budget constraints. Consider how
+often model predictions will be requested, how quickly
+responses must be delivered, and what resource constraints
+you may have.
+- **Implement Amazon SageMaker AI Real-time
+Inference for continuous, low-latency needs**.
+Deploy models that require near-instantaneous responses and
+consistent availability using
+[SageMaker AI
+real-time endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html). These fully managed endpoints
+support auto-scaling and are ideal for applications like
+real-time recommendation engines, chatbots, or fraud
+detection systems where immediate response is critical.
+- **Implement Amazon SageMaker AI
+Serverless Inference for variable traffic
+patterns**. For workloads with inconsistent request
+patterns or idle periods between traffic spikes, use
+[SageMaker AI
+Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html). This option automatically
+provisions and scales compute resources based on traffic,
+avoiding the need to manage server infrastructure while
+optimizing costs during periods of low utilization.
+- **Implement Amazon SageMaker AI
+Asynchronous Inference for large payloads or long
+processing**. For use cases involving large input
+files (up to 1GB) or models requiring extended processing
+time (up to 15 minutes), deploy using
+[SageMaker AI
+Asynchronous Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html). This option queues incoming
+requests and processes them when resources are available,
+making it ideal for tasks like video processing, large
+document analysis, or complex NLP tasks.
+- **Implement Amazon SageMaker AI Batch
+Transform for scheduled bulk processing**. For
+non-time-sensitive workloads where predictions can be
+processed in batches, such as overnight processing of
+transactions or weekly sentiment analysis of customer
+feedback, use
+[SageMaker AI
+Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html). This option automatically
+distributes workloads across compute instances and shuts
+down resources when processing is complete.
+- **Monitor and optimize your
+deployment**. Once deployed, continuously monitor
+your model's performance, resource utilization, and costs.
+Use Amazon CloudWatch metrics to track invocation metrics,
+errors, latency, and resource utilization. Adjust
+auto-scaling configurations or switch deployment options if
+your usage patterns change over time.
+- **Implement security and
+governance**. Incorporate proper security controls
+in your model deployments, including IAM roles with least
+privilege access, network isolation where appropriate, and
+encryption of data in transit and at rest. Use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to create persona-based IAM
+roles for different ML user types (data scientists, MLOps
+engineers, business analysts) with preconfigured templates
+that follow least-privilege principles. For regulated
+industries, implement model governance practices to track
+model versions, approvals, and changes.
+
+## Resources
+
+**Related documents:**
+
+- [Real-time
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Batch
+transform for inference with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Deploy
+models with Amazon SageMaker AI](https://sagemaker-examples.readthedocs.io/en/latest/inference/index.html)
+- [Deploying
+ML models using SageMaker AI Serverless Inference](https://aws.amazon.com/blogs/machine-learning/deploying-ml-models-using-sagemaker-serverless-inference-preview/)
+- [Optimize
+deployment cost of Amazon SageMaker AI JumpStart foundation
+models with Amazon SageMaker AI asynchronous endpoints](https://aws.amazon.com/blogs/machine-learning/optimize-deployment-cost-of-amazon-sagemaker-jumpstart-foundation-models-with-amazon-sagemaker-asynchronous-endpoints/)
+- [Announcing
+managed inference for Hugging Face models in Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/announcing-managed-inference-for-hugging-face-models-in-amazon-sagemaker/)
+- [Run
+computer vision inference on large videos with Amazon SageMaker AI asynchronous endpoints](https://aws.amazon.com/blogs/machine-learning/run-computer-vision-inference-on-large-videos-with-amazon-sagemaker-asynchronous-endpoints/)
+
+**Related videos:**
+
+- [Achieve high
+performance and cost-effective model deployment](https://youtu.be/gWuO0gNKlm8)
+- [Amazon SageMaker AI serverless inference](https://youtu.be/KB6vLQGixjA)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf05-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLPERF06.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLPERF06.md
@@ -1,0 +1,1041 @@
+# MLPERF06
+
+**Pillar**: Unknown  
+**Best Practices**: 6
+
+---
+
+# MLPERF06-BP01 Include human-in-the-loop monitoring
+
+Including human-in-the-loop monitoring is an effective method for
+efficiently tracking and maintaining model performance. By
+incorporating human review into automated decision processes,
+organizations can establish a reliable quality assurance mechanism
+that validates model inferences and detects performance degradation
+over time.
+
+**Desired outcome:** You implement a
+robust human-in-the-loop monitoring system that enables continuous
+assessment of your machine learning models. You can compare human
+labels with model inferences to detect model drift and performance
+degradation, allowing timely mitigation through retraining or other
+remediation actions. This creates a feedback loop that maintains
+high model quality and reliability in production environments.
+
+**Common anti-patterns:**
+
+- Relying solely on automated metrics without human validation.
+- Ignoring edge cases and low-confidence predictions.
+- Not establishing a systematic review process for model outputs.
+- Failing to incorporate human feedback into model retraining
+cycles.
+- Using untrained reviewers without subject matter expertise.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model drift and performance degradation.
+- Higher quality assurance for critical model predictions.
+- Better understanding of edge cases and model limitations.
+- Continuous improvement of model performance through expert
+feedback.
+- Increased trust in AI systems through human oversight.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Human-in-the-loop monitoring provides a crucial safety net for
+your machine learning systems by adding appropriate human
+oversight to important decisions. This approach is particularly
+valuable when automated systems make predictions that impact
+critical business processes or customer experiences. By
+establishing a workflow where human experts review model outputs,
+particularly those with low confidence or selected randomly for
+quality assurance, you create a reliable mechanism to evaluate
+model performance in real-world scenarios.
+
+Avoid relying solely on automated metrics without human
+validation. Many organizations ignore edge cases and
+low-confidence predictions, don't establish a systematic review
+process for model outputs, fail to incorporate human feedback into
+model retraining cycles, and use untrained reviewers without
+subject matter expertise.
+
+This monitoring approach can identify when models begin to drift
+or perform poorly on new data. The comparison between human labels
+and model predictions serves as a key indicator of model health,
+signaling when retraining or other interventions are necessary.
+This feedback loop is essential for maintaining high-quality,
+reliable AI systems over time.
+
+### Implementation steps
+
+- **Design a quality assurance system
+for model inferences**. Create a comprehensive plan
+for how human review will integrate with your machine
+learning workflow. Determine which predictions will be sent
+for human review (low-confidence predictions, random
+samples, or high-risk categories) and establish clear
+guidelines for reviewers to follow when evaluating model
+outputs.
+- **Establish a team of subject matter
+experts**. Identify and recruit individuals with
+domain expertise who can accurately evaluate model
+inferences. These reviewers should understand both the
+technical aspects of your models and the business context in
+which they operate, allowing them to provide valuable
+feedback on model performance and identify potential issues.
+- **Implement Amazon Augmented AI for
+human review workflows**. Use
+[Amazon
+Augmented AI](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-use-augmented-ai-a2i-human-review-loops.html) (Amazon A2I) to create and manage human
+review workflows for your machine learning models. Amazon
+A2I integrates with other AWS services like
+[IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html),
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html), and
+[Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) to handle the entire review process.
+- **Configure review criteria and
+thresholds**. Define the conditions that initiate
+human review, such as confidence score thresholds or types
+of predictions that require human validation. Set up rules
+in Amazon A2I to automatically route these cases to your
+human reviewers while allowing high-confidence, routine
+predictions to proceed without review.
+- **Develop feedback integration
+mechanisms**. Create systems to incorporate human
+feedback into your model improvement cycle. This includes
+storing human labels alongside model predictions, analyzing
+disagreement patterns, and using this information to
+identify areas where your model needs improvement.
+- **Monitor and analyze human-model
+agreement rates**. Track how often human reviewers
+agree with model predictions and analyze patterns in
+disagreements. This data can identify systematic issues with
+your model so that you can prioritize areas for improvement.
+- **Implement model retraining based on
+feedback**. Use the labeled data gathered through
+human review to periodically retrain your models. This
+creates a continuous improvement loop where your models
+learn from past mistakes and adapt to changing patterns in
+your data.
+- **Measure and optimize
+cost-effectiveness**. Analyze the ROI of your
+human-in-the-loop system by comparing the costs of human
+review with the benefits of improved model accuracy. Adjust
+your review sampling strategy to focus human attention where
+it provides the most value.
+
+## Resources
+
+**Related documents:**
+
+- [Using
+Amazon Augmented AI for Human Review](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-use-augmented-ai-a2i-human-review-loops.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Customized
+model monitoring for near real-time batch inference with
+Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/customized-model-monitoring-for-near-real-time-batch-inference-with-amazon-sagemaker/)-
+- [Human-in-the-loop
+review of model explanations with Amazon SageMaker AI Clarify and
+Amazon A2I](https://aws.amazon.com/blogs/machine-learning/human-in-the-loop-review-of-model-explanations-with-amazon-sagemaker-clarify-and-amazon-a2i/)
+
+**Related videos:**
+
+- [Easily
+Implement Human in the Loop into Your Machine Learning
+Predictions with Amazon A2I](https://www.youtube.com/watch?v=jNUp1SO_0YU)
+- [Accelerate
+foundation model evaluation with Amazon SageMaker AI
+Clarify](https://www.youtube.com/watch?v=9X2oDkOBYyA)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp01.html*
+
+---
+
+# MLPERF06-BP02 Evaluate model explainability
+
+Model explainability allows you to understand and interpret how your
+machine learning models arrive at their decisions. By evaluating
+model explainability, you gain insights into the factors that
+influence predictions to build trustworthy AI systems that meet
+business requirements and regulatory standards.
+
+**Desired outcome:** You can
+demonstrate why your machine learning models make predictions, which
+enables you to build trust with stakeholders, adhere to regulatory
+requirements, and identify potential biases in model outcomes. You
+have the tools to balance model complexity with explainability based
+on your business needs and can produce documentation that satisfies
+governance requirements.
+
+**Common anti-patterns:**
+
+- Treating machine learning models as unknown without
+understanding their decision-making process.
+- Ignoring explainability requirements until after model
+deployment.
+- Prioritizing model performance metrics over interpretability
+when business or regulations requires explainability.
+- Failing to document model explanations for regulatory adherence.
+- Using complex models when simpler, more interpretable
+alternatives would meet business requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Increased trust from stakeholders and end-users in AI systems.
+- Improves adherence with regulations requiring transparent AI
+decision-making.
+- Ability to detect and mitigate biases in model predictions.
+- Enhanced model debugging and performance improvement.
+- Better alignment between model behavior and business objectives.
+- More effective model governance and risk management.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model explainability is a critical aspect of responsible AI
+development. When you evaluate explainability, you assess how
+transparently your machine learning models make decisions and
+whether those decisions can be explained to stakeholders,
+regulators, and end-users. This transparency is particularly
+important in regulated industries and for applications where
+decisions impact individuals.
+
+Avoid treating machine learning models as opaque without
+understanding their decision-making process. Many organizations
+ignore explainability requirements until after model deployment,
+prioritize model performance metrics over interpretability when
+business or regulatory requirements demand explainability, and
+fail to document model explanations for regulatory adherence.
+
+The trade-off between model complexity and explainability is a key
+consideration. Complex models like deep neural networks may
+deliver higher accuracy but are often harder to interpret. Simpler
+models like decision trees or linear regression provide more
+straightforward explanations but might sacrifice some performance.
+Your choice should be guided by your business context, including
+regulatory requirements and the importance of building trust with
+end-users.
+
+For example, a credit approval system may require clear
+explanations for why applications are denied, while a
+manufacturing quality control system might prioritize accuracy
+over explainability. By evaluating these requirements early, you
+can select appropriate modeling approaches and develop the right
+metrics for assessing both performance and interpretability.
+
+### Implementation steps
+
+- **Assess explainability
+requirements**. Begin by understanding the business
+and compliance-aligned needs that drive your explainability
+requirements. Consider regulatory constraints (like GDPR,
+which includes a right to explanation), business
+transparency goals, and stakeholder expectations. Document
+these requirements clearly and prioritize them based on
+their importance to your use case.
+- **Select appropriate model
+types**. Choose model architectures that align with
+your explainability needs. If high explainability is
+required, consider inherently interpretable models like
+decision trees, rule-based systems, or linear models. For
+applications where performance takes priority, more complex
+models with post-hoc explanation techniques may be
+appropriate.
+- **Implement Amazon SageMaker AI
+Clarify**.
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html) provides tools to explain model
+predictions using feature attribution methods. It can
+identify which features contribute most to a prediction,
+enabling you to understand and communicate model behavior.
+SageMaker AI Clarify supports various model types and
+integrates seamlessly with the SageMaker AI environment.
+- **Apply feature attribution
+techniques**. Use feature attribution methods like
+[SHAP
+(SHapley Additive exPlanations) values](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html) through
+SageMaker AI Clarify to quantify the contribution of each
+feature to individual predictions. These techniques explain
+both global model behavior (which features are most
+important overall) and local explanations (why a prediction
+was made).
+- **Establish explainability
+metrics**. Define quantitative metrics to assess
+model explainability, such as feature importance stability,
+explanation fidelity, or consistency. Use these metrics to
+objectively evaluate explainability alongside traditional
+performance metrics like accuracy or F1 score. Include these
+metrics in your model evaluation framework and monitoring
+systems.
+- **Create model
+documentation**. Develop comprehensive
+documentation that describes how your model works, what
+features influence its decisions, and how explanations are
+generated. This documentation should be understandable by
+both technical and non-technical stakeholders. SageMaker AI
+Clarify can generate reports that contribute to model
+governance documentation.
+- **Implement bias detection**.
+Use
+[SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) to detect potential bias in your models
+during development and production. Configure the appropriate
+bias metrics based on your use case and sensitive
+attributes. Regularly assess these metrics to verify that
+your model remains fair across different demographic groups.
+- **Set up continuous
+monitoring**. Configure SageMaker AI Clarify to
+monitor production inferences for bias or feature
+attribution drift. This allows you to detect when model
+explanations change over time, which might indicate problems
+with the model or changes in the underlying data. Establish
+alerts for shifts in explanations or bias metrics.
+- **Integrate human review
+processes**. For high-stakes decisions, implement
+human-in-the-loop review of model explanations using Amazon SageMaker AI Clarify in combination with
+[Amazon
+Augmented AI (A2I)](https://aws.amazon.com/augmented-ai/). This provides an additional layer
+of oversight and can build confidence in the model's
+decisions.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Feature
+Attributions that Use Shapley Values](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html)
+- [Run
+SageMaker AI Clarify Processing Jobs for Bias Analysis and
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [ML
+model explainability with Amazon SageMaker AI Clarify and the
+SKLearn pre-built container](https://aws.amazon.com/blogs/machine-learning/use-amazon-sagemaker-clarify-with-the-sklearn-pre-built-container/)
+- [Human-in-the-loop
+review of model explanations with Amazon SageMaker AI Clarify and
+Amazon A2I](https://aws.amazon.com/blogs/machine-learning/human-in-the-loop-review-of-model-explanations-with-amazon-sagemaker-clarify-and-amazon-a2i/)
+
+**Related examples:**
+
+- [Fairness
+and Explainability with SageMaker AI Clarify](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-experiments/sagemaker_clarify_integration/tracking_bias_explainability.html)
+- [Explainability
+with Amazon SageMaker AI Debugger](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-debugger/xgboost_census_explanations/xgboost-census-debugger-rules.html)
+- [Amazon SageMaker AI Clarify Processing GitHub Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp02.html*
+
+---
+
+# MLPERF06-BP03 Evaluate data drift
+
+Data drift can impact the performance of your machine learning
+models, leading to inaccurate predictions and diminished business
+value. By implementing effective monitoring and detection
+strategies, you can identify when your models are no longer
+performing optimally due to changes in the underlying data patterns.
+
+**Desired outcome:** You can detect
+and mitigate data drift in your machine learning models, providing
+continued accuracy and reliability over time. By implementing model
+monitoring capabilities, you gain visibility into changes in data
+distributions and model performance, allowing for timely
+interventions and retraining when necessary.
+
+**Common anti-patterns:**
+
+- Deploying models without drift monitoring mechanisms.
+- Ignoring gradual changes in input data distribution until model
+performance deteriorates.
+- Assuming that a model trained on historical data will remain
+accurate indefinitely.
+- Manually checking model performance at arbitrary intervals
+rather than implementing continuous monitoring.
+- Retraining models on fixed schedules without considering actual
+data drift patterns.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation before it
+impacts business outcomes.
+- Increased trust in ML model predictions through continuous
+quality assurance.
+- Improved model lifecycle management with data-driven retraining
+decisions.
+- Reduced operational risks associated with inaccurate
+predictions.
+- Enhanced ability to detect and mitigate bias in ML models over
+time.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data drift occurs when the statistical properties of model inputs
+change over time, causing discrepancies between training data and
+production data. This can happen gradually due to evolving user
+behaviors, market conditions, or abrupt changes like economic
+shifts. When your model encounters data drift, it's essentially
+making predictions on data distributions it wasn't trained on,
+which can lead to decreased accuracy and potentially harmful
+business decisions.
+
+Avoid deploying models without drift monitoring mechanisms. Many
+organizations ignore gradual changes in input data distribution
+until model performance deteriorates, assume that a model trained
+on historical data will remain accurate indefinitely, and manually
+check model performance at arbitrary intervals rather than
+implementing continuous monitoring.
+
+Implementing a robust data drift monitoring strategy assists you
+in maintaining high-performing models by identifying when
+retraining becomes necessary. Rather than retraining models on
+arbitrary schedules, you can make data-driven decisions based on
+actual changes in your data distributions and model performance
+metrics. This approach verifies that you're optimizing both model
+performance and resource utilization.
+
+Amazon SageMaker AI provides comprehensive tools to monitor your ML
+models in production environments, allowing you to detect data
+drift, concept drift, and bias. By setting up automated monitoring
+pipelines, you can receive alerts when your models require
+attention, enabling proactive management of your ML systems.
+
+### Implementation steps
+
+- **Set up baseline data for
+monitoring**. Establish a reference dataset that
+represents your model's expected input and output
+distributions. This baseline will be used to compare against
+your production data to detect drift. Use the training data
+or a representative subset that performed well during model
+validation.
+- **Configure SageMaker AI Model
+Monitor**. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automatically detect
+deviations in your model's data quality and performance
+metrics. SageMaker AI Model Monitor can be set up to run on a
+schedule, analyzing incoming production data and comparing
+it to your baseline.
+- **Define data quality and drift
+metrics**. Determine which statistical metrics are
+most relevant for detecting drift in your use case.
+SageMaker AI Model Monitor supports various statistical
+measures like KL divergence, Jensen-Shannon divergence, and
+population stability index to quantify differences between
+distributions.
+- **Establish threshold
+values**. Set appropriate threshold values for your
+metrics that, when exceeded, will initiate alerts. These
+thresholds should balance sensitivity to meaningful changes
+while avoiding false alarms from minor variations.
+- **Create automated monitoring
+schedules**. Configure SageMaker AI Model Monitor to
+run analysis jobs at regular intervals that match your
+business requirements. For critical models, consider more
+frequent monitoring schedules.
+- **Implement bias detection**.
+Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-post-training-bias.html) to detect bias in your ML models
+both pre-training and during production. SageMaker AI Clarify
+can identify if your model is developing biases over time as
+the data distribution changes.
+- **Set up alert mechanisms**.
+Configure Amazon CloudWatch alarms to notify appropriate
+stakeholders when data drift exceeds your defined
+thresholds. Integrate these alerts with your team's
+communication tools for timely responses.
+- **Develop a retraining
+strategy**. Establish clear criteria for when to
+retrain models based on drift detection results. This should
+include considerations for data collection, feature
+engineering updates, and model revalidation.
+- **Implement automated retraining
+pipelines**. Create SageMaker AI pipelines that can be
+run automatically when drift exceeds critical thresholds,
+streamlining the retraining process and minimizing the time
+models operate with degraded performance.
+- **Document drift patterns and
+interventions**. Maintain records of detected drift
+incidents, their causes, and the effectiveness of
+interventions. This documentation builds institutional
+knowledge that can improve future model development and
+monitoring strategies.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Detecting
+bias after training](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-post-training-bias.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Amazon SageMaker AI Clarify Detects Bias and Increases the Transparency
+of Machine Learning Models](https://aws.amazon.com/blogs/aws/new-amazon-sagemaker-clarify-detects-bias-and-increases-the-transparency-of-machine-learning-models/)
+- [Detecting
+data drift using Amazon SageMaker AI](https://aws.amazon.com/blogs/architecture/detecting-data-drift-using-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Clarify](https://github.com/aws/amazon-sagemaker-clarify)
+- [Amazon SageMaker AI Model Monitor examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp03.html*
+
+---
+
+# MLPERF06-BP04 Monitor, detect, and handle model performance degradation
+
+Model performance could degrade over time for reasons such as data
+quality, model quality, model bias, and model explainability.
+Continuously monitor the quality of the ML model in real time.
+Identify the right time and frequency to retrain and update the
+model. Configure alerts to notify and initiate actions if a drift in
+model performance is observed.
+
+**Desired outcome:** You establish a
+comprehensive monitoring system for your machine learning models
+that detects performance degradation, alerts relevant stakeholders,
+and takes appropriate remediation actions. Your ML systems maintain
+high accuracy and reliability over time through automated
+monitoring, detection, and handling of performance issues.
+
+**Common anti-patterns:**
+
+- Implementing ML models without ongoing monitoring.
+- Relying solely on periodic manual checks of model performance.
+- Ignoring data drift or concept drift until model performance
+severely degrades.
+- Not having an established retraining strategy or schedule.
+- Missing alert systems for model performance degradation.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance issues.
+- Automated notifications when models start to degrade.
+- Improved model reliability and accuracy over time.
+- Reduced operational risk from poor model predictions.
+- Better understanding of model behavior in production
+environments.
+- Increased trust in ML-powered systems.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model performance monitoring is critical for maintaining reliable
+machine learning systems in production environments. As real-world
+data changes over time, models can experience data drift (changes
+in the distribution of input data) or concept drift (changes in
+the relationship between inputs and target variables). Establish a
+robust monitoring framework to detect these issues early and take
+appropriate action.
+
+Avoid implementing ML models without ongoing monitoring. Many
+organizations rely solely on periodic manual checks of model
+performance, ignore data drift or concept drift until model
+performance severely degrades, don't have an established
+retraining strategy or schedule, and miss alert systems for model
+performance degradation.
+
+When implementing model monitoring, you should establish baseline
+performance metrics during the training and validation phases.
+These baselines serve as the foundation for comparison once the
+model is deployed. Monitor not just accuracy metrics, but also
+data statistics, feature distributions, and prediction patterns to
+identify subtle changes that might indicate underlying problems.
+
+Setting up automated alerts notifies your team when key
+performance indicators fall below acceptable thresholds. These
+alerts should be configured with appropriate severity levels to
+reflect the business impact of model degradation. Additionally,
+implement automated scaling to handle varying workloads
+efficiently, which keeps your model endpoints responsive
+regardless of demand.
+
+### Implementation steps
+
+- **Monitor model
+performance**.
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) continually monitors the
+quality of Amazon SageMaker AI machine learning models in
+production. Establish a baseline during training before
+model is in production. Collect data while in production and
+compare changes in model inferences. Observations of drifts
+in the data statistics will indicate that the model may need
+to be retrained. Use
+[SageMaker AI
+Clarify](https://aws.amazon.com/sagemaker/clarify/) to identify model bias. Configure alerting
+systems with
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to send notifications for unexpected bias
+or changes in data quality.
+- **Perform automatic
+scaling**. Amazon SageMaker AI includes automatic
+scaling capabilities for your hosted model to dynamically
+adjust underlying compute supporting an endpoint based on
+demand. This capability verifies that that your endpoint can
+dynamically support demand while reducing operational
+overhead.
+- **Monitor endpoint metrics**.
+Amazon SageMaker AI also outputs endpoint metrics for
+monitoring the usage and health of the endpoint. Amazon SageMaker AI Model Monitor provides the capability to monitor
+your ML models in production and provides alerts when data
+quality issues appear. For enhanced observability, leverage
+one-click metrics and monitoring for HyperPod training jobs,
+deployments, health, resource usage, and historical job
+traces to drive faster debugging and operational excellence
+in foundation model workflows. Create a mechanism to
+aggregate and analyze model prediction endpoint metrics
+using services, such as
+[Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/). OpenSearch Service supports
+[dashboards](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/dashboards.html)
+for visualization. Consider integrating third-party AI tools
+(Comet, Deepchecks, Fiddler AI, Lakera) for extended
+governance, bias detection, explainable AI, and vertical
+solutions. The traceability of hosting metrics back to
+versioned inputs allows for analysis of changes that could
+be impacting current operational performance.
+- **Establish data quality
+monitoring**. Configure SageMaker AI Model Monitor to
+track data quality metrics such as missing values,
+statistical outliers, and feature distribution shifts. Set
+up constraints that define acceptable ranges for these
+metrics and generate alerts when violations occur.
+- **Implement bias detection and
+tracking**. Use SageMaker AI Clarify to detect bias in
+your model predictions over time. Monitor for changes in
+fairness metrics across different segments of your data and
+create visualizations to track these metrics over time.
+- **Set up model explainability
+analysis**. Deploy SageMaker AI Clarify to track
+feature importance and SHAP values over time. These values
+can determine if the model's decision-making process is
+changing in unexpected ways that might indicate performance
+issues.
+- **Create a retraining
+pipeline**. Develop an automated pipeline that can
+retrain your models when performance degradation is
+detected. Use
+[AWS Step Functions](https://aws.amazon.com/step-functions/) to orchestrate the retraining
+workflow, including data preparation, model training,
+evaluation, and deployment.
+- **Implement A/B testing for model
+updates**. When deploying updated models, use
+SageMaker AI's
+[production
+variants](https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html) to perform A/B testing between the current
+and new model versions. This allows you to validate
+performance improvements before fully replacing the existing
+model.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness
+and Explainability with SageMaker AI Clarify](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-clarify/fairness_and_explainability/fairness_and_explainability.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Monitoring
+in-production ML models at large scale using Amazon SageMaker AI
+Model Monitor](https://aws.amazon.com/blogs/machine-learning/monitoring-in-production-ml-models-at-large-scale-using-amazon-sagemaker-model-monitor/)
+- [ML
+model explainability with Amazon SageMaker AI Clarify and the
+SKLearn pre-built container](https://aws.amazon.com/blogs/machine-learning/use-amazon-sagemaker-clarify-with-the-sklearn-pre-built-container/)
+
+**Related videos:**
+
+- [Understand
+ML model predictions & biases with Amazon SageMaker AI
+Clarify](https://www.youtube.com/watch?v=t2SJTYiTnYM)
+- [Deep
+Dive on Amazon SageMaker AI Debugger & Amazon SageMaker AI Model
+Monitor](https://www.youtube.com/watch?v=0zqoeZxakOI)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Model Monitor Examples - Github](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+- [SageMaker AI
+Clarify Examples - Github](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp04.html*
+
+---
+
+# MLPERF06-BP05 Establish an automated re-training framework
+
+Monitor data and model predictions to identify errors due to data
+and concept drift. By implementing automated model re-training at
+scheduled intervals or when performance metrics reach defined
+thresholds, you can maintain model accuracy and effectiveness over
+time. This approach keeps your machine learning models relevant as
+data patterns evolve.
+
+**Desired outcome:** You can detect
+when your deployed ML models experience data drift or performance
+degradation, and automatically run retraining processes. You
+establish mechanisms to monitor data statistics and ML inferences in
+production, allowing you to maintain high-quality predictions
+without manual intervention. Your models are consistently updated
+with new data, and model versions are properly tracked to maintain
+traceability and reproducibility.
+
+**Common anti-patterns:**
+
+- Waiting for model performance to fail catastrophically before
+initiating retraining.
+- Manually monitoring model performance without automated alerts
+or prompts.
+- Retraining on a fixed schedule regardless of model performance
+or data patterns.
+- Lacking proper version control for retrained models.
+- Not maintaining consistent evaluation metrics across model
+versions.
+
+**Benefits of establishing this best
+practice:**
+
+- Maintains model accuracy and relevance as data patterns evolve.
+- Reduces manual intervention required to keep models performing
+optimally.
+- Enables quick response to data drift and concept drift.
+- Creates a documented, repeatable process for model updates.
+- Provides consistent model quality through automated evaluation.
+- Maximizes return on investment for machine learning solutions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing an automated retraining framework is crucial for
+maintaining ML model performance over time. As new data becomes
+available or as the underlying patterns in your data change, your
+models can drift and become less accurate. By implementing a
+systematic approach to model monitoring and retraining, you can
+verify that your ML solutions continue to deliver business value.
+
+Avoid waiting for model performance to fail catastrophically
+before initiating retraining. Many organizations manually monitor
+model performance without automated alerts or prompts, retrain on
+a fixed schedule regardless of model performance or data patterns,
+lack proper version control for retrained models, and don't
+maintain consistent evaluation metrics across model versions.
+
+Start by defining clear performance metrics for your models that
+align with your business objectives. These metrics should be
+continuously monitored in production to detect performance
+degradation. Additionally, monitor your input data for statistical
+changes that may indicate drift from the training distribution.
+When changes are detected, your automated framework should run
+retraining workflows.
+
+The process should include data preparation, model training with
+both existing and new data, thorough evaluation, and controlled
+deployment. Each retrained model should be versioned appropriately
+to maintain traceability and allow for rollback if needed.
+
+### Implementation steps
+
+- **Define model performance
+metrics**. Establish clear metrics that measure how
+well your model is performing relative to business
+objectives. These could include accuracy, precision, recall,
+F1 score, or custom domain-specific metrics. Verify that
+these metrics can be calculated automatically and regularly
+in your production environment.
+- **Configure monitoring
+systems**. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously monitor the
+quality of your ML models in production. Set up data quality
+monitoring to detect drift in input features, model quality
+monitoring to track prediction quality, bias drift
+monitoring to detect changes in fairness metrics, and
+feature attribution drift to identify changes in feature
+importance.
+- **Establish retraining
+prompts**. Define the conditions that will initiate
+model retraining. These can include scheduled intervals
+based on business requirements, performance degradation
+beyond defined thresholds, detection of data drift above
+acceptable limits, and availability of new training data.
+Set up
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) alerts to notify or automatically run
+retraining workflows.
+- **Design retraining
+pipelines**. Create automated pipelines using
+[Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) that handle the entire retraining
+workflow, including data preparation, feature engineering,
+model training, evaluation, and deployment. For large-scale
+foundation model training or distributed workloads, leverage
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) which provides managed, resilient
+high-performance clusters with automatic health checks and
+PyTorch auto-resume capabilities for long-running training
+jobs. In your pipeline, include steps for validation against
+holdout data before deployment.
+- **Implement model
+versioning**. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to track and manage
+different versions of your models. As a result, you can
+recreate a model version if needed and provide traceability
+for your deployed models. Associate metadata with each
+version to document training data, hyperparameters, and
+performance metrics.
+- **Automate data processing for new
+training data**. Set up automated data processing
+workflows that prepare new data for training. Configure
+[Amazon S3](https://aws.amazon.com/s3/) event notifications to run Lambda functions or
+
+[AWS Step Functions](https://aws.amazon.com/step-functions/) workflows when new data becomes
+available. Use
+
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to manage features
+consistently across training and inference.
+- **Set up orchestration**. Use
+[AWS Step Functions Data Science SDK for SageMaker AI](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-python-sdk.html) to
+orchestrate complex ML workflows. Define each step in the
+workflow and configure alerts to initiate the process. For
+detecting new training data, combine
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) with Amazon CloudWatch Events to
+automatically start Step Function workflows.
+- **Implement deployment
+safeguards**. Use deployment techniques like
+blue-green deployment or canary releases to safely
+transition to new model versions. Monitor the performance of
+new models closely during initial deployment and configure
+automatic rollback if performance degrades.
+- **Create feedback loops**.
+Establish mechanisms to collect ground truth data from
+production to continually evaluate and improve your models.
+This might involve user feedback, delayed outcomes, or
+manual labeling processes for a subset of predictions.
+- **Document the retraining
+process**. Create comprehensive documentation for
+your retraining framework, including prompts, pipelines,
+evaluation criteria, and deployment strategies. This process
+fosters knowledge transfer and consistent application of the
+process.
+
+## Resources
+
+**Related documents:**
+
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+- [Retraining
+Models on New Data](https://docs.aws.amazon.com/machine-learning/latest/dg/retraining-models-on-new-data.html)
+- [Data
+and model quality monitoring with SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Train
+a Machine Learning Model (using AWS Step Functions)](https://docs.aws.amazon.com/step-functions/latest/dg/sample-train-model.html)
+- [Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Best practices and design patterns for building machine learning workflows with Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/best-practices-and-design-patterns-for-building-machine-learning-workflows-with-amazon-sagemaker-pipelines/)
+- [Create SageMaker AI Pipelines for training, consuming and monitoring your batch use cases](https://aws.amazon.com/blogs/machine-learning/create-sagemaker-pipelines-for-training-consuming-and-monitoring-your-batch-use-cases/)
+- [Launch Amazon SageMaker AI Autopilot experiments directly from within Amazon SageMaker AI Pipelines to easily automate MLOps workflows](https://aws.amazon.com/blogs/machine-learning/automating-complex-deep-learning-model-training-using-amazon-sagemaker-debugger-and-aws-step-functions/)
+
+**Related videos:**
+
+- [Automating Machine Learning Workflows: Leveraging Amazon SageMaker AI Pipelines and Autopilot for Efficient Model Development and Deployment](https://aws.amazon.com/awstv/watch/f2ed03696ea/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI MLOps Immersion Day](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab6-mlops)
+- [Amazon SageMaker AI MLOps](https://github.com/aws-samples/mlops-amazon-sagemaker-devops-with-ml)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp05.html*
+
+---
+
+# MLPERF06-BP06 Review for updated data and features for retraining
+
+Establishing a framework to regularly review and update your machine
+learning model's data and features is essential for maintaining
+model accuracy. As business environments evolve, new data patterns
+emerge that can impact your model's performance. By systematically
+reviewing your data and features at appropriate intervals, you can
+keep your models accurate and reliable.
+
+**Desired outcome:** You establish a
+systematic approach to monitor data changes, explore new features,
+and incorporate updated data into your models. Through regular data
+exploration and feature engineering, you maintain model accuracy
+even as underlying data patterns evolve. This creates a proactive
+rather than reactive approach to model maintenance and verifies that
+your ML solutions consistently deliver business value.
+
+**Common anti-patterns:**
+
+- Assuming that data patterns remain stable over time.
+- Retraining models only when performance degrades.
+- Failing to explore new potential features as business evolves.
+- Using the same feature engineering approach regardless of
+changing data characteristics.
+- Not establishing regular review schedules for data and feature
+updates.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model accuracy through updated training data and
+features.
+- Early detection of data drift and proactive model updates.
+- Continuous discovery of new, potentially valuable features.
+- Consistent model performance despite changing business
+conditions.
+- Extended model lifecycle and reduced need for complete rebuilds.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data is the foundation of a machine learning model, and its
+characteristics can change over time due to various factors such
+as seasonal variations, market shifts, or changes in customer
+behavior. Without a framework to regularly review and update your
+data and features, models can gradually become less accurate as
+they fail to account for these changes.
+
+Avoid assuming that data patterns remain stable over time. Many
+organizations retrain models only when performance degrades, fail
+to explore new potential features as their business evolves, and
+use the same feature engineering approach regardless of changing
+data characteristics.
+
+To implement this practice effectively, you need to understand the
+volatility of your business environment and establish appropriate
+review intervals. For example, retail businesses might need more
+frequent reviews during holiday seasons when consumer behavior
+changes rapidly. You also need tools to efficiently explore data,
+identify new patterns, and engineer features that capture these
+insights.
+
+Amazon SageMaker AI provides comprehensive capabilities for data
+preparation, feature engineering, and model monitoring. By using
+these tools, you can create an efficient pipeline for regularly
+reviewing and updating your model's data and features, providing
+continued accuracy and relevance.
+
+### Implementation steps
+
+- **Assess data volatility in your
+business environment**. Analyze how quickly your
+business data changes by examining historical data patterns
+and identifying seasonal trends, market shifts, or other
+factors that affect your data. This assessment can determine
+how frequently you need to review your model's data and
+features.
+- **Establish a review
+schedule**. Based on your data volatility
+assessment, create a calendar for regular data and feature
+reviews. For highly volatile environments, you may need
+monthly reviews, while more stable contexts might require
+quarterly or biannual reviews.
+- **Set up data monitoring**.
+Implement
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously track data
+drift by comparing production data against your model's
+training data. Configure alerts when deviations occur to run
+expedited reviews.
+- **Create a data exploration workflow
+with Amazon SageMaker AI Canvas**. Use
+[Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-data-prep.html) to build data exploration workflows.
+The unified SageMaker AI Studio environment provides seamless
+integration with S3, Redshift, and EMR for comprehensive
+data exploration, engineering, training, and deployment
+workflows. Canvas now includes enhanced no/low-code ML tools
+with templates, automation, and wizards that enable
+non-engineering users to train custom models for verticals
+like sales, fraud, and demand with minimal technical
+expertise. These workflows should include data
+visualizations, statistical analyses, and data quality
+assessments.
+- **Implement feature engineering
+processes**. Develop standardized feature
+engineering pipelines in SageMaker AI Data Wrangler that can
+transform raw data into model features. Include steps to
+identify potential new features during each review cycle.
+- **Integrate with SageMaker AI Feature
+Store**. Store engineered features in
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to maintain feature
+consistency between training and inference. This creates a
+single source of truth for features and simplifies
+retraining with updated data.
+- **Establish an evaluation
+framework**. Create a systematic approach to
+compare model performance using original features versus
+updated or new features. This quantifies the impact of
+feature changes and supports data-driven decisions about
+model updates.
+- **Form a cross-functional review
+team**. Assemble a team including data scientists,
+domain experts, and business stakeholders who can
+collectively evaluate data changes, validate new features,
+and authorize model retraining when necessary.
+- **Document changes and maintain
+version control**. Track changes to data sources,
+feature definitions, and transformation logic using version
+control systems. This creates an audit trail and supports
+reproducibility.
+- **Automate the retraining
+pipeline**. Use
+[Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) to create automated workflows
+that can retrain models with updated data and features when
+approved by the review team.
+
+## Resources
+
+**Related documents:**
+
+- [Automate
+data preparation with Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-data-export.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [No-code
+data preparation for time series forecasting using Amazon SageMaker AI Canvas](https://aws.amazon.com/blogs/machine-learning/no-code-data-preparation-for-time-series-forecasting-using-amazon-sagemaker-canvas/)
+
+**Related videos:**
+
+- [Introducing
+Amazon SageMaker AI Canvas](https://www.youtube.com/watch?v=Tb4NTq9n_Hc)
+- [Automating
+Machine Learning Workflows with SageMaker AI Pipelines](https://aws.amazon.com/awstv/watch/f2ed03696ea/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp06.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLREL01.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLREL01.md
@@ -1,0 +1,350 @@
+# MLREL01
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLREL01-BP01 Use APIs to abstract change from model consuming applications
+
+APIs abstract changes from model-consuming applications, keeping
+machine learning solutions flexible and resilient. Establishing an
+abstraction layer between ML models and consuming applications
+enables model updates, replacements, or enhancements without
+disrupting existing workloads.
+
+**Desired outcome:** You have a
+flexible application and API design that isolates machine learning
+model implementations from consuming applications. You make changes
+to ML models with minimal or no disruption to existing applications.
+Your ML endpoints are well-documented and accessible, and changes to
+underlying models do not require extensive modifications to
+downstream applications.
+
+**Common anti-patterns:**
+
+- Directly embedding model code within applications.
+- Hardcoding model versions or parameter specifications in client
+applications.
+- Lacking proper API documentation and version control.
+- Designing rigid interfaces that break when model inputs or
+outputs change.
+- Creating tight coupling between ML models and consuming
+applications.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces downtime when updating or replacing ML models.
+- Simplifies model deployment and versioning processes.
+- Increases agility and flexibility when evolving ML capabilities.
+- Lowers maintenance costs for applications using ML models.
+- Enhances ability to A/B test different model versions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Abstracting changes from model-consuming applications requires
+thoughtful API design and implementation. Create a well-designed
+API layer between ML models and applications so that you can make
+modifications to models without disrupting services. This approach
+involves developing stable interfaces that hide underlying
+complexity and implementation details of ML models.
+
+When designing these APIs, focus on creating contracts that are
+flexible enough to accommodate model evolution while maintaining
+backward compatibility. Document APIs thoroughly so developers
+consuming models understand how to interact with them correctly.
+Consider implementing versioning strategies that allow introducing
+new model capabilities while supporting existing clients.
+
+### Implementation steps
+
+- **Adopt best practices in API
+design**. Expose ML endpoints through APIs so
+changes to the model can be introduced without disrupting
+upstream communications. Create a well-designed API contract
+that focuses on business capabilities rather than technical
+implementation details. Document your API in a central
+repository or documentation site so calling services can
+understand API routes and flags. Communicate changes to your
+API with calling services.
+- **Implement API versioning**.
+Use versioning strategies for APIs to enable backward
+compatibility while supporting new features. Consider using
+URL path versioning (for example,
+/v1/predict), header-based versioning, or
+query parameter versioning depending on organizational
+standards. This allows introducing new model versions
+without breaking existing client applications.
+- **Deploy models in Amazon SageMaker AI**. After training your model, deploy it
+using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to get predictions. To establish a
+persistent endpoint for one prediction at a time, use
+SageMaker AI hosting services. For predictions on entire
+datasets, use SageMaker AI batch transform. SageMaker AI provides
+flexibility in deployment options, including
+[multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html),
+[serverless
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html), and
+[asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html).
+- **Use Amazon API Gateway to create
+APIs**.
+[Amazon API Gateway](https://aws.amazon.com/api-gateway/) is a fully managed service that enables
+developers to create, publish, maintain, monitor, and secure
+APIs. Using API Gateway, you can create RESTful APIs and
+WebSocket APIs that enable real-time two-way communication
+applications. API Gateway supports containerized and
+serverless workloads, as well as web applications.
+- **Implement request and response
+transformations**. Use API Gateway's mapping
+templates to transform client requests to match your model's
+input format and transform model responses to maintain a
+consistent API contract. This allows changing model
+implementations without requiring client applications to
+change how they format requests or interpret responses.
+- **Add caching and
+throttling**. Configure API Gateway's caching
+capability to improve performance and reduce costs for
+frequently accessed predictions. Implement throttling to
+protect ML endpoints from traffic spikes and provide
+consistent performance. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to optimize endpoint
+configurations for optimal latency and cost performance.
+- **Monitor and analyze API
+usage**. Set up monitoring and logging for APIs to
+understand how they are being used and identify potential
+issues. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) metrics and logs to track API performance,
+errors, and usage patterns. This data can optimize ML
+endpoints and identify opportunities for improvement.
+- **Consider inference components for
+shared endpoints**. Use
+[SageMaker AI
+inference components](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deploy-models.html) to deploy multiple models to
+shared endpoints, improving resource utilization and
+reducing costs while maintaining API abstraction.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+deployment options in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html)
+- [What
+is Amazon API Gateway?](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html)
+- [Real-time
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Deploying
+ML models using SageMaker AI Serverless Inference](https://aws.amazon.com/blogs/machine-learning/deploying-ml-models-using-sagemaker-serverless-inference-preview/)
+- [Optimize
+deployment cost of Amazon SageMaker AI JumpStart foundation
+models with Amazon SageMaker AI asynchronous endpoints](https://aws.amazon.com/blogs/machine-learning/optimize-deployment-cost-of-amazon-sagemaker-jumpstart-foundation-models-with-amazon-sagemaker-asynchronous-endpoints/)
+
+**Related videos:**
+
+- [Amazon
+Sagemaker Serverless Inference](https://www.youtube.com/watch?v=esG_Q8egwMU)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Examples Repository](https://github.com/aws/amazon-sagemaker-examples)
+- [Amazon SageMaker AI MLOps Workshop](https://github.com/aws-samples/amazon-sagemaker-mlops-workshop)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel01-bp01.html*
+
+---
+
+# MLREL01-BP02 Adopt a machine learning microservice strategy
+
+Machine learning systems can be effectively implemented through a
+microservice architecture that breaks down complex business problems
+into smaller, loosely coupled components. This approach enables
+distributed development, improves scalability, and facilitates
+change management while reducing the impact of single failures on
+the overall workload.
+
+**Desired outcome:** You decompose
+complex business problems into manageable components with clear
+interfaces. You have a more resilient ML system architecture that
+can scale individual components independently, enable faster
+iterations, and allow specialized teams to work simultaneously on
+different parts of the solution. Your organization benefits from
+improved fault isolation, simplified testing, and greater
+flexibility to update or replace individual ML models without
+affecting the entire system.
+
+**Common anti-patterns:**
+
+- Building monolithic ML applications where functionality is
+tightly coupled in a single runtime.
+- Creating overly complex microservices that serve multiple
+purposes.
+- Implementing microservices without clear business domain
+boundaries.
+- Neglecting proper service interfaces and communication patterns
+between microservices.
+- Overlooking the operational complexity introduced by distributed
+systems.
+
+**Benefits of establishing this best
+practice:**
+
+- Improves resilience through isolation of failures to individual
+components.
+- Enhances scalability by allowing independent scaling of
+individual services.
+- Accelerates development cycles through parallel work streams.
+- Simplifies testing and deployment of individual components.
+- Provides flexibility to use different technologies for different
+ML model requirements.
+- Aligns technical components with business domains.
+- Eases integration of new ML models and capabilities.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When implementing ML systems, adopt a microservice architecture to
+break down complex problems into manageable components. Rather
+than creating one large monolithic application that handles the
+entirety of of your machine learning workflow, you can develop
+specialized services that handle specific functions like data
+preprocessing, model training, inference, and business logic
+integration. This approach is particularly valuable for machine
+learning applications where different models may have varying
+resource requirements, development cycles, and deployment
+frequencies.
+
+Microservices provide the flexibility to use different
+technologies for different parts of your ML system. For example,
+you might use Python-based services for data science tasks while
+implementing Java-based services for integration with enterprise
+systems. By establishing clear service interfaces, you verify that
+these components work together seamlessly while maintaining
+freedom.
+
+When designing your ML microservices, focus on business domains
+rather than technical functions. Instead of creating a generic
+prediction service, you might create more specific services like
+*customer churn prediction* or
+*product recommendation* that align with
+business capabilities. This domain-driven approach makes your
+architecture more intuitive and adaptable to changing business
+needs.
+
+### Implementation steps
+
+- **Adopt a microservice
+strategy**. Implement a service-oriented
+architecture (SOA) by making software components reusable
+through service interfaces. Break your monolithic
+application into separate components along business
+boundaries or logical domains. Focus on building
+single-purpose applications that can be composed in
+different ways to deliver various end-user experiences.
+Design clear APIs between services to implement proper
+isolation and communication patterns.
+- **Define domain boundaries**.
+Analyze your machine learning workflow and identify natural
+boundaries between different functional areas. Map out the
+data flow and determine where service boundaries make sense.
+Consider creating separate microservices for data ingestion,
+preprocessing, feature engineering, model training, model
+serving, and business logic integration. Verify that each
+microservice has a clear, single responsibility within your
+ML system.
+- **Choose appropriate AWS
+services**. Select AWS services that best support
+your microservice architecture.
+[AWS Lambda](https://aws.amazon.com/lambda/) provides serverless compute that scales
+automatically and charges only for the compute time
+consumed. For container-based deployments, use
+[AWS Fargate](https://aws.amazon.com/fargate/) to run containers without managing
+infrastructure. Consider
+[Amazon ECS](https://aws.amazon.com/ecs/) or
+[Amazon EKS](https://aws.amazon.com/eks/) for container orchestration needs, and
+[Amazon API Gateway](https://aws.amazon.com/api-gateway/) to manage and secure your microservice
+APIs.
+- **Implement model serving
+infrastructure**. Set up efficient model serving
+using services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) for deploying, monitoring, and scaling ML
+models. SageMaker AI endpoints provide a managed solution for
+hosting models and handling inference requests.
+Alternatively, use
+[AWS Lambda](https://aws.amazon.com/lambda/) for lightweight, event-driven inferencing or
+containers on
+[AWS Fargate](https://aws.amazon.com/fargate/) for more complex requirements.
+- **Establish communication
+patterns**. Design how your microservices will
+communicate with each other. Use synchronous REST APIs for
+direct request-response patterns, and asynchronous
+communication through
+[Amazon SNS](https://aws.amazon.com/sns/) or
+[Amazon SQS](https://aws.amazon.com/sqs/) for event-driven architectures. Implement
+[AWS EventBridge](https://aws.amazon.com/eventbridge/) to create event-driven workflows between
+your ML microservices and other AWS services.
+- **Implement monitoring and
+observability**. Set up comprehensive monitoring
+for your ML microservices using
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/). Track operational metrics like latency,
+throughput, and error rates along with ML-specific metrics
+such as prediction accuracy or drift. Implement distributed
+tracing with
+[AWS X-Ray](https://aws.amazon.com/xray/) to troubleshoot issues across service
+boundaries and identify performance bottlenecks.
+- **Automate deployments**.
+Implement CI/CD pipelines using
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) and
+[AWS CodeBuild](https://aws.amazon.com/codebuild/) to automate the testing and deployment of
+your ML microservices. Use infrastructure as code with
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to define and provision your microservice
+infrastructure consistently.
+- **Implement security best
+practices**. Secure your ML microservices by
+implementing proper authentication and authorization using
+[Amazon Cognito](https://aws.amazon.com/cognito/) or
+[AWS IAM](https://aws.amazon.com/iam/). Use
+[AWS WAF](https://aws.amazon.com/waf/) to protect your APIs from common web exploits,
+and encrypt sensitive data using
+[AWS KMS](https://aws.amazon.com/kms/) to improve data privacy and adhere to regulatory
+requirements.
+
+## Resources
+
+**Related documents:**
+
+- [Implementing
+Microservices on AWS](https://docs.aws.amazon.com/whitepapers/latest/microservices-on-aws/microservices-on-aws.html)
+- [AWS Lambda Documentation](https://docs.aws.amazon.com/lambda/index.html)
+- [Architect
+for AWS Fargate for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/what-is-fargate.html)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [What
+is the AWS Serverless Application Model (AWS SAM)?](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html)
+- [Build
+and deploy ML inference applications from scratch using Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/build-and-deploy-ml-inference-applications-from-scratch-using-amazon-sagemaker/)
+
+**Related examples:**
+
+- [Run
+a Serverless "Hello, World" with AWS Lambda](https://aws.amazon.com/getting-started/hands-on/run-serverless-code/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel01-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLREL02.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLREL02.md
@@ -1,0 +1,547 @@
+# MLREL02
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLREL02-BP01 Use a data catalog
+
+Process data across multiple data stores using data catalog
+technology. An advanced data catalog service can enable ETL process
+integration. This approach improves reliability and efficiency.
+
+**Desired outcome:** You establish a
+centralized system that inventories your ML data assets across the
+organization. You can track, discover, and manage data
+transformations, and your stakeholders can find and use appropriate
+datasets. With a complete data catalog in place, you gain better
+data governance, reduce duplication of effort, increase data
+quality, and accelerate ML model development through streamlined
+data preparation workflows.
+
+**Common anti-patterns:**
+
+- Maintaining separate, isolated data silos without centralized
+metadata.
+- Manual tracking of data assets using spreadsheets or wiki pages.
+- Failing to document data transformations and lineage.
+- Rebuilding ETL processes for each new ML project.
+- Relying on tribal knowledge for understanding data
+characteristics.
+
+**Benefits of establishing this best
+practice:**
+
+- Provides centralized visibility of available data assets.
+- Improves data governance.
+- Reduces time spent searching for and understanding data.
+- Enhances data quality through consistent transformation
+processes.
+- Strengthens collaboration between data engineers and data
+scientists.
+- Accelerates ML model development with faster data preparation.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+A data catalog is critical infrastructure for machine learning
+workloads to succeed. Without proper cataloging, data scientists
+spend excessive time searching for, understanding, and preparing
+data rather than analyzing it or building models. A comprehensive
+data catalog provides a centralized inventory of your data assets,
+complete with metadata, transformation history, and usage
+information.
+
+When implementing a data catalog for ML workloads, focus on
+creating a single source of truth for data discovery. The catalog
+should document where data resides, what transformations have been
+applied, and how it can be accessed. This reduces the time spent
+on data preparation, which typically consumes 60-80% of a data
+scientist's time.
+
+For AWS environments, the AWS AWS Glue Data Catalog offers a powerful
+solution as it integrates seamlessly with other AWS analytics and
+machine learning services. By implementing a data catalog as part
+of your ML infrastructure, you create a foundation for consistent,
+reliable data processing that supports both current and future ML
+initiatives.
+
+### Implementation steps
+
+- **Set up AWS AWS Glue Data Catalog**. Establish the
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html) as your central metadata
+repository. This fully managed service provides a unified
+view of your data across multiple data stores, making it
+accessible to various AWS services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/),
+[Amazon EMR](https://aws.amazon.com/emr/),
+[Amazon Athena](https://aws.amazon.com/athena/), and
+[Amazon Redshift](https://aws.amazon.com/redshift/).
+- **Define your metadata
+strategy**. Determine what metadata to capture
+about each dataset, including business definitions, data
+lineage, quality metrics, and usage patterns.
+Well-documented metadata assists data scientists in quickly
+understanding if a dataset is appropriate for their modeling
+needs.
+- **Populate the data
+catalog**. Use
+[AWS Glue crawlers](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html) to automatically discover schemas, data
+types, and statistics from your data sources. Crawlers can
+scan various data stores including Amazon S3, Amazon RDS,
+and other database systems. Systematically add your data
+sources to build comprehensive coverage.
+- **Implement ETL processes with AWS Glue**. Create ETL jobs that transform raw data
+into formats optimized for machine learning.
+[AWS Glue](https://aws.amazon.com/glue/) can automatically generate Python or Scala code
+for these transformations, reducing development time and
+improving consistency across different data processing
+pipelines.
+- **Establish data lineage
+tracking**. Configure your data catalog to track
+transformations and maintain clear lineage information. With
+data lineage tracking, data scientists can understand data
+provenance, which builds trust in the datasets used for
+model training.
+- **Integrate with ML
+workflows**. Connect your AWS AWS Glue Data Catalog
+with Amazon SageMaker AI to streamline data access for model
+training. For enterprise environments, implement
+[Amazon SageMaker AI Catalog](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects-templates-sm.html) as a central metadata hub for ML
+and data assets, enabling secure sharing and governed access
+via Amazon DataZone integration. This integration allows
+data scientists to discover and use properly prepared
+datasets directly from their modeling environments.
+- **Implement access controls and
+governance**. Configure appropriate permissions for
+your data catalog using
+[AWS IAM](https://aws.amazon.com/iam/) roles. Verify that data scientists have access to
+the metadata and datasets they need while maintaining
+security and regulatory adherence.
+- **Automate catalog
+maintenance**. Set up automated processes to keep
+your data catalog current as new data arrives and
+transformations occur. Regular updates verify that data
+scientists have access to the latest information about
+available datasets.
+- **Monitor and measure
+impact**. Track key metrics like time saved in data
+discovery, reduction in redundant data preparation work, and
+improvements in model development cycles to quantify the
+benefits of your data catalog implementation.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI and when to use Amazon SageMaker AI vs Amazon
+DataZone](https://docs.aws.amazon.com/datazone/latest/userguide/sagemaker-datazone.html)
+- [The
+lakehouse architecture of Amazon SageMaker AI](https://aws.amazon.com/sagemaker/lakehouse/)
+- [Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/)
+- [Catalog
+and search](https://docs.aws.amazon.com/whitepapers/latest/building-data-lakes/data-cataloging.html)
+- [Getting
+started with serverless ETL on AWS Glue](https://docs.aws.amazon.com/prescriptive-guidance/latest/serverless-etl-aws-glue/metadata-management.html)
+- [Using
+crawlers to populate the Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html)
+- [AWS modern data architecture](https://docs.aws.amazon.com/prescriptive-guidance/latest/strategy-aws-data/aws-architecture.html)
+- [Moving
+from development to automated ML pipelines using Amazon SageMaker AI and AWS Glue](https://aws.amazon.com/blogs/machine-learning/moving-from-notebooks-to-automated-ml-pipelines-using-amazon-sagemaker-and-aws-glue/)
+- [How
+Genworth built a serverless ML pipeline on AWS using Amazon SageMaker AI and AWS Glue](https://aws.amazon.com/blogs/machine-learning/how-genworth-built-a-serverless-ml-pipeline-on-aws-using-amazon-sagemaker-and-aws-glue/)
+- [How
+to build and automate a serverless data lake using AWS Glue](https://aws.amazon.com/blogs/big-data/build-and-automate-a-serverless-data-lake-using-an-aws-glue-trigger-for-the-data-catalog-and-etl-jobs/)
+
+**Related videos:**
+
+- [Amazon SageMaker AI Lakehouse - Unified, open, and secure data
+lakehouse](https://www.youtube.com/watch?v=wH0dZLtS88Y)
+- [Understanding
+Amazon S3 Tables: Architecture, performance, and
+integration](https://www.youtube.com/watch?v=e1ypMWSHgsM)
+- [Accelerate
+your Analytics and AI with Amazon SageMaker AI LakeHouse](https://www.youtube.com/watch?v=qZTbS0xPN-U)
+- [Unifying
+data governance with Immuta and AWS Lake Formation](https://www.youtube.com/watch?v=X09-n2jJZKw)
+
+**Related examples:**
+
+- [Explaining
+Credit Decisions with Amazon SageMaker AI](https://github.com/awslabs/sagemaker-explaining-credit-decisions)
+- [How
+to build an end-to-end Machine Learning pipeline using AWS Glue, Amazon S3, Amazon SageMaker AI and Amazon Athena](https://github.com/aws-samples/amazon-sagemaker-predict-accessibility)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel02-bp01.html*
+
+---
+
+# MLREL02-BP02 Use a data pipeline
+
+Automate the processing, movement, and transformation of data
+between different compute and storage services. This automation
+enables data processing that is fault tolerant, repeatable, and
+highly available.
+
+**Desired outcome:** You achieve
+streamlined and consistent data processing workflows that
+automatically handle data movement and transformations. You can
+process your machine learning data with increased reliability,
+repeatability, and availability, while reducing manual effort and
+potential errors. Your data processing becomes more efficient and
+scalable, enabling you to focus on deriving insights rather than
+managing data logistics.
+
+**Common anti-patterns:**
+
+- Manually moving and transforming data between systems.
+- Creating one-off scripts for data processing tasks.
+- Inconsistent data transformation processes across teams.
+- Neglecting error handling and recovery mechanisms in data
+workflows.
+- Not versioning data processing code or configurations.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces manual errors and inconsistencies in data processing.
+- Increases repeatability and reliability of data transformations.
+- Enables fault tolerance and automatic recovery mechanisms.
+- Improves scalability of data processing workflows.
+- Facilitates collaboration through standardized data processing
+patterns.
+- Enhances traceability and governance of data transformations.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data is the foundation of a machine learning workload, and how you
+handle this data directly impacts the quality of your ML models.
+Data pipelines automate and standardize the process of collecting,
+cleaning, transforming, and delivering data to your ML workflows.
+Without proper data pipelines, your ML initiatives can suffer from
+inconsistent data quality, limited reproducibility, and
+operational inefficiencies.
+
+Creating effective data pipelines requires careful planning around
+data sources, transformation logic, error handling, and monitoring
+capabilities. By implementing automated data pipelines, you verify
+that your data preparation follows a consistent, repeatable
+process that can scale with your ML workload demands. This
+approach leads to more reliable models and faster deployment
+cycles.
+
+AWS provides a comprehensive set of tools specifically designed to
+build robust ML data pipelines, with Amazon SageMaker AI offering
+integrated capabilities for the entire ML lifecycle. These tools
+enable you to focus on deriving insights from your data rather
+than managing infrastructure.
+
+### Implementation steps
+
+- **Assess your data processing
+requirements**. Begin by identifying your data
+sources, required transformations, and destination systems.
+Document the flow of data from source to consumption, noting
+data quality requirements, validation rules, or business
+logic that must be applied during processing.
+- **Implement data preparation and
+wrangling processes**. Establish comprehensive data
+preparation workflows that transform raw data into ML-ready
+formats. Use a combination of AWS services and tools to:
+
+Connect to data sources including
+[Amazon S3](https://aws.amazon.com/s3/),
+[Amazon Athena](https://aws.amazon.com/athena/),
+[Amazon Redshift](https://aws.amazon.com/redshift/), and other databases using appropriate
+connectors
+- Explore and profile your data using
+[Amazon EMR](https://aws.amazon.com/emr/) with Apache Spark or
+[AWS Glue](https://aws.amazon.com/glue/) interactive sessions to identify patterns,
+anomalies, and data quality issues
+- Transform your data using
+[AWS Glue ETL jobs](https://docs.aws.amazon.com/glue/latest/dg/author-job.html),
+[Amazon EMR](https://aws.amazon.com/emr/) clusters, or
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) jobs with custom transformation
+scripts
+- Generate data quality reports and validation checks
+using
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) or custom validation scripts to
+identify issues before model training
+- Create reusable data preparation workflows using
+[AWS Glue workflows](https://docs.aws.amazon.com/glue/latest/dg/workflows_overview.html) or
+[SageMaker AI
+Pipelines](https://aws.amazon.com/sagemaker/pipelines/) that verify consistency across
+different datasets and projects
+
+- **Build automated ML workflows with
+SageMaker AI Pipelines**. After creating your data
+preparation workflow, export it to
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to automate your entire ML
+workflow. SageMaker AI Pipelines helps you:
+
+Create end-to-end ML workflows that combine data
+preparation, model training, evaluation, and deployment
+- Automate pipeline execution on a schedule or
+trigger-based approach
+- Track lineage of ML artifacts for governance
+- Implement quality gates to verify that models meet
+performance criteria
+- Version control your pipelines for reproducibility
+
+- **Implement error handling and
+monitoring**. Configure your pipelines to handle
+errors gracefully and provide visibility into pipeline
+performance:
+
+Set up retry mechanisms for transient failures
+- Create notification systems for critical pipeline
+failures
+- Implement logging throughout your pipeline steps
+- Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor pipeline metrics and set up
+alerts
+
+- **Version and store your data
+artifacts**. Maintain traceability of your data
+processing:
+
+Store processed datasets in Amazon S3 with appropriate
+versioning
+- Use
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to create reusable
+feature repositories
+- Document data transformations and their business logic
+- Implement data lineage tracking to understand data
+provenance
+
+- **Integrate with your existing ML
+workflow**. Connect your data pipelines to other
+components of your ML environment:
+
+Feed processed data directly into model training jobs
+- Integrate with model registries and deployment pipelines
+- Establish feedback loops from model performance back to
+data preparation
+
+- **Scale your data processing as
+needed**. Configure your pipelines to handle
+growing data volumes:
+
+Use distributed processing for large datasets with
+services like
+[Amazon EMR](https://aws.amazon.com/emr/)
+- Implement incremental processing patterns for streaming
+data
+- Configure compute resources appropriately for each
+pipeline stage
+
+## Resources
+
+**Related documents:**
+
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Get
+started with Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-getting-started.html)
+- [Data
+preparation and cleaning](https://docs.aws.amazon.com/prescriptive-guidance/latest/modern-data-centric-use-cases/data-preparation-cleaning.html)
+- [Run
+secure processing jobs using PySpark in Amazon SageMaker AI
+Pipelines](https://aws.amazon.com/blogs/machine-learning/run-secure-processing-jobs-using-pyspark-in-amazon-sagemaker-pipelines/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+
+**Related videos:**
+
+- [AWS Glue and Amazon SageMaker AI Studio Integration](https://aws.amazon.com/awstv/watch/5d00e03ffe3/)
+- [Build,
+automate, manage, and scale ML workflows using Amazon SageMaker AI Pipelines](https://www.youtube.com/watch?v=Hvz2GGU3Z8g)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples)
+- [MLOps
+Workshop with Amazon SageMaker AI Pipelines](https://catalog.us-east-1.prod.workshops.aws/workshops/741835d3-a2bf-4cb6-81f0-d0bb4a62edca/en-US)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel02-bp02.html*
+
+---
+
+# MLREL02-BP03 Automate managing data changes
+
+Effective management of machine learning training data changes is
+crucial for maintaining model reproducibility and providing
+consistent performance over time. By implementing automated version
+control for training data, you can precisely recreate a model
+version when needed and maintain a clear audit trail of data
+transformations.
+
+**Desired outcome:** You establish
+automated processes for tracking and managing changes to your
+training data using version control technology. You gain the ability
+to reproduce model versions exactly as they were originally created,
+track data lineage through your ML pipeline, and maintain consistent
+model performance across deployments. Your ML operations become more
+reliable, transparent, and compatible with governance requirements.
+
+**Common anti-patterns:**
+
+- Manually tracking data versions in spreadsheets or
+documentation.
+- Storing multiple versions of datasets with inconsistent naming
+conventions.
+- Neglecting to record relationships between datasets and
+resulting models.
+- Not preserving feature engineering transformations applied to
+training data.
+- Relying on ad-hoc backup processes instead of systematic version
+control.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables reproducible machine learning by maintaining exact data
+version history.
+- Improves troubleshooting by allowing precise recreation of model
+versions.
+- Enhances collaboration among data scientists through shared
+version control.
+- Provides audit trail for governance requirements.
+- Reduces errors in model deployment by providing consistent
+training data.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Managing changes to training data is fundamental to maintaining
+reproducible machine learning models. As your data evolves through
+acquisition, cleaning, and feature engineering, implementing
+automated version control allows you to track these changes
+systematically. This provides confidence that you can recreate any
+model version precisely when needed, which is essential for
+troubleshooting, compliance alignment, and proviidng consistent
+performance.
+
+By implementing automated data versioning, you create a traceable
+history of your training data that integrates seamlessly with your
+ML pipeline. This approach mirrors software development best
+practices by treating data as a critical asset requiring the same
+level of version control as code. When data changes occur, whether
+through new acquisitions or transformations, your versioning
+system automatically captures these changes, making it possible to
+track model lineage from training data to deployment.
+
+### Implementation steps
+
+- **Implement a data version control
+system**. Begin by setting up a data version
+control system that can handle ML datasets efficiently.
+Tools like Git LFS, DVC (Data Version Control), or AWS
+solutions can be used to track changes in your training
+datasets. These tools provide mechanisms to capture dataset
+metadata and references without storing the entire dataset
+in the version control repository.
+- **Establish a data management
+strategy**. Define clear workflows for how data
+should be versioned, including naming conventions, branching
+strategies, and metadata requirements. Document how data
+should flow through your ML pipeline and how versions will
+be tracked at each stage.
+- **Use AWS MLOps Framework**.
+Implement the
+[AWS MLOps Framework](https://aws.amazon.com/sagemaker/ai/mlops/) to establish a standardized interface
+for managing ML pipelines. This framework works with both
+Amazon Machine Learning services and third-party services,
+providing a comprehensive solution for ML operations. The
+framework allows you to upload trained models (bring your
+own model), configure pipeline orchestration, and monitor
+operations—all while maintaining version control of data
+assets.
+- **Integrate with SageMaker AI Model
+Registry**. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to track model versions and
+their associated artifacts. Model Registry maintains
+comprehensive records of model lineage, including which
+datasets were used for training and validation, preserving
+the connection between models and their source data.
+- **Establish CI/CD for ML
+pipelines**. Set up continuous integration and
+continuous deployment (CI/CD) pipelines specifically
+designed for ML workflows using
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/). This assists you to version and
+test changes to both code and data properly before moving to
+production.
+- **Create reproducible training
+environments**. Use container technology to package
+your training environment along with references to specific
+data versions.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides mechanisms to create reproducible
+training jobs that can reference specific versions of your
+datasets stored in
+[Amazon S3](https://aws.amazon.com/s3/).
+- **Implement data quality
+monitoring**. Set up automated monitoring of data
+quality metrics to detect drift or anomalies in incoming
+data. Tools like
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) can identify when new data
+differs from the baseline training data, allowing you to
+make informed decisions about model retraining.
+- **Configure automated
+testing**. Implement automated tests that validate
+data consistency and model performance when data versions
+change. This verifies that new data meets quality standards
+before being used in training or inference.
+- **Document data versioning
+procedures**. Create comprehensive documentation
+that describes your data versioning strategy, including how
+to retrieve specific versions of datasets and how to match
+models with their corresponding training data versions.
+
+## Resources
+
+**Related documents:**
+
+- [Implement
+MLOps](https://docs.aws.amazon.com/sagemaker/latest/dg/mlops.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Pipelines Brings DevOps Capabilities to your Machine
+Learning Projects](https://aws.amazon.com/blogs/machine-learning/promote-pipelines-in-a-multi-environment-setup-using-amazon-sagemaker-model-registry-hashicorp-terraform-github-and-jenkins-ci-cd/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Fully
+managed MLflow 3.0 on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+
+**Related videos:**
+
+- [Implementing
+End-to-End MLOps Solutions with Amazon SageMaker AI](https://aws.amazon.com/awstv/watch/5057107a7fc/)
+- [Accelerate
+production for gen AI using Amazon SageMaker AI MLOps &
+FMOps](https://www.youtube.com/watch?v=-3Otl7GVeCc)
+- [Deliver
+high-performance ML models faster with MLOps tools](https://www.youtube.com/watch?v=T9llSCYJXxc)
+
+**Related examples:**
+
+- [Amazon SageMaker AI secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+- [ML
+Pipelines using Amazon SageMaker AI](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops/sm-mlflow_pipelines)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel02-bp03.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLREL03.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLREL03.md
@@ -1,0 +1,679 @@
+# MLREL03
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLREL03-BP01 Enable CI/CD/CT automation with traceability
+
+Enable source code, data, and artifact version control of ML
+workloads to enable roll back to a specific version. Incorporate
+continuous integration (CI), continuous delivery (CD), and
+continuous training (CT) practices to ML workload operations,
+providing automation with added traceability.
+
+**Desired outcome:** You establish
+automated pipelines that handle the entire machine learning
+lifecycle from development to deployment and continuous training.
+You gain the ability to track every artifact, model version,
+dataset, and code change throughout the ML workflow, enabling
+transparent auditing, reproducibility of experiments, and the
+capability to quickly roll back to previous versions when needed.
+
+**Common anti-patterns:**
+
+- Manual deployment and training processes without version
+control.
+- Lack of documentation on model lineage and data provenance.
+- Inability to reproduce ML experiments due to missing environment
+configurations.
+- Performing model training only when necessary without automated
+testing and validation.
+- Siloed development and operations teams working separately on ML
+workflows.
+
+**Benefits of establishing this best
+practice:**
+
+- Increases productivity through automation of repetitive ML
+development tasks.
+- Improves reproducibility of ML experiments and model training.
+- Enhances collaboration between data scientists and operations
+teams.
+- Accelerates time-to-market for ML-powered features and
+applications.
+- Reduces risk through ability to quickly roll back problematic
+deployments.
+- Improves adherence to audit requirements through comprehensive
+traceability.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Implementing CI/CD/CT for machine learning workloads requires a
+different approach than traditional software development due to
+the data-centric nature of ML systems. While software CI/CD
+focuses primarily on code, ML pipelines must also track data,
+model artifacts, and training environments for full
+reproducibility.
+
+MLOps combines DevOps practices with machine learning to automate
+and streamline the entire lifecycle of ML systems. By implementing
+MLOps with traceability, you create a foundation that supports
+reproducible science, auditability, and operational excellence.
+This allows your organization to deploy ML models with confidence
+while maintaining the ability to understand exactly how each model
+was created and what data influenced its behavior.
+
+Amazon SageMaker AI provides a comprehensive solution to implement
+MLOps practices with built-in version control, lineage tracking,
+and pipeline automation. By using SageMaker AI and complementary AWS
+services, you can establish a robust MLOps framework that makes
+your ML workflows reproducible, traceable, and maintainable.
+
+### Implementation steps
+
+- **Implement version control for ML
+artifacts**. Set up repositories for code, data,
+models, and configurations using version control systems.
+Use
+[AWS CodeCommit](https://aws.amazon.com/codecommit/) or integrate with GitHub to version your
+ML code and configurations. For data and models, use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to version and catalog your
+models, creating a system of record that tracks the lineage
+of each model.
+- **Set up data versioning and lineage
+tracking**. Implement data version control to track
+changes in your datasets over time. Use
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to store, share, and manage
+features for ML development, which you can use to track and
+version feature values. Implement Lineage Tracking to track
+the relationships between ML artifacts including data,
+models, training jobs, and deployments.
+- **Establish continuous integration
+practices**. Configure automated tests that verify
+both code quality and model performance. Set up CI pipelines
+using
+[AWS CodeBuild](https://aws.amazon.com/codebuild/) that run unit tests, integration tests, and
+model quality tests when changes are pushed to your
+repositories. Implement automated code review practices to
+maintain quality standards across your ML codebase.
+- **Build continuous delivery pipelines
+for models**. Create automated deployment pipelines
+for ML models using
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) or
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/). Configure pipelines to include stages
+for data preparation, model training, evaluation, and
+deployment. Implement approval gates for human validation
+before models are deployed to production environments.
+- **Implement continuous training
+mechanisms**. Set up automated retraining pipelines
+that can be triggered by data drift, scheduled intervals, or
+on-demand. Use Amazon SageMaker AI Pipelines to create
+end-to-end workflows for model retraining. Implement
+monitoring for model drift using
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) and trigger retraining when performance
+degrades below thresholds.
+- **Establish model governance and
+approval workflows**. Create a governance framework
+that requires appropriate reviews and approvals before
+models move to production. Use SageMaker AI Model Registry to
+implement model approval workflows with different approval
+stages. Configure integration with notification services
+like [Amazon SNS](https://aws.amazon.com/sns/) to alert stakeholders when models need review.
+- **Implement immutable infrastructure
+for reproducibility**. Use infrastructure as code
+(IaC) to define your ML environments consistently. Leverage
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to define your SageMaker AI environments,
+maintaining consistency across development, testing, and
+production. Create standardized container images for
+training and inference to improve environment
+reproducibility.
+- **Set up comprehensive monitoring and
+logging**. Implement monitoring for your ML
+pipelines and deployed models. Use
+[CloudWatch](https://aws.amazon.com/cloudwatch/)
+to track operational metrics of your pipeline runs and model
+endpoints. Configure SageMaker AI Model Monitor to track data
+drift, model drift, and prediction quality over time.
+- **Create rollback mechanisms for
+models and pipelines**. Establish automated
+rollback procedures that can quickly revert to previous
+model versions when issues are detected. Configure SageMaker AI
+endpoints with production variants to support blue/green
+deployments and canary testing, enabling safe rollbacks when
+needed.
+
+## Resources
+
+**Related documents:**
+
+- [Implement
+MLOps](https://docs.aws.amazon.com/sagemaker/latest/dg/mlops.html)
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [AWS DevOps Guidance](https://docs.aws.amazon.com/wellarchitected/latest/devops-guidance/devops-guidance.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Create
+Amazon SageMaker AI projects with image building CI/CD
+pipelines](https://aws.amazon.com/blogs/machine-learning/create-amazon-sagemaker-projects-with-image-building-ci-cd-pipelines/)
+
+**Related videos:**
+
+- [Deliver
+high-performance ML models faster with MLOps tools](https://www.youtube.com/watch?v=T9llSCYJXxc)
+- [Accelerate
+production for gen AI using Amazon SageMaker AI MLOps &
+FMOps](https://www.youtube.com/watch?v=-3Otl7GVeCc)
+
+**Related examples:**
+
+- [Amazon
+Sagemaker MLOps](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+- [Amazon SageMaker AI secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp01.html*
+
+---
+
+# MLREL03-BP02 Verify feature consistency across training and inference
+
+Provide consistent, scalable, and highly available features between
+training and inference using a feature storage. This results in
+reducing the training-serving skew by keeping feature consistency
+between training and inference.
+
+**Desired outcome:** You create a
+centralized feature repository where feature definitions are stored,
+versioned, and shared across your organization. This makes the same
+features used during model training consistently available during
+inference, which reduces training-serving skew. You can discover,
+reuse, and share features across different ML projects, reducing
+duplicate work and standardizing feature engineering practices.
+
+**Common anti-patterns:**
+
+- Recreating feature transformations separately for training and
+inference pipelines.
+- Storing features in different formats or locations for training
+versus production.
+- Lack of versioning for features, leading to inconsistencies when
+models are updated.
+- Duplicating feature engineering work across different teams or
+projects.
+- Using non-standardized approaches to feature storage and
+retrieval.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces training-serving skew, leading to more reliable model
+performance in production.
+- Increases developer productivity through feature reusability.
+- Standardizes feature definitions across the organization.
+- Improves model governance and auditability through feature
+versioning.
+- Saves costs by avoiding redundant feature computation and
+storage.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Feature consistency between training and inference is critical for
+machine learning system reliability. When the features used to
+train a model differ from those used during inference, model
+performance can degrade, a problem known as training-serving skew.
+To avoid this issue, you need a centralized feature repository
+that provides consistent access to the same feature definitions
+and transformations across both training and inference
+environments.
+
+A feature store serves as this centralized repository, enabling
+you to define, store, and retrieve features consistently. It
+provides mechanisms for versioning features, which verifies that
+you can maintain compatibility between models and the features
+they expect as your data and feature engineering processes evolve.
+Additionally, a feature store allows for the sharing and reuse of
+features across multiple ML projects, increasing efficiency and
+standardizing feature engineering practices across your
+organization.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Feature
+Store**. Create and configure a
+[SageMaker AI
+Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to serve as your centralized repository
+for ML features. SageMaker AI Feature Store provides both
+online and offline storage capabilities: the online store
+supports low-latency, real-time inference use cases, while
+the offline store supports training and batch inference
+processes. Create a feature group that defines your feature
+structure, data types, and storage configurations using the
+SageMaker AI SDK or console.
+- **Define feature groups and
+schemas**. Organize your features into logical
+groups based on business domains, data sources, or ML use
+cases. Define schemas for your features, including data
+types, descriptions, and metadata. This organization makes
+features more discoverable and more straightforward to
+manage across your organization.
+- **Implement feature ingestion
+pipelines**. Build automated pipelines to ingest
+and process raw data into features. Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html),
+[AWS Glue](https://aws.amazon.com/glue/), or
+[Amazon EMR](https://aws.amazon.com/emr/) to transform raw data into feature values.
+Configure both batch ingestion for historical data and
+streaming ingestion for real-time updates using services
+like
+[Amazon Kinesis](https://aws.amazon.com/kinesis/) with SageMaker AI Feature Store.
+- **Develop feature retrieval
+mechanisms**. Create standardized ways to retrieve
+features for both training and inference. For training
+datasets, implement code that pulls features from the
+offline store, while for inference, develop services that
+query the online store. Verify that both paths use the same
+feature definitions and transformations.
+- **Integrate with ML
+workflows**. Connect your feature store to your ML
+pipelines by integrating it with
+[SageMaker AI
+Pipelines](https://aws.amazon.com/sagemaker/pipelines/) or your custom ML workflows. This makes
+feature retrieval consistent throughout the ML lifecycle,
+from experimentation to production deployment.
+- **Monitor and validate
+features**. Implement monitoring for your feature
+store to detect data drift, missing values, or other quality
+issues. Use
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) or custom validation scripts for
+feature consistency and quality over time. Set up alerts for
+deviations in feature distributions.
+- **Enable feature discovery and
+sharing**. Document your features with metadata and
+descriptions to make them discoverable across your
+organization. Integrate with data catalogs like
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html) to enhance discoverability and
+governance of features.
+
+## Resources
+
+**Related documents:**
+
+- [Get
+started with Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-getting-started.html)
+- [Feature
+Store concepts](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-concepts.html)
+- [Store,
+Discover, and Share Machine Learning Features with Amazon SageMaker AI Feature Store](https://aws.amazon.com/blogs/machine-learning/unlock-ml-insights-using-the-amazon-sagemaker-feature-store-feature-processor/)
+- [Unlock
+ML insights using the Amazon SageMaker AI Feature Store Feature
+Processor](https://aws.amazon.com/blogs/machine-learning/unlock-ml-insights-using-the-amazon-sagemaker-feature-store-feature-processor/)
+
+**Related videos:**
+
+- [Amazon SageMaker AI Feature Store: Store, discover, & share features
+for ML apps](https://www.youtube.com/watch?v=pEg5c6d4etI)
+- [Deep
+dive on Amazon SageMaker AI Feature Store](https://www.youtube.com/watch?v=mHEUlPFT6xg)
+
+**Related examples:**
+
+- [Introduction
+to Feature Store](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-featurestore/feature_store_introduction.html)
+- [Amazon SageMaker AI Feature Store SageMaker AI Examples](https://github.com/aws/amazon-sagemaker-examples/tree/master/sagemaker-featurestore)
+- [Amazon SageMaker AI Feature Store: Streaming Aggregation](https://github.com/aws-samples/amazon-sagemaker-feature-store-streaming-aggregation)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp02.html*
+
+---
+
+# MLREL03-BP03 Validate models with relevant data
+
+Testing and validating machine learning models with appropriate data
+is essential for reliable performance in production. Use real and
+representative data that covers many possible patterns and scenarios
+to avoid model failures when deployed in real-world environments.
+
+**Desired outcome:** You establish
+processes that validate your machine learning models with
+real-world, representative data before deployment. You can identify
+distribution mismatches between training, validation, test, and
+inference data early, allowing you to address issues before they
+impact production performance. Your validation approach includes
+both real-world and engineered data to account for the scenarios
+your model might encounter.
+
+**Common anti-patterns:**
+
+- Testing models with only synthetic data that doesn't represent
+real-world conditions.
+- Failing to check for distribution mismatch between training and
+production data.
+- Ignoring edge cases and rare scenarios in validation datasets.
+- Using validation data that lacks diversity or has sampling
+biases.
+- Neglecting periodic revalidation after models are deployed.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces risk of model failures in production environments.
+- Enables early detection of data drift and model quality
+degradation.
+- Creates more robust models that perform well across expected
+scenarios.
+- Increases trust in model predictions from stakeholders.
+- Improves alignment between model performance in testing and
+production.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Validating your machine learning models with relevant data is a
+critical step in the ML development lifecycle. Data that fails to
+represent the full range of scenarios your model will encounter in
+production can lead to poor performance, biased outputs, or
+complete failures when deployed. The key challenge lies in
+obtaining and using data that accurately mirrors your production
+environment.
+
+Begin by analyzing your data sources to capture the breadth and
+depth of real-world scenarios. This includes common cases as well
+as edge cases that might be rare but important. For example, a
+model designed to detect fraudulent transactions needs exposure to
+both typical and unusual fraud patterns. Missing these edge cases
+can create vulnerabilities in your deployed model.
+
+Pay particular attention to distribution mismatches, where the
+statistical properties of your training, validation, test, and
+eventual inference data differ. These mismatches often lead to
+degraded model performance in production. For instance, if you
+train a product recommendation model on data from one demographic
+group but deploy it for a different group, the model may make
+irrelevant recommendations.
+
+Implement continuous monitoring after deployment to detect when
+the data distribution shifts over time, which is common in
+real-world applications. This allows you to retrain models before
+performance degradation impacts business outcomes.
+
+### Implementation steps
+
+- **Establish data quality
+criteria**. Define what constitutes representative
+data for your use case. Include requirements for data
+completeness, diversity, and coverage of edge cases.
+Document these criteria as part of your ML development
+process to create consistency across projects.
+- **Implement cross-validation
+techniques**. Use techniques like k-fold
+cross-validation to verify that your model generalizes well
+across different subsets of your data. This can identify
+potential overfitting issues before deployment and provides
+a more robust estimate of how your model will perform in
+production.
+- **Use Amazon SageMaker AI MLFlow
+Tracking**. Set up experiments to track and compare
+different training runs with various data configurations.
+[SageMaker AI
+MLFlow Tracking](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html) allows you to organize, monitor, and
+evaluate your machine learning experiments systematically.
+This can identify which data configurations lead to the best
+performance and provides a historical record for future
+reference.
+- **Create engineered test
+data**. Generate synthetic data to supplement
+real-world data, especially for rare but important edge
+cases. Verify that this synthetic data maintains the
+statistical properties of real data while providing coverage
+for scenarios that might be underrepresented in your
+original dataset.
+- **Implement data drift
+detection**. Set up processes to continuously
+compare the distribution of inference data with your
+baseline training data. Use this comparison to identify when
+the real-world data begins to diverge from what the model
+was trained on, which can signal the need for retraining.
+- **Use Amazon SageMaker AI Model
+Monitor**. Deploy
+[Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automatically track and analyze model
+behavior in production. Configure alerts for deviations in
+model quality, data quality, bias drift, and feature
+attribution drift. SageMaker AI Model Monitor continuously
+evaluates your deployed models and notifies you when action
+is needed.
+- **Establish a regular validation
+cadence**. Schedule periodic evaluations of your
+model using fresh data, even if drift hasn't been detected.
+This can catch subtle changes that might not trigger
+automated alerts but could still affect model performance
+over time.
+- **Document validation
+results**. Create detailed reports of validation
+processes and outcomes for each model version. Include
+metrics on data representativeness, performance across
+different data segments, and identified gaps or biases.
+
+## Resources
+
+**Related documents:**
+
+- [Evaluating
+ML Models](https://docs.aws.amazon.com/machine-learning/latest/dg/evaluating_models.html)
+- [Cross-Validation](https://docs.aws.amazon.com/machine-learning/latest/dg/cross-validation.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/)
+- [Detect
+data drift using Amazon SageMaker AI Model Monitor](https://aws.amazon.com/blogs/architecture/detecting-data-drift-using-amazon-sagemaker/)
+- [Monitoring
+in-production ML models at large scale using Amazon SageMaker AI
+Model Monitor](https://aws.amazon.com/blogs/machine-learning/monitoring-in-production-ml-models-at-large-scale-using-amazon-sagemaker-model-monitor/)
+
+**Related videos:**
+
+- [How
+To Efficiently Manage ML experiments using Amazon SageMaker AI ML
+Flow](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Model Monitor](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp03.html*
+
+---
+
+# MLREL03-BP04 Establish data bias detection and mitigation
+
+Detect and mitigate bias to avoid inaccurate model results.
+Establish bias detection methodologies at data preparation stage
+before training starts. Monitor, detect, and mitigate bias after the
+model is in production. Establish feedback loops to track the drift
+over time and initiate a re-training.
+
+**Desired outcome:** You can identify
+and address biases in your machine learning data and models,
+providing fair and accurate predictions. You have established
+systematic approaches for detecting bias before training and
+continuously monitoring bias in production. Your AI systems produce
+more reliable, fair, and trustworthy results through automated
+detection and mitigation processes.
+
+**Common anti-patterns:**
+
+- Waiting until after model deployment to consider bias detection.
+- Using a single bias metric for each use case without
+understanding context-specific requirements.
+- Focusing only on training data bias and ignoring bias that may
+emerge in production.
+- Failing to establish feedback mechanisms to monitor and address
+drift over time.
+- Treating bias detection as a one-time activity rather than an
+ongoing process.
+
+**Benefits of establishing this best
+practice:**
+
+- Improves model accuracy and fairness across different
+demographic groups.
+- Reduces risk of deploying models with harmful or discriminatory
+outcomes.
+- Enhances transparency and explainability for model predictions.
+- Increases trust from users and stakeholders in AI systems.
+- Improves adherence to emerging AI regulations and ethical
+guidelines.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Bias in machine learning models can lead to unfair or inaccurate
+outcomes that disproportionately impact certain groups. You need a
+systematic approach to detect and mitigate bias throughout the
+machine learning lifecycle. This begins with careful analysis of
+your training data to identify potential imbalances or historical
+biases that could be propagated by your models. By implementing
+bias detection methodologies before training, you can address
+issues early in the development process.
+
+Once your models are in production, ongoing monitoring is
+essential as new data patterns may introduce unexpected biases
+over time. Setting up automated detection systems allows you to
+continuously evaluate model fairness and take corrective actions
+when necessary. Building feedback loops provides the data needed
+to understand how bias manifests in real-world applications and
+informs model retraining strategies.
+
+Amazon SageMaker AI provides comprehensive tools like SageMaker AI
+Clarify to implement bias detection and mitigation strategies
+throughout the ML lifecycle. These tools offer quantitative
+metrics to measure different types of bias and provide
+explanations for model predictions to understand and address the
+root causes of unfairness.
+
+### Implementation steps
+
+- **Understand different types of
+bias**. Begin by educating your team about various
+forms of bias that can affect machine learning models,
+including selection bias, measurement bias, aggregation
+bias, and evaluation bias. Educate your team members on how
+bias can be introduced at different stages of the ML
+lifecycle and the potential impacts on model predictions.
+- **Analyze your training
+data**. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) to examine your training data for
+potential bias before model development. Analyze the
+distribution of sensitive attributes and identify imbalances
+or correlations that could lead to unfair outcomes. Address
+data imbalances through techniques like resampling,
+weighting, or generating synthetic data for underrepresented
+groups.
+- **Select appropriate bias
+metrics**. Choose bias metrics that align with your
+specific use case and fairness requirements. SageMaker AI
+Clarify provides multiple pre-training bias metrics
+including class imbalance, difference in proportions of
+labels, and conditional demographic disparity. For
+post-training, metrics like disparate impact, difference in
+positive proportions across predicted labels, and accuracy
+difference can evaluate model fairness.
+- **Run SageMaker AI Clarify processing
+jobs**. Integrate
+[SageMaker AI
+Clarify processing jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html) into your ML pipeline to
+analyze bias and provide explainability. Configure these
+jobs to calculate bias metrics on your training data and
+model predictions, identifying potential issues before
+deployment.
+- **Implement bias mitigation
+strategies**. Address identified biases using
+techniques like preprocessing (modifying training data),
+in-processing (incorporating fairness constraints during
+training), or post-processing (adjusting model outputs).
+Experiment with different approaches and measure their
+impact on both fairness metrics and model performance.
+- **Set up production
+monitoring**. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously track bias
+metrics on production data. Create alerts that alarm when
+bias metrics exceed predefined thresholds, enabling prompt
+investigation and remediation of emerging issues.
+- **Establish feedback loops**.
+Implement mechanisms to collect and analyze feedback on
+model predictions, particularly focusing on cases where bias
+may be present. Use this feedback to improve your
+understanding of real-world bias patterns and inform model
+retraining strategies.
+- **Generate model governance
+reports**. Use SageMaker AI Clarify to create
+comprehensive reports on model fairness and explainability
+for stakeholders, including risk and compliance-aligned
+teams and external regulators. These reports should document
+your bias detection and mitigation efforts, providing
+transparency into your responsible AI practices.
+- **Conduct regular model
+reviews**. Schedule periodic reviews of your
+models' fairness performance, bringing together
+cross-functional teams to evaluate bias metrics, examine
+challenging cases, and decide on necessary interventions or
+improvements.
+
+## Resources
+
+**Related documents:**
+
+- [Run
+SageMaker AI Clarify Processing Jobs for Bias Analysis and
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Amazon SageMaker AI Clarify Detects Bias and Increases the Transparency
+of Machine Learning Models](https://aws.amazon.com/blogs/aws/new-amazon-sagemaker-clarify-detects-bias-and-increases-the-transparency-of-machine-learning-models/)
+- [Build
+a secure enterprise machine learning platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.html)
+
+**Related videos:**
+
+- [Introducing
+Amazon SageMaker AI Clarify, part 1 - Bias detection](https://www.youtube.com/watch?v=jvcPZmnXaxo)
+- [Introducing
+Amazon SageMaker AI Clarify, part 2 - Model explainability](https://www.youtube.com/watch?v=1IGMG_c280E)
+- [Responsible
+use of artificial intelligence and machine learning](https://pages.awscloud.com/Responsible-Use-of-Artificial-Intelligence-and-Machine-Learning_2022_1007-MCL_OD.html)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Clarify: ML Bias Detection and Explainability](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+- [Amazon SageMaker AI Model Monitoring](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp04.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLREL04.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLREL04.md
@@ -1,0 +1,320 @@
+# MLREL04
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLREL04-BP01 Automate endpoint changes through a pipeline
+
+Manual change management can be error prone and potentially incur a
+high effort cost. Use automated pipelines (that integrate with a
+change management tracking system) to deploy changes to your model
+endpoints. Versioned pipeline inputs and artifacts allow you to
+track the changes and automatically rollback after a failed change.
+
+**Desired outcome:** You establish a
+reliable and consistent deployment process for your machine learning
+models. You gain the ability to track changes, perform automatic
+rollbacks when needed, and improve adherence to change management
+policies. This approach reduces manual errors, increases operational
+efficiency, and provides you with better visibility into your ML
+deployment lifecycle.
+
+**Common anti-patterns:**
+
+- Making manual updates directly to production endpoints.
+- Using different deployment processes across teams or
+environments.
+- Lacking proper version control for model artifacts.
+- Not having clear rollback mechanisms for failed deployments.
+- Bypassing change management tracking systems.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces human error during deployments.
+- Increases deployment speed and reliability.
+- Improves traceability and auditability of changes.
+- Enables rollback to previous versions.
+- Improves adherence to change management policies.
+- Supports scalable ML operations across multiple models.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Implementing automated pipelines for model endpoint changes brings
+consistency and reliability to your ML operations. By using a
+standardized deployment approach, you can verify that that changes
+to production endpoints follow the same validated process. This
+reduces the risk of deployment errors and improves overall
+operational efficiency.
+
+The pipeline should include steps for testing, validation, and
+approval of model changes before they reach production.
+Integration with your existing change management system allows for
+proper tracking and documentation of changes. The pipeline should
+also maintain versioned artifacts of models deployed, enabling
+rollback if issues arise in production.
+
+### Implementation steps
+
+- **Set up a CI/CD pipeline for ML
+workloads**. Establish a continuous integration and
+continuous delivery pipeline specifically designed for
+machine learning workloads.
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) provides a purpose-built solution
+for creating end-to-end ML workflows at scale.
+- **Integrate with change management
+systems**. Connect your pipeline to existing change
+management tracking systems to document endpoint changes.
+This improves adherence with your organization's governance
+requirements and provides a full audit trail of deployment
+activity.
+- **Implement artifact
+versioning**. Store model artifacts, code, and
+configuration files in version control. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog and version your
+models, making it straightforward to track which model
+versions are deployed to which endpoints.
+- **Define automated testing and
+validation**. Include automated testing steps in
+your pipeline to validate model performance before
+deployment. This should include unit tests, integration
+tests, and model quality evaluations using metrics specific
+to your use case.
+- **Establish approval gates**.
+Configure approval checkpoints in your pipeline where
+stakeholders can review changes before they are promoted to
+production. These gates maintain quality control and improve
+adherence to business requirements.
+- **Implement automated rollback
+mechanisms**. Create automated procedures to roll
+back to the previous stable version if a deployment fails or
+if issues are detected after deployment. This minimizes
+downtime and impact on users.
+- **Monitor deployment
+metrics**. Track the success rate of deployments
+and time-to-deployment metrics to continuously improve your
+pipeline. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor these operational metrics.
+
+## Resources
+
+**Related documents:**
+
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Build
+a CI/CD pipeline for deploying custom machine learning models
+using AWS services](https://aws.amazon.com/blogs/machine-learning/build-a-ci-cd-pipeline-for-deploying-custom-machine-learning-models-using-aws-services/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+
+**Related videos:**
+
+- [Implementing
+MLOps practices with Amazon SageMaker AI](https://youtu.be/fuXUi_hoK78)
+
+**Related examples:**
+
+- [SageMaker AI
+Pipelines and SageMaker AI Model Registry](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel04-bp01.html*
+
+---
+
+# MLREL04-BP02 Use an appropriate deployment and testing strategy
+
+Select the right deployment and testing strategy for your machine
+learning models to create smoother transitions to production,
+minimize disruption, and allow for careful evaluation of model
+performance before full implementation.
+
+**Desired outcome:** You can
+confidently deploy machine learning models to production using
+strategies that minimize risk and maximize availability. You have
+established processes to monitor model performance, allowing you to
+make data-driven decisions about when to roll back to previous
+versions or roll forward with new updates. Your deployment pipelines
+include appropriate testing, validation, and metrics collection to
+improve model quality and performance in production environments.
+
+**Common anti-patterns:**
+
+- Deploying new models directly to production without testing
+strategies.
+- Lacking version control for model artifacts.
+- Not implementing monitoring metrics to evaluate model
+performance.
+- Using the same deployment strategy for models without
+considering specific use case requirements.
+- Failing to plan for rollbacks when model performance degrades.
+
+**Benefits of establishing this best
+practice:**
+
+- Minimizes disruption to production services during model
+updates.
+- Enables testing models with real production traffic before full
+deployment.
+- Reduces risk through controlled deployment strategies.
+- Improves visibility into model performance.
+- Provides better mechanisms for recovering from poor-performing
+model deployments.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning models require special consideration when
+deploying to production environments because their behavior can be
+complex and sometimes unpredictable. Unlike traditional software
+where functionality is explicitly coded, ML models learn patterns
+from data, making it crucial to validate their performance with
+production data before full deployment.
+
+Different deployment strategies provide varying levels of risk
+mitigation and testing capabilities. Blue/green deployments allow
+for instantaneous rollback by maintaining two identical
+environments. Canary deployments reduce risk by exposing only a
+small portion of traffic to new models. A/B testing enables you to
+compare performance metrics between model versions. Shadow
+deployments let you test new models without affecting user
+experience by running them alongside the production model but not
+using their predictions.
+
+Your choice of deployment strategy should be guided by your
+specific requirements for availability, risk tolerance, and the
+criticality of the ML application. For high-stakes applications
+like fraud detection or medical diagnostics, more cautious
+approaches like canary or shadow deployments may be appropriate.
+For less critical applications, simpler strategies might suffice.
+
+### Implementation steps
+
+- **Perform a deployment strategy
+trade-off analysis**. Evaluate your business
+requirements and risk tolerance to determine which
+deployment strategies are most appropriate for your ML
+models. Consider factors like required availability,
+acceptable downtime, criticality of predictions, and
+monitoring capabilities. Document your analysis and
+selection criteria for each model deployment.
+- **Implement robust model
+versioning**. Establish a system to version model
+artifacts, including the model itself, preprocessing
+components, and associated configurations. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog models and track
+their lineage, approval status, and deployment history.
+Then, you can quickly identify what model version is running
+and roll back if needed.
+- **Set up blue/green deployments with
+SageMaker AI**. Implement blue/green deployments for
+your real-time inference endpoints to maximize availability
+during updates. SageMaker AI automatically provisions new
+infrastructure (green fleet) before transitioning traffic
+from the old infrastructure (blue fleet), providing nearly
+continuous service. Configure the appropriate
+[traffic
+shifting mode](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green.html) based on your risk tolerance.
+- **Configure canary deployments for
+higher-risk updates**. For model updates where you
+want additional safety, implement canary deployments that
+route a small percentage of traffic to the new model version
+first. Use
+[SageMaker AI
+deployment guardrails](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green-canary.html) to set up canary testing with
+baking periods to monitor model performance before shifting
+the remaining traffic.
+- **Establish linear traffic shifting
+for granular control**. For the most controlled
+deployments, set up
+[linear
+traffic shifting](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green-linear.html) in SageMaker AI to gradually move
+traffic from the blue fleet to the green fleet in multiple
+steps. Define appropriate step sizes and baking periods
+between shifts to carefully monitor model behavior at each
+stage.
+- **Implement A/B testing for model
+comparison**. When you need to validate that a new
+model performs better than the existing one, set up A/B
+testing to compare metrics between versions with real
+production traffic. Use
+[SageMaker AI
+A/B testing](https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html) to route defined percentages of traffic
+to different model variants and collect performance data.
+- **Deploy shadow models to reduce the
+risk of testing**. For high-risk applications,
+consider implementing shadow deployments where the new model
+runs alongside the production model but doesn't affect
+customer-facing decisions. This allows you to compare how
+the new model would have performed using real production
+data while minimizing the risk.
+- **Define and implement model
+performance metrics**. Establish clear metrics to
+evaluate model performance in production, such as prediction
+accuracy, latency, throughput, and business KPIs. Set up
+monitoring with
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track these metrics and create alarms
+that can run automatic or manual interventions when
+performance degrades.
+- **Create automatic rollback
+mechanisms**. Implement automated procedures to
+roll back to previous model versions when performance
+metrics indicate problems. Define specific thresholds for
+metrics that would trigger a rollback, and establish the
+process for rolling back with minimal disruption.
+- **Build comprehensive CI/CD
+pipelines**. Integrate your deployment strategies
+into complete CI/CD pipelines that automate the testing,
+deployment, and monitoring of models. Use
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) and
+[AWS CodeDeploy](https://aws.amazon.com/codedeploy/) in conjunction with SageMaker AI to create
+reliable deployment workflows.
+
+## Resources
+
+**Related documents:**
+
+- [Deployment
+guardrails for updating models in production](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails.html)
+- [Blue/Green
+Deployments](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green.html)
+- [Testing
+models with production variants](https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Take
+advantage of advanced deployment strategies using Amazon SageMaker AI deployment guardrails](https://aws.amazon.com/blogs/machine-learning/take-advantage-of-advanced-deployment-strategies-using-amazon-sagemaker-deployment-guardrails/)
+- [A/B
+Testing ML models in production using Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/a-b-testing-ml-models-in-production-using-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Deliver
+high-performance ML models faster with MLOps tools](https://www.youtube.com/watch?v=T9llSCYJXxc)
+- [Canaries
+in the code mines: Monitoring deployment pipelines](https://www.youtube.com/watch?v=IHbY897uEbQ)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Inference Deployment Guardrails](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-inference-deployment-guardrails)
+- [Amazon SageMaker AI A/B Testing Pipeline](https://github.com/aws-samples/amazon-sagemaker-ab-testing-pipeline)
+- [Amazon SageMaker AI Safe Deployment Pipeline](https://github.com/aws-samples/amazon-sagemaker-safe-deployment-pipeline)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel04-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLREL05.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLREL05.md
@@ -1,0 +1,290 @@
+# MLREL05
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLREL05-BP01 Allow automatic scaling of the model endpoint
+
+Implement capabilities that allow the automatic scaling of model
+endpoints. This improves the reliable processing of predictions to
+meet changing workload demands. Include monitoring on endpoints to
+identify a threshold that initiates the addition or removal of
+resources to support current demand.
+
+**Desired outcome:** You can
+efficiently handle varying workload demands by implementing
+automatic scaling for your model endpoints. Your endpoints
+dynamically adjust resources based on real-time needs, providing
+consistent performance and availability without manual intervention.
+This results in reliable prediction processing, optimal resource
+utilization, and cost-effective operations.
+
+**Common anti-patterns:**
+
+- Manually scaling endpoints in response to traffic changes.
+- Over-provisioning resources to handle peak loads at non-peak
+times.
+- Neglecting to set up monitoring for endpoint performance.
+- Ignoring traffic patterns when configuring scaling policies.
+- Using fixed infrastructure that can't adapt to changing
+workloads.
+
+**Benefits of establishing this best
+practice:**
+
+- Improves reliability and availability of prediction services.
+- Optimizes costs through dynamic resource allocation.
+- Enhances user experience with consistent response times.
+- Reduces operational overhead through automation.
+- Strengthens ability to handle unexpected traffic spikes.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Automatic scaling of model endpoints is critical for maintaining
+reliable machine learning services in production. By implementing
+auto scaling, your endpoints can handle varying loads efficiently
+without manual intervention. This capability is especially
+important for applications with fluctuating traffic patterns or
+those that experience periodic spikes in demand.
+
+When setting up automatic scaling, you need to consider
+appropriate metrics that trigger scaling actions, such as CPU
+utilization, memory usage, or request latency. Define appropriate
+thresholds for these metrics so that your system scale at the
+right time - not too early (which wastes resources) or too late
+(which impacts performance).
+
+Monitoring is an essential component of an auto scaling solution.
+By implementing comprehensive monitoring, you gain visibility into
+endpoint performance and scaling operations, allowing you to
+optimize your configuration over time based on real usage
+patterns.
+
+### Implementation steps
+
+- **Configure automatic scaling for
+Amazon SageMaker AI endpoints**. Amazon SageMaker AI
+supports
+[automatic
+scaling (auto scaling)](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html) for your hosted models.
+SageMaker AI endpoints can be configured with auto scaling to
+maintain service availability as traffic increases.
+Automatic scaling automatically provisions new resources
+horizontally to handle increased user demand or system load.
+- **Set up appropriate scaling
+policies**. Define target metrics for scaling such
+as CPU utilization, memory usage, or request count.
+Configure appropriate minimum and maximum instance counts
+based on your expected traffic patterns and performance
+requirements. Consider implementing both scale-out policies
+(adding capacity when load increases) and scale-in policies
+(removing capacity when load decreases) to optimize resource
+utilization.
+- **Implement comprehensive
+monitoring**. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor the performance of your
+endpoint and collect metrics that can inform scaling
+decisions. Create dashboards to visualize endpoint
+performance and scaling activities. Set up alerts to notify
+you of issues or anomalies with your endpoints.
+- **Leverage SageMaker AI Serverless
+Inference**. For workloads with intermittent or
+unpredictable traffic patterns, consider using
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html), which automatically
+scales compute capacity up and down based on traffic,
+avoiding the need to choose instance types or manage scaling
+policies.
+- **Utilize SageMaker AI Inference
+Recommender**. Before deploying models to
+production, use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to get
+recommendations on instance types and configurations that
+will best meet your performance and cost requirements,
+assisting you in optimizing your scaling policies.
+- **Implement load testing**.
+Perform load testing on your endpoints to understand how
+they behave under different traffic conditions. This
+information can fine-tune your scaling policies so that
+they're effective when real traffic increases occur.
+
+## Resources
+
+**Related documents:**
+
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Configuring
+autoscaling inference endpoints in Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/configuring-autoscaling-inference-endpoints-in-amazon-sagemaker/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel05-bp01.html*
+
+---
+
+# MLREL05-BP02 Create a recoverable endpoint with a managed version control strategy
+
+Establish a fully recoverable system for model prediction endpoints
+by implementing proper version control and lineage tracking for
+components that generate these endpoints.
+
+**Desired outcome:** You have a
+robust infrastructure where components related to model deployment,
+including model artifacts, container images, and endpoint
+configurations, are version controlled and traceable. You can
+recover quickly from issues by identifying and reverting to previous
+stable versions, and you can audit the full lineage of model
+deployments for governance and regulatory requirements.
+
+**Common anti-patterns:**
+
+- Storing model artifacts without proper versioning.
+- Using deployment processes only when needed without
+infrastructure as code.
+- Failing to track dependencies between model artifacts,
+containers, and configurations.
+- Not maintaining a centralized registry for models.
+- Relying on manual processes for endpoint recovery.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces recovery time when endpoint issues occur.
+- Improves auditability and adherence through comprehensive
+lineage tracking.
+- Enhances collaboration between data scientists and operations
+teams.
+- Improves the consistency and reliability of model deployments.
+- Enables reproduction of model endpoints exactly as they were at
+specific points in time.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning model endpoints represent the interface where
+your business delivers value from AI/ML investments. Verifying
+that these endpoints are recoverable is critical for business
+continuity. Recoverability depends on having comprehensive version
+control for components involved in creating the endpoint.
+
+A properly implemented MLOps framework for endpoint recoverability
+tracks not just the model artifacts, but components that influence
+the prediction service—training data, feature transformations,
+container definitions, and infrastructure configurations. When
+incidents occur, you need to understand the complete lineage of
+your model endpoint, including which data trained the model, which
+code created the container, and which configurations defined the
+infrastructure.
+
+By implementing proper version control and lineage tracking, you
+create a system that is both resilient to failures and compatible
+with governance requirements. You can trace exactly how each
+endpoint was created and recreate it precisely when needed.
+
+### Implementation steps
+
+- **Implement MLOps with Amazon SageMaker AI Pipelines and Projects**.
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) automates ML workflows by
+providing a service for building, running, and managing ML
+pipelines. It handles every step from data preparation to
+model deployment in a versioned, predictable manner.
+- **Implement a model registry
+system**. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog your models for
+production. The registry tracks model versions and their
+approval status, creating a system of record for models in
+your organization. Define a clear approval workflow for
+moving models from development to production for proper
+governance at each stage. For each model, register metadata
+including performance metrics, training datasets, and
+intended use cases.
+- **Track experiments with SageMaker AI
+MLflow**. MLflow in SageMaker AI allows you to create,
+manage, analyze, and compare experiments. This way, data
+scientists can view and track the experiments for the
+current project. Each experiment logs every metric and
+hyperparameter automatically, along with model artifacts and
+dataset information.
+- **Use infrastructure as code (IaC)
+tools**. Define and build your infrastructure,
+including model endpoints, using
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/). IaC makes your infrastructure version
+controlled, repeatable, and able to be reverted to previous
+states if needed. Store your infrastructure code in git
+repositories alongside your model code, creating a unified
+version history. This approach reduces configuration drift
+between environments and verifies that your production
+deployment exactly matches your tested configuration.
+- **Store containers in Amazon Elastic Container Registry**. Use
+[Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html) to version and store the Docker containers that
+serve your models. Amazon ECR automatically creates version
+hashes for containers as you update them, enabling rollbacks
+to previous versions. Implement image scanning to detect
+security vulnerabilities, and apply lifecycle policies to
+manage older versions of your containers.
+- **Implement automated testing and
+deployment pipelines**. Create CI/CD pipelines
+using
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) to automate the testing and deployment
+of your models. These pipelines should validate models
+before deployment, deploy infrastructure changes through
+CloudFormation, and update model endpoints with minimal
+downtime. Integrate automated quality checks to avoid
+problematic models from reaching production.
+- **Configure automated backups and
+recovery processes**. Establish automated backup
+procedures for your model artifacts, container images, and
+endpoint configurations. Use
+[Amazon S3 versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html) for model artifacts and
+[AWS Backup](https://aws.amazon.com/backup/) to protect configuration data. Document and
+test recovery procedures regularly to verify that they work
+when needed.
+
+## Resources
+
+**Related documents:**
+
+- [AWS CloudFormation Documentation](https://docs.aws.amazon.com/cloudformation/index.html)
+- [Infrastructure
+as code](https://docs.aws.amazon.com/whitepapers/latest/introduction-devops-aws/infrastructure-as-code.html)
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [What
+is Amazon Elastic Container Registry?](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Fully
+managed MLflow 3.0 on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Multi-account
+model deployment with Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/multi-account-model-deployment-with-amazon-sagemaker-pipelines/)
+- [Automate
+feature engineering pipelines with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/automate-feature-engineering-pipelines-with-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Next-generation
+CDK development with Amazon Q Developer](https://www.youtube.com/watch?v=WEYuvh3YqkI)
+- [Infrastructure
+as Code on AWS - AWS Online Tech Talks](https://www.youtube.com/watch?v=cKQtPZwf97s)
+- [How
+to create fully automated ML workflows with Amazon SageMaker AI
+Pipelines](https://www.youtube.com/watch?v=W7uabCTfLrg)
+
+**Related examples:**
+
+- [Amazon SageMaker AI MLOps](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel05-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSEC01.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSEC01.md
@@ -1,0 +1,190 @@
+# MLSEC01
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSEC01-BP01 Validate ML data permissions, privacy, software, and license terms
+
+Machine learning implementations require careful consideration of
+data permissions, privacy, and software licensing to adhere to
+organizational and legal requirements. Validating these elements
+throughout the ML lifecycle builds trusted ML systems that respect
+data rights while delivering business value.
+
+**Desired outcome:** Establish a
+robust governance process that verifies that ML data usage and
+software implementations meets your organization's requirements.
+Maintain clear documentation of data permissions, approved software
+packages, and license adherence. Operate ML implementations within a
+framework that respects data subject rights, follows privacy
+regulations, and avoids legal complications related to software
+licensing.
+
+**Common anti-patterns:**
+
+- Assuming data collected for one purpose can automatically be
+used for ML training without additional consent.
+- Installing ML libraries and packages without reviewing their
+license terms or data collection practices.
+- Failing to document data permissions and consent mechanisms for
+adherence verification.
+- Ignoring the need for a process to handle withdrawn consent from
+data subjects.
+- Using third-party ML models without understanding their privacy
+implications or license restrictions.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces legal and regulatory risks related to data privacy and
+software licensing.
+- Enhances trust from data subjects and stakeholders through
+ethical data handling.
+- Avoids unexpected limitations on business plans due to
+restrictive license terms.
+- Improves documentation for audits and regulatory requirements.
+- Streamlines deployment through pre-validated software and
+container solutions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+ML libraries and packages handle various aspects of the machine
+learning lifecycle, from data processing and model development to
+training and hosting. Each component may come with specific
+license terms, privacy considerations, and data handling
+requirements. Validating these elements verifies your
+organization's ML initiatives adhere to regulatory requirements
+and don't introduce unexpected limitations.
+
+When implementing ML systems, verify that data being used has
+proper permissions for ML applications specifically. This often
+means going beyond general data collection consent to verify
+explicit permission for ML usage. For example, if you collected
+customer data for service delivery, you may need additional
+consent to use that data for training ML models.
+
+Understanding license implications is critical for software
+components. Some open-source ML libraries may have restrictions
+that could affect your ability to commercialize models trained
+with them. Similarly, third-party models or APIs might include
+terms that grant the provider certain rights to your data or
+restrict how you can deploy solutions.
+
+Privacy considerations extend beyond initial data collection to
+the entire ML lifecycle. Establish mechanisms to handle data
+subject requests, including the right to withdraw consent or be
+forgotten. Your ML implementation should respect these requests
+without compromising the entire system.
+
+### Implementation steps
+
+- **Attain data permissions for
+ML**. Verify whether your intended data can be used
+for machine learning specifically. Document the legitimate
+business purpose for using the data, and determine whether
+you need additional consent from data owners or subjects.
+Implement a process to handle data subjects who withdraw
+their consent, including the ability to remove their data
+from training sets or models when required. Maintain
+comprehensive documentation of data permissions for
+compliance-aligned purposes and potential audits.
+- **Create a software license
+inventory**. Develop and maintain an inventory of
+ML libraries, packages, and dependencies used in your ML
+pipeline. For each component, document the license type, key
+terms, restrictions, and implications for your business
+model. Use tools like
+[AWS License Manager](https://aws.amazon.com/license-manager/) to track and manage software licenses
+across your ML environments, improving adherence to
+licensing agreements and optimizing license usage.
+- **Bootstrap instances with lifecycle
+management policies**. Create lifecycle
+configurations with references to your approved package
+repositories and scripts to install required packages. This
+improves consistency across development environments and
+avoids the introduction of unauthorized packages. Implement
+[Amazon SageMaker AI Lifecycle Configurations](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lifecycle-configurations.html) to automate the
+setup of development environments with pre-approved software
+packages and configurations.
+- **Evaluate package integrations that
+require external lookup services**. Based on your
+data privacy requirements, opt out of data collection
+features when necessary. Minimize data exposure by
+establishing trusted relationships with service providers
+and understanding their data handling practices. Evaluate
+privacy policies and license terms for ML packages that
+might collect telemetry or other data. For sensitive
+implementations, consider creating private mirrors of
+required packages to maintain control over external
+connections.
+- **Use prebuilt containers**.
+Start with pre-packaged and verified containers to quickly
+provide support for commonly used dependencies while
+improving license adherence.
+[AWS Deep Learning Containers](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html) contain several deep
+learning framework libraries and tools including TensorFlow,
+PyTorch, and Apache MXNet with pre-validated license terms.
+These containers maintain consistency while reducing the
+risk of introducing unauthorized or incompatible packages.
+- **Establish a privacy-preserving ML
+workflow**. Implement data minimization principles
+by using only the data necessary for your ML tasks. Apply
+anonymization or pseudonymization techniques to sensitive
+data before using it for training. Consider using
+privacy-preserving ML techniques such as differential
+privacy or federated learning for highly sensitive
+applications. Document your privacy-preserving measures for
+compliance-aligned purposes and to build trust with
+stakeholders.
+- **Monitor for license and privacy
+adherence**. Implement continuous monitoring of
+your ML environments to detect potential license violations
+or privacy issues. Create automated checks for package
+versions and license changes during CI/CD processes.
+Regularly audit data access patterns to verify that they
+comply with documented permissions and privacy requirements.
+Establish a process for addressing issues when they arise.
+- **Consider synthetic data for training
+and testing**. Create synthetic datasets that
+preserve the statistical properties of real data while
+avoiding privacy concerns.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides capabilities for generating
+synthetic data for training and testing ML models when using
+real data presents privacy or licensing challenges. Document
+the use of synthetic data in your ML pipelines to
+demonstrate privacy-preserving practices.
+
+## Resources
+
+**Related documents:**
+
+- [Protecting
+compute](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-compute.html)
+- [What
+is AWS Deep Learning Containers?](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html)
+- [AWS License Manager](https://aws.amazon.com/license-manager/)
+- [Lifecycle
+configurations within Amazon SageMaker AI Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lifecycle-configurations.html)
+- [Data
+Privacy in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/data-privacy.html)
+- [Best
+practices for endpoint security and health with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/best-practice-endpoint-security.html)
+- [Private
+package installation in Amazon SageMaker AI running in
+internet-free mode](https://aws.amazon.com/blogs/machine-learning/private-package-installation-in-amazon-sagemaker-running-in-internet-free-mode/)
+- [Machine
+Learning Best Practices in Financial Services](https://aws.amazon.com/blogs/machine-learning/machine-learning-best-practices-in-financial-services/)
+
+**Related videos:**
+
+- [Machine
+Learning Best Practices in Financial Services](https://youtu.be/HlSEUvApDZE?t=578)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec01-bp01.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSEC02.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSEC02.md
@@ -1,0 +1,165 @@
+# MLSEC02
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSEC02-BP01 Design data encryption and obfuscation
+
+Consider how to protect personal data. Use field level encryption or
+obfuscation to protect personally identifiable data.
+
+**Desired outcome:** You establish
+robust protection for sensitive information by implementing data
+encryption and obfuscation techniques in your machine learning
+workflows. You identify and secure personally identifiable
+information (PII) through field-level encryption and data masking,
+which improves your adherence to privacy regulations while
+maintaining data utility for ML models.
+
+**Common anti-patterns:**
+
+- Storing personally identifiable information in plain text
+format.
+- Using the same encryption keys across different environments.
+- Implementing inconsistent data protection policies across ML
+pipelines.
+- Overlooking data protection requirements during the design
+phase.
+- Failing to audit data for attributes requiring special
+treatment.
+
+**Benefits of establishing this best
+practice:**
+
+- Enhanced protection of sensitive and personally identifiable
+data.
+- Improves adherence to data privacy regulations.
+- Reduced risk of data breaches and unauthorized access.
+- Improved trust from users and stakeholders.
+- Ability to utilize sensitive data for ML training while
+maintaining privacy.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When designing machine learning workflows, protect personal and
+sensitive data throughout the entire data lifecycle. You should
+evaluate your data early in the process to identify fields
+containing PII or other sensitive information requiring
+protection. Implementing field-level encryption or data
+obfuscation techniques maintains data utility for machine learning
+while safeguarding individual privacy.
+
+AWS provides multiple services to identify, classify, and protect
+sensitive data within your ML workflows. Services like
+[AWS Glue](https://aws.amazon.com/glue/)
+can automatically detect PII, while
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) and
+[AWS CloudHSM](https://aws.amazon.com/cloudhsm/) support robust encryption strategies. You should
+establish consistent policies for handling sensitive data across
+your organization and regularly audit your data protection
+measures to improve your adherence to privacy regulations.
+
+### Implementation steps
+
+- **Audit data for attributes requiring
+special treatment**. Identify fields containing
+data requiring special treatment, such as field-level
+encryption, data masking, or obfuscation. Use automated
+tools like
+[AWS Glue](https://aws.amazon.com/glue/) to identify PII and sensitive data patterns
+within your datasets.
+- **Establish a data classification
+framework**. Develop a systematic approach to
+categorize data based on sensitivity levels. Define which
+categories require encryption, masking, or other protection
+techniques, and document these requirements in your
+organization's security policies.
+- **Implement field-level
+encryption**. Apply encryption selectively to
+sensitive fields rather than entire datasets. Use
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to manage encryption keys
+and integrate with services like
+[Amazon S3](https://aws.amazon.com/s3/) or
+[Amazon DynamoDB](https://aws.amazon.com/dynamodb/) for transparent encryption of selected
+fields.
+- **Apply data obfuscation
+techniques**. Use methods such as tokenization,
+data masking, or anonymization to protect sensitive
+information while preserving data utility for machine
+learning. Consider using services like
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) for data transformation and masking
+operations.
+- **Establish key rotation
+policies**. Implement regular rotation of
+encryption keys to minimize the impact of potential key
+compromises. Configure
+[AWS KMS](https://aws.amazon.com/kms/) to automate key rotation according to your
+security policies and regulatory requirements.
+- **Secure ML model
+artifacts**. Verify that trained models and their
+associated metadata do not inadvertently expose sensitive
+information. Use
+[Amazon SageMaker AI's](https://aws.amazon.com/sagemaker/) security features to encrypt model
+artifacts and secure API endpoints that serve predictions.
+- **Implement access
+controls**. Restrict access to sensitive data and
+encryption keys using
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) policies. Apply the
+principle of least privilege to verify that only authorized
+personnel can access protected information.
+- **Monitor and audit access
+patterns**. Implement continuous monitoring to
+detect unauthorized access attempts or unusual patterns that
+might indicate a security breach. Configure
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) and
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track and alert on suspicious
+activities.
+- **Implement differential privacy
+techniques**. When working with AI models, consider
+implementing differential privacy techniques to add
+statistical noise to training data, protecting individual
+privacy while maintaining overall data utility.
+- **Establish mechanisms to stop model
+memorization**. Implement safeguards to block AI
+models from memorizing and potentially reproducing sensitive
+information from training data, especially when using large
+language models.
+
+## Resources
+
+**Related documents:**
+
+- [Detect
+and process sensitive data](https://docs.aws.amazon.com/glue/latest/dg/detect-PII.html)
+- [Security
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Data
+protection in Amazon SageMaker AI Unified Studio](https://docs.aws.amazon.com/sagemaker-unified-studio/latest/adminguide/data-protection.html)
+- [Data
+Privacy in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/data-privacy.html)
+- [Data
+Encryption](https://docs.aws.amazon.com/whitepapers/latest/introduction-aws-security/data-encryption.html)
+- [Introducing
+PII Data Identification and Handling Using AWS Glue
+DataBrew](https://aws.amazon.com/blogs/big-data/introducing-pii-data-identification-and-handling-using-aws-glue-databrew/)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Secure
+deployment of Amazon SageMaker AI resources](https://aws.amazon.com/blogs/security/secure-deployment-of-amazon-sagemaker-resources/)
+
+**Related videos:**
+
+- [Privacy-preserving
+machine learning](https://www.youtube.com/watch?v=ZQkB9XRqdnc)
+- [Data
+Protection Best Practices in Machine Learning](https://www.youtube.com/watch?v=1iZYmtFFLnw)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec02-bp01.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSEC03.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSEC03.md
@@ -1,0 +1,974 @@
+# MLSEC03
+
+**Pillar**: Unknown  
+**Best Practices**: 5
+
+---
+
+# MLSEC03-BP01 Provide least privilege access
+
+Protect resources across various phases of the ML lifecycle using
+the principle of least privilege. These resources include: data,
+algorithms, code, hyperparameters, trained model artifacts, and
+infrastructure. Provide dedicated network environments with
+dedicated resources and services to operate individual projects.
+
+**Desired outcome:** You establish a
+secure machine learning environment by implementing the principle of
+least privilege for resources involved in your ML workflows. Your
+organization controls access to sensitive data, models, and
+infrastructure based on business roles, maintains clear separation
+between development, test, and production environments, and uses
+appropriate governance mechanisms to enforce security policies. This
+approach minimizes your attack surface and protects valuable ML
+assets.
+
+**Common anti-patterns:**
+
+- Granting excessive permissions to data scientists or developers
+beyond what they need.
+- Using a single AWS account for ML workloads without proper
+separation.
+- Not tagging sensitive data and resources for access control
+purposes.
+- Failing to isolate ML environments based on data sensitivity
+requirements.
+- Relying solely on manual access management without proper
+governance structures.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of unauthorized access to sensitive data and ML
+assets.
+- Clear segregation of duties based on business roles.
+- Improves adherence to regulatory requirements for data
+protection.
+- Simplified governance through standardized access patterns.
+- Minimized potential impact of security breaches.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Protecting machine learning workflows requires a comprehensive
+security approach that applies the principle of least privilege to
+resources involved. By carefully controlling who has access to
+data, code, and infrastructure, you can reduce the risk of
+unauthorized access or data breaches.
+
+When implementing least privilege for ML resources, consider the
+different phases of the ML lifecycle and the types of access
+needed by various roles. For example, data scientists might need
+read access to training data but not production systems, while ML
+engineers may need deployment permissions but limited access to
+raw data.
+
+Setting up a multi-account architecture with
+[AWS Organizations](https://aws.amazon.com/organizations/) provides strong isolation between
+environments with different security requirements. This allows you
+to maintain separate development, testing, and production
+environments with appropriate controls for each.
+
+### Implementation steps
+
+- **Define role-based access control for
+ML teams**. Identify the distinct roles within your
+ML workflow, such as data scientists, ML engineers, and
+operations teams. Map these roles to specific access
+patterns required for their daily tasks. Use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to quickly create
+persona-based IAM roles with preconfigured templates for
+common ML roles including data scientists, MLOps engineers,
+and business analysts. This reduces manual permissions
+management and facilitates least privilege access by
+default. Complement with
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) for custom role-based
+policies. Implement regular access reviews to verify that
+permissions remain appropriate as responsibilities change.
+- **Implement account separation with
+AWS Organizations**. Create a multi-account
+architecture that segregates workloads between development,
+test, and production environments. Use
+[AWS Organizations](https://aws.amazon.com/organizations/) to centrally manage accounts and apply
+consistent policies. Establish tagging strategies to
+identify data sensitivity levels and resource ownership.
+Apply these tags to relevant resources like S3 buckets
+containing training data or SageMaker AI instances. Use
+[Service
+Catalog](https://aws.amazon.com/servicecatalog/) to create pre-provisioned environments that
+align with security requirements.
+- **Organize ML workloads by access
+patterns**. Group ML workloads based on common
+access requirements and security profiles. Create
+organizational units (OUs) in AWS Organizations that reflect
+these groupings. Delegate specific access permissions to
+each group according to their needs. Apply service control
+policies (SCPs) to enforce security guardrails at the
+organizational unit level. Limit administrative access to
+infrastructure to designated administrators only.
+- **Isolate sensitive data
+environments**. Create dedicated, isolated
+environments for working with sensitive data. Implement
+network controls such as security groups and network ACLs to
+restrict data flow between environments. Use
+[Amazon VPC](https://aws.amazon.com/vpc/) endpoints to provide private connectivity to AWS
+services without traversing the public internet. Configure
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) for secure access to SageMaker AI endpoints
+from within your VPC.
+- **Implement automated security
+controls**. Deploy
+[AWS Config](https://aws.amazon.com/config/) rules to continuously monitor resource
+configurations for adherence to security policies. Use
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) for threat detection across your ML
+infrastructure. Implement
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to log and monitor API calls related to ML
+resources. Consider using
+[Amazon Macie](https://aws.amazon.com/macie/) to automatically discover and protect sensitive
+data stored in Amazon S3.
+- **Use secure ML development
+practices**. Implement code repositories with
+appropriate access controls for ML code and models. Use
+version control for artifacts including data, code, and
+model parameters. Apply the principle of least privilege to
+CI/CD pipelines that deploy ML models. Implement model
+governance processes that include security reviews before
+deployment to production.
+- **Deploy ML guardrails with service
+control policies**. Create SCPs that enforce
+requirements across your ML environments. Define policies
+that block storage of sensitive data in unencrypted formats.
+Restrict network egress from environments containing
+sensitive data. Limit which AWS Regions can be used for
+specific types of ML workloads based on requirements.
+- **Implement safeguards for AI
+systems**. For AI workloads, implement additional
+security controls to protect against input injection
+attacks. Implement built-in guardrails for responsible AI
+use. Apply input validation for user inputs to AI systems.
+Implement output filtering to avoid inadvertent disclosure
+of sensitive information. Consider using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) with governance features to enforce
+compliance-aligned and responsible AI practices.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Service Catalog](https://aws.amazon.com/servicecatalog/)
+- [Build
+a Secure Enterprise Machine Learning Platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.pdf)
+- [Protecting
+data at rest](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-data-at-rest.html)
+- [Security
+best practices in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
+- [Building
+secure Amazon SageMaker AI access URLs with Service
+Catalog](https://aws.amazon.com/blogs/mt/building-secure-amazon-sagemaker-access-urls-with-aws-service-catalog/)
+- [Setting
+up secure, well-governed machine learning environments on
+AWS](https://aws.amazon.com/blogs/mt/setting-up-machine-learning-environments-aws/)
+- [ML
+security: Using Amazon SageMaker AI with AWS PrivateLink](https://aws.amazon.com/blogs/machine-learning/connect-to-amazon-services-using-aws-privatelink-in-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Architectural
+best practices for machine learning applications](https://www.youtube.com/watch?v=fBytsYBVgbo)
+- [Secure
+and compliant machine learning for regulated industries](https://www.youtube.com/watch?v=8p-B3sTLmFg)
+- [Amazon SageMaker AI Model Development in a Highly Regulated
+Environment (SDD315)](https://youtu.be/cSYFqKRQ0j0?t=1051)
+
+**Related examples:**
+
+- [Build
+your own Anomaly Detection ML Pipeline](https://d1.awsstatic.com/architecture-diagrams/ArchitectureDiagrams/build-your-own-anomaly-detection-ml-pipeline-ra.pdf?did=wp_card&trk=wp_card)
+- [AWS MLOps Framework](https://d1.awsstatic.com/architecture-diagrams/ArchitectureDiagrams/aws-mlops-framework-sol.pdf?did=wp_card&trk=wp_card)
+- [Secure
+ML deployment architecture reference](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/deploy-ml-models-securely-on-aws.html)
+- [Secure
+Data Science Reference Architecture](https://github.com/aws-samples/secure-data-science-reference-architecture)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp01.html*
+
+---
+
+# MLSEC03-BP02 Secure data and modeling environment
+
+Secure your machine learning data and development environments to
+protect valuable information assets throughout the ML lifecycle. By
+implementing proper security measures for storage, compute, and
+network resources, you can maintain data integrity and
+confidentiality while enabling data scientists to work effectively.
+
+**Desired outcome:** You have a
+secure foundation for storing, processing, and utilizing data for
+machine learning workloads. Your data is encrypted at rest and in
+transit, with access tightly controlled through identity management,
+infrastructure isolation, and secure coding practices. Your
+development environments are protected from unauthorized access
+while providing the necessary tools for your ML practitioners.
+
+**Common anti-patterns:**
+
+- Storing unencrypted training data in publicly accessible
+storage.
+- Using default security configurations for ML environments.
+- Allowing unrestricted internet access from ML environments.
+- Using hard-coded credentials in ML code and notebooks.
+- Installing ML packages from untrusted sources without
+validation.
+- Granting excessive permissions to development environments.
+
+**Benefits of establishing this best
+practice:**
+
+- Protection of sensitive training data from unauthorized access
+or exfiltration.
+- Reduced risk of compromised ML models and systems.
+- Improves adherence to regulatory requirements for data handling.
+- Improved governance of ML development environments.
+- Enhanced ability to detect and respond to security events.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Securing your ML environments requires a comprehensive approach
+addressing data storage, compute resources, network isolation, and
+access controls. The ML lifecycle involves multiple stages where
+data could be exposed if proper security measures aren't
+implemented. By establishing secure foundations for your ML
+infrastructure, you can protect valuable intellectual property
+while still enabling productivity.
+
+Start by securing your data repositories with encryption and
+access controls. Then build secure compute environments for model
+development that maintain isolation through private networking.
+Implement proper credential management to avoid exposure of
+secrets. Finally, verify that your package management practices
+block the introduction of malicious code into your ML pipeline.
+
+Modern ML workloads often involve large datasets and complex
+algorithms, making security even more critical as the impact of a
+breach could be substantial. By implementing the measures in this
+best practice, you create a secure foundation for your ML
+initiatives.
+
+### Implementation steps
+
+- **Build a secure analysis
+environment**. During the data preparation and
+feature engineering phases, leverage secure data exploration
+options on AWS. Use
+[Amazon SageMaker AI Studio](https://aws.amazon.com/sagemaker/studio/) managed environments or
+[Amazon EMR](https://aws.amazon.com/emr/) for data processing. Alternatively, use managed
+services like
+[Amazon Athena](https://aws.amazon.com/athena/) and
+[AWS Glue](https://aws.amazon.com/glue/) to explore data without moving it from your data
+lake. For smaller datasets, use Amazon SageMaker AI Studio to
+explore, visualize, and engineer features, then scale up
+your feature engineering using managed ETL services like
+Amazon EMR or AWS Glue.
+- **Create dedicated IAM and KMS
+resources**. Limit the scope and impact of
+credentials and keys by creating dedicated
+[AWS IAM](https://aws.amazon.com/iam/) roles and
+[AWS KMS](https://aws.amazon.com/kms/) keys for ML workloads. Create private
+[Amazon S3](https://aws.amazon.com/s3/) buckets with versioning enabled to protect your
+data and intellectual property. Implement a centralized data
+lake using
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) on Amazon S3. Secure your data lake
+using a combination of services to encrypt data in transit
+and at rest. Monitor access with granular
+[AWS IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html),
+[S3
+bucket policies](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-bucket-policy.html),
+[S3
+Access Logs](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html),
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), and
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/).
+- **Use Secrets Manager and Parameter
+Store to protect credentials**. Replace hard-coded
+secrets in your code with API calls to programmatically
+retrieve and decrypt secrets using
+[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/). Use
+[AWS Systems Manager Parameter Store](https://aws.amazon.com/systems-manager/features/#Parameter_Store) to store application
+configuration variables such as AMI IDs or license keys.
+Grant permissions to your SageMaker AI IAM role to access these
+services from your ML environments.
+- **Automate managing
+configuration**. Use lifecycle configuration
+scripts to manage ML environments. These scripts run when
+environments are created or restarted, allowing you to
+install custom packages, preload datasets, and set up source
+code repositories. Lifecycle configurations can be reused
+across multiple environments and updated centrally. Use
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) infrastructure as code and
+[Service Catalog](https://aws.amazon.com/servicecatalog/) to simplify configuration for end
+users while maintaining security standards.
+- **Create private, isolated, network
+environments**. Use
+[Amazon Virtual Private Cloud](https://aws.amazon.com/vpc/) (Amazon VPC) to limit
+connectivity to only essential services and users. Deploy
+Amazon SageMaker AI resources in a VPC to enable network-level
+controls and capture network activity in
+[VPC
+Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html). For distributed training workloads, use
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html) which provides managed, resilient
+clusters with built-in VPC integration and multi-AZ
+deployment for enhanced security and availability. This
+deployment model also enables secure queries to data sources
+within your VPC, such as
+[Amazon RDS](https://aws.amazon.com/rds/) databases or
+[Amazon Redshift](https://aws.amazon.com/redshift/) data warehouses. Use IAM to restrict access
+to ML environment web UIs so they can only be accessed from
+within your VPC. Implement
+[AWS PrivateLink](https://docs.aws.amazon.com/whitepapers/latest/aws-vpc-connectivity-options/aws-privatelink.html) to privately connect your SageMaker AI
+resources with supported AWS services, facilitating secure
+communication within the AWS network. Use
+[AWS KMS](https://aws.amazon.com/kms/) to encrypt data on the
+[Amazon EBS](https://aws.amazon.com/ebs/) volumes attached to SageMaker AI resources.
+- **Restrict access**. ML
+development environments provide web-based access to the
+underlying compute resources, typically with elevated
+privileges. Restrict this access to remove the ability to
+assume root permissions while still allowing users to
+control their local environment. Implement least privilege
+access controls for ML resources.
+- **Secure ML algorithms**.
+Amazon SageMaker AI uses container technology to train and host
+algorithms and models. When creating custom containers,
+publish them to a private container registry hosted on
+[Amazon
+Elastic Container Repository (Amazon ECR)](https://aws.amazon.com/ecr/). Encrypt
+containers hosted on Amazon ECR at rest using AWS KMS.
+Regularly scan containers for vulnerabilities and implement
+a secure container update process.
+- **Enforce code best
+practices**. Use secure git repositories for
+storing code. Implement code reviews, automated security
+scanning, and version control for ML code. Integrate
+security checks into your ML CI/CD pipeline to detect
+potential security issues early in the development process.
+- **Implement a package mirror for
+consuming approved packages**. Evaluate license
+terms to determine appropriate ML packages for your business
+across the ML lifecycle phases. Common ML Python packages
+include Pandas, PyTorch, Keras, NumPy, and Scikit-learn.
+Build an automated validation mechanism to check packages
+for security issues. Only download packages from approved
+and private repos. Validate package contents before
+importing. SageMaker AI supports
+[modifying
+package channel paths to a private repository](https://aws.amazon.com/blogs/machine-learning/private-package-installation-in-amazon-sagemaker-running-in-internet-free-mode/). When
+appropriate, use an internal repository as a proxy for
+public repositories to minimize network traffic and reduce
+overhead.
+- **Implement model security
+monitoring**. Deploy continuous monitoring
+solutions to detect unauthorized access attempts, unusual
+data access patterns, and potential data exfiltration from
+your ML environments. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/),
+[AWS Security Hub CSPM](https://aws.amazon.com/security-hub/), and
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) to create a comprehensive security
+monitoring solution for ML resources.
+- **Implement additional security
+controls for AI workloads**. For AI workloads,
+implement additional security controls around input
+validation and data leakage prevention. Implement
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to detect drift in production
+AI systems. Consider using
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model security
+characteristics and limitations.
+
+## Resources
+
+**Related documents:**
+
+- [Prerequisites
+for using SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html)
+- [Storage
+Best Practices for Data and Analytics Applications](https://docs.aws.amazon.com/whitepapers/latest/building-data-lakes/building-data-lake-aws.html)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Protecting
+compute](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-compute.html)
+- [Protecting
+data in transit](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-data-in-transit.html)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Building
+secure machine learning environments with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/building-secure-machine-learning-environments-with-amazon-sagemaker/)
+- [Setting
+up secure, well-governed machine learning environments on
+AWS](https://aws.amazon.com/blogs/mt/setting-up-machine-learning-environments-aws/)
+- [Private
+package installation in Amazon SageMaker AI running internet-free
+mode](https://aws.amazon.com/blogs/machine-learning/private-package-installation-in-amazon-sagemaker-running-in-internet-free-mode/)
+- [Secure
+Deployment of Amazon SageMaker AI resources](https://aws.amazon.com/blogs/security/secure-deployment-of-amazon-sagemaker-resources/)
+- [Apply
+fine-grained data access controls with AWS Lake Formation and
+Amazon EMR from Amazon SageMaker AI Studio](https://aws.amazon.com/blogs/machine-learning/apply-fine-grained-data-access-controls-with-aws-lake-formation-and-amazon-emr-from-amazon-sagemaker-studio/)
+
+**Related videos:**
+
+- [Security
+for AI/ML Models in AWS](https://www.youtube.com/watch?v=toDQL_c8Zug)
+- [Security
+best practices the AWS Well-Architected way](https://www.youtube.com/watch?v=wfIVI-M7lbQ)
+
+**Related examples:**
+
+- [Secure
+Data Science Reference Architecture](https://github.com/aws-samples/secure-data-science-reference-architecture)
+- [Amazon SageMaker AI Secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp02.html*
+
+---
+
+# MLSEC03-BP03 Protect sensitive data privacy
+
+Protect sensitive data used in training against unintended
+disclosure by implementing appropriate identification,
+classification, and handling strategies. This practice improves data
+privacy while maintaining model utility through techniques such as
+data removal, masking, tokenization, and principal component
+analysis (PCA).
+
+**Desired outcome:** You establish
+effective protocols to identify, classify, and protect sensitive
+data throughout your machine learning workflows. Your sensitive data
+is appropriately secured with encryption, access controls, and data
+minimization techniques. Your organization maintains clear
+documentation of governance practices for consistent application
+across projects.
+
+**Common anti-patterns:**
+
+- Failing to identify sensitive data before using it for model
+training.
+- Using raw PII or other sensitive data when anonymized data would
+suffice.
+- Not implementing proper encryption for sensitive training data.
+- Assuming cloud services automatically protect sensitive data
+without proper configuration.
+- Neglecting to document data handling processes for future
+reference.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of data breaches and privacy violations.
+- Improves adherence to data protection regulations.
+- Increased trust from customers and stakeholders.
+- Improved ability to use sensitive data for legitimate machine
+learning purposes.
+- Better governance through documented protocols.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Protecting sensitive data privacy in machine learning workflows
+requires a systematic approach that begins with data
+identification and classification. You need to understand what
+data you have and its sensitivity levels before determining
+appropriate protection mechanisms. Different types of sensitive
+data may require different handling strategies—some might need
+complete removal, while others can be effectively masked or
+tokenized.
+
+When working with sensitive data in ML workflows, you should adopt
+a defense-in-depth approach. This means implementing multiple
+layers of protection, including access controls, encryption, data
+minimization techniques, and monitoring systems. For example, you
+might use [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to encrypt your training data,
+implement role-based access controls, and use
+[Amazon Macie](https://aws.amazon.com/macie/) to continuously monitor for sensitive data exposure.
+
+Privacy-preserving machine learning techniques are increasingly
+important as models become more sophisticated. Techniques like
+differential privacy, federated learning, and secure multi-party
+computation can allow you to train effective models while
+minimizing exposure of sensitive data. These approaches maintain
+privacy while still extracting valuable insights from your data.
+
+### Implementation steps
+
+- **Implement automated data discovery
+and classification**. Use automated sensitive data
+discovery in
+[Amazon Macie](https://aws.amazon.com/macie/) to gain continuous, cost-efficient,
+organization-wide visibility into where sensitive data
+resides across your Amazon S3 environment. Macie
+automatically inspects your S3 buckets for sensitive data
+such as personally identifiable information (PII), financial
+data, and AWS credentials, then builds and maintains an
+interactive data map of sensitive data locations and
+provides sensitivity scores for each bucket.
+- **Apply resource tagging for sensitive
+data tracking**. Tag resources and models that
+contain or are derived from sensitive elements to quickly
+differentiate between resources requiring protection and
+those that do not. Use
+[AWS resource tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) to systematically identify and
+manage resources containing sensitive data throughout their
+lifecycle.
+- **Implement comprehensive encryption
+strategies**. Encrypt sensitive data using services
+such as [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/), the
+[AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/getting-started.html), or client-side encryption. Apply
+encryption consistently across data at rest and in transit,
+with appropriate key management practices.
+- **Implement data minimization
+techniques**. Evaluate and identify data for
+anonymization or de-identification to reduce sensitivity.
+Use techniques such as masking, tokenization, or principal
+component analysis to reduce the risk associated with using
+sensitive data for training. Consider using
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) with appropriate
+transformation techniques to create privacy-preserving
+feature representations.
+- **Establish governance documentation
+and processes**. Create comprehensive documentation
+of your sensitive data handling practices, including
+classification schemes, protection mechanisms, access
+control policies, and incident response procedures.
+Regularly review and update these documents to reflect
+changes in regulations, technologies, and organizational
+practices.
+- **Implement differential privacy
+techniques**. Apply differential privacy methods to
+add controlled noise to your data or models to block the
+extraction of individual data points while maintaining
+overall statistical validity.
+[AWS Clean Rooms](https://aws.amazon.com/clean-rooms/) assist organizations with collaborating
+on sensitive data while maintaining privacy and adherence to
+regulations.
+- **Perform regular privacy impact
+assessments**. Conduct systematic evaluations of
+how your ML workflows collect, use, and protect sensitive
+data. Use the results to identify areas for improvement in
+your privacy protection mechanisms and adhere to relevant
+regulations.
+- **Implement safeguards for large
+language models**. When using large language
+models, implement safeguards to block memorization and
+exposure of sensitive training data. Use
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) with appropriate
+privacy-preserving configurations and implement proper data
+filtering and anonymization techniques during model training
+and fine-tuning.
+
+## Resources
+
+**Related documents:**
+
+- [Running
+sensitive data discovery jobs in Amazon Macie](https://docs.aws.amazon.com/macie/latest/user/discovery-jobs.html)
+- [Categorizing
+your storage using tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html)
+- [AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html)
+- [Using
+the AWS Encryption SDK with AWS KMS](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/getting-started.html)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Use
+Macie to discover sensitive data as part of automated data
+pipelines](https://aws.amazon.com/blogs/security/use-macie-to-discover-sensitive-data-as-part-of-automated-data-pipelines/)
+- [Building
+a Serverless Tokenization Solution to Mask Sensitive
+Data](https://aws.amazon.com/blogs/compute/building-a-serverless-tokenization-solution-to-mask-sensitive-data/)
+
+**Related videos:**
+
+- [Security
+for AI/ML Models in AWS](https://www.youtube.com/watch?v=toDQL_c8Zug)
+- [Security
+best practices the AWS Well-Architected way](https://www.youtube.com/watch?v=wfIVI-M7lbQ)
+
+**Related examples:**
+
+- [Secure
+Data Science Reference Architecture](https://github.com/aws-samples/secure-data-science-reference-architecture)
+- [Amazon SageMaker AI Secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp03.html*
+
+---
+
+# MLSEC03-BP04 Enforce data lineage
+
+Data lineage tracking allows you to monitor and track data origins
+and transformations over time, enabling better visibility into your
+machine learning workflows. By enforcing data lineage, you can trace
+the root cause of data processing errors and and protect the
+integrity of your ML models.
+
+**Desired outcome:** You can trace a
+data element back to its source, verify the transformations it
+underwent, and verify data integrity throughout the ML lifecycle.
+You have visibility into your entire ML workflow from data
+preparation to model deployment, enabling you to reproduce
+workflows, establish model governance standards, and demonstrate
+audit adherence.
+
+**Common anti-patterns:**
+
+- Treating data lineage as an afterthought rather than a core
+requirement.
+- Failing to maintain records of data transformations during
+preprocessing.
+- Not implementing integrity checks for detecting data
+manipulation or corruption.
+- Neglecting to document code and infrastructure changes that
+affect the ML pipeline.
+- Relying on manual tracking methods that are prone to errors and
+inconsistencies.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved troubleshooting through the ability to trace issues
+back to their source.
+- Improves adherence to regulatory requirements through
+comprehensive audit trails.
+- Greater confidence in model outputs by understanding the
+provenance of training data.
+- Faster iteration cycles by being able to reproduce workflows
+efficiently.
+- Better governance and risk management across ML operations.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data lineage is a critical component of responsible ML operations.
+By tracking the journey of your data from its source through
+various transformations to model deployment, you create
+accountability and transparency in your ML systems. Enforcing data
+lineage involves implementing mechanisms to record metadata about
+data origins, transformations, and access controls throughout the
+ML lifecycle.
+
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides built-in capabilities to track and
+maintain data lineage through its MLflow tracking capabilities.
+This system allows you to record the relationships between various
+ML artifacts such as datasets, algorithms, hyperparameters, and
+model artifacts. By utilizing these tracking capabilities, you can
+establish a clear audit trail that assists with reproducibility,
+governance, and troubleshooting.
+
+Proper data lineage implementation also requires strict access
+controls to block unauthorized data manipulation. Your tracking
+system should record who accessed the data, what changes were
+made, and when those changes occurred. Additionally, implement
+integrity checks against your training data to detect unexpected
+deviations caused by data corruption or malicious manipulation.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI MLflow
+Tracking**. Enable tracking capabilities in your
+SageMaker AI environment to automatically capture metadata
+about your ML workflows. Configure SageMaker AI to track
+artifacts, associations, and context information using
+[Amazon SageMaker AI MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html). MLflow in SageMaker AI allows you to
+create, manage, analyze, and compare experiments, providing
+comprehensive tracking of training runs, model versions, and
+associated metadata.
+- **Implement automated metadata
+collection**. Configure your ML pipelines to
+automatically record metadata at each stage of processing.
+Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) jobs to track data transformations and
+record preprocessing steps. Apply
+[SageMaker AI
+Pipeline](https://aws.amazon.com/sagemaker/pipelines/) steps to document the flow of data from one
+stage to another, creating a complete record of the data
+journey.
+- **Establish data access
+controls**. Implement strict access controls to
+protect data integrity. Use
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) roles and policies to
+restrict access to specific datasets and models. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect unauthorized access
+or changes to your data.
+- **Create integrity verification
+mechanisms**. Implement data validation steps in
+your pipeline to detect anomalies or unexpected changes. Use
+checksums, statistical analysis, or machine learning-based
+anomaly detection to identify potential data corruption.
+Store integrity verification results as part of your lineage
+tracking records.
+- **Document code and infrastructure
+changes**. Track changes to your code repositories
+and infrastructure configurations that affect the ML
+workflow. Use version control systems like Git integrated
+with
+[AWS CodeCommit](https://aws.amazon.com/codecommit/) to maintain a history of code changes, and
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to version your infrastructure as code.
+- **Implement end-to-end
+traceability**. Verify that your lineage tracking
+system can trace model predictions back to the original data
+sources used for training. Use
+[SageMaker AI
+MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to catalog your models and
+associate them with their training data lineage. This
+enables you to understand exactly which data influenced
+specific model behaviors.
+- **Establish audit and
+compliance-aligned reporting**. Create automated
+reports that demonstrate data lineage for compliance-aligned
+purposes. Use
+[Quick](https://aws.amazon.com/quicksight/) to visualize data lineage graphs and
+[Amazon Athena](https://aws.amazon.com/athena/) to query lineage metadata for audit reports.
+Regularly review these reports to improve your adherence to
+your governance requirements.
+- **Implement foundation model
+tracking**. For foundation model workflows, track
+not only the data but also the foundation models used, their
+versions, and fine-tuning parameters. Use
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model
+characteristics and
+[Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) to monitor model
+performance. Implement comprehensive traceability features
+to document model provenance and usage.
+- **Track model input
+variations**. Maintain a record of input variations
+used with models, as these influence model outputs. Use
+[Amazon SageMaker AI MLflow tracking server](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html) with enhanced MLflow
+3.0 capabilities to track different input variations and
+their effectiveness, treating inputs as critical components
+of your data lineage system. The managed MLflow service
+provides robust experiment management at scale for ML
+projects with comprehensive tracking of training runs, model
+versions, and associated metadata.
+
+## Resources
+
+**Related documents:**
+
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [SageMaker AI
+MLflow Tracking Server](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html)
+- [Accelerating
+generative AI development with fully managed MLflow 3.0 on
+Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+
+**Related videos:**
+
+- [How
+To Efficiently Manage ML experiments using Amazon SageMaker AI ML
+Flow](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp04.html*
+
+---
+
+# MLSEC03-BP05 Keep only relevant data
+
+Reduce data exposure risks by preserving only use-case relevant data
+across computing environments. Implementing data lifecycle
+management and privacy-preserving techniques maintains data security
+while enabling effective machine learning workflows.
+
+**Desired outcome:** You maintain a
+streamlined dataset across development, staging, and production
+environments that contains only the data elements needed for your
+machine learning use cases. You have implemented automated data
+lifecycle management processes that properly identify data, redact
+it when necessary, and remove it when no longer needed. This
+approach reduces your security risk exposure while maintaining data
+usability for ML operations.
+
+**Common anti-patterns:**
+
+- Keeping collected data indefinitely in case it might be useful
+later.
+- Failing to implement data redaction for personally identifiable
+information (PII) in ML datasets.
+- Using production data with sensitive information in development
+environments.
+- Not establishing clear timelines for data retention and removal.
+- Ignoring privacy regulations when designing ML workflows.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of data breaches and privacy violations.
+- Lower storage and computational costs from processing only
+necessary data.
+- Improved adherence to data privacy regulations.
+- Enhanced ML model performance through focus on relevant
+features.
+- Streamlined data management processes across environments.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Managing data exposure is crucial for machine learning security.
+The more data you collect and store, the greater your attack
+surface and potential for data breaches. By focusing on data
+minimization principles, you can reduce these risks while still
+achieving your ML objectives.
+
+Your data lifecycle management strategy should begin with a
+thorough assessment of what data is truly needed for your ML use
+cases. This requires close collaboration between data scientists,
+security professionals, and business stakeholders to identify
+essential features and acceptable levels of data granularity. Once
+identified, implement mechanisms to maintain only the necessary
+data elements across environments.
+
+When working with potentially sensitive information, apply
+privacy-preserving techniques like anonymization,
+pseudonymization, or redaction of PII. AWS services like
+[Amazon Comprehend](https://aws.amazon.com/comprehend/) and
+[Amazon Macie](https://aws.amazon.com/macie/) can identify sensitive data automatically, while
+[Amazon Transcribe](https://aws.amazon.com/transcribe/) offers automatic redaction capabilities. For
+more advanced scenarios, consider techniques like differential
+privacy or federated learning that allow you to derive insights
+from sensitive data without exposing the raw information.
+
+Regular data audits and automated cleanup processes are essential
+components of an effective data lifecycle management strategy. By
+implementing automated policies for data retention and deletion,
+you can verify that data doesn't linger unnecessarily in your
+systems after its useful life has ended.
+
+### Implementation steps
+
+- **Assess data requirements**.
+Begin by thoroughly analyzing your ML use case to determine
+exactly which data elements are required for model training,
+validation, and inference. Document the minimum data
+requirements for each stage of your ML pipeline and justify
+the need for each attribute. Consider using techniques like
+feature importance analysis to identify which data elements
+contribute most to model performance.
+- **Develop a comprehensive data
+lifecycle plan**. Create a documented plan that
+defines how data will flow through your ML pipeline,
+including data collection, processing, storage, usage, and
+eventual deletion. Identify usage patterns and requirements
+for debugging and operational tasks. Specify retention
+periods based on business needs, regulatory requirements,
+and the purpose of the data.
+- **Implement data minimization
+techniques**. Design your data collection and
+preprocessing pipelines to capture only the necessary data
+attributes identified in your assessment. Use
+[AWS Glue](https://aws.amazon.com/glue/) or similar ETL services to filter out
+unnecessary fields before storage. Consider implementing
+record-level filtering in addition to column-level
+filtering.
+- **Set up automated PII detection and
+redaction**. Deploy solutions to automatically
+identify and redact sensitive information. Use
+[Amazon Comprehend](https://aws.amazon.com/comprehend/) for detecting PII in text data and
+[Amazon Rekognition](https://aws.amazon.com/rekognition/) for identifying sensitive elements in
+images. Implement
+[Amazon Transcribe's automatic redaction feature](https://aws.amazon.com/blogs/aws/now-available-in-amazon-transcribe-automatic-redaction-of-personally-identifiable-information/) for audio
+transcriptions.
+- **Establish data governance
+controls**. Implement access controls and
+encryption mechanisms using
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) and
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/). Use
+[Amazon Macie](https://aws.amazon.com/macie/) to automatically discover, classify, and
+protect sensitive data in AWS. Apply data classification
+tags to facilitate appropriate handling of different data
+types.
+- **Configure automated data lifecycle
+policies**. Set up
+[S3
+Lifecycle configurations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) to automatically transition
+or expire data based on your retention policies. Implement
+similar mechanisms for other storage systems used in your ML
+pipeline. Create automated jobs to periodically review and
+remove stale data from environments.
+- **Implement privacy-preserving ML
+techniques**. Where possible, use privacy-enhancing
+technologies like differential privacy, federated learning,
+or encrypted computation. Consider using
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) to centrally define and enforce
+fine-grained access controls. For sensitive use cases,
+explore options for machine learning on encrypted data.
+- **Monitor and audit data
+usage**. Set up logging and monitoring using
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) and
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track data access patterns.
+Periodically audit data usage against documented
+requirements to identify and avoid unnecessary data
+collection. Use
+[Amazon Athena with user-defined functions](https://aws.amazon.com/blogs/big-data/redacting-sensitive-information-with-user-defined-functions-in-amazon-athena/) for analyzing and
+redacting sensitive information in logs and audit trails.
+- **Implement responsible data practices
+for AI models**. When using AI models, be
+especially careful with training data to block memorization
+of sensitive information. Utilize
+[Amazon SageMaker AI's feature store](https://aws.amazon.com/sagemaker/feature-store/) for centralized feature
+management with built-in security controls. Consider data
+poisoning risks and implement appropriate data validation
+before model training.
+
+## Resources
+
+**Related documents:**
+
+- [Reference
+Guide: Extract More Value from your Data](https://pages.awscloud.com/data-lifecycle-reference-guide.html?sc_channel=bl&sc_campaign=datalifecycleandanalyticsintheawscloud&sc_geo=mult&sc_country=global&sc_outcome=multi)
+- [Data
+Privacy Center](https://aws.amazon.com/compliance/data-privacy/)
+- [Building
+a data analytics practice across the data lifecycle](https://aws.amazon.com/blogs/publicsector/building-a-data-analytics-practice-across-the-data-lifecycle/)
+- [Detecting
+and redacting PII using Amazon Comprehend](https://aws.amazon.com/blogs/machine-learning/detecting-and-redacting-pii-using-amazon-comprehend/)
+- [Now
+available in Amazon Transcribe: Automatic Redaction of
+Personally Identifiable Information](https://aws.amazon.com/blogs/aws/now-available-in-amazon-transcribe-automatic-redaction-of-personally-identifiable-information/)
+- [Redacting
+sensitive information with user-defined functions in Amazon Athena](https://aws.amazon.com/blogs/big-data/redacting-sensitive-information-with-user-defined-functions-in-amazon-athena/)
+
+**Related videos:**
+
+- [Privacy-preserving
+machine learning](https://www.youtube.com/watch?v=ZQkB9XRqdnc)
+- [Best
+practices for Amazon S3](https://youtu.be/HT3QiuzgjZg?t=524)
+
+**Related examples:**
+
+- [Field
+Notes: Redacting Personal Data from Connected Cars Using
+Amazon Rekognition](https://aws.amazon.com/blogs/architecture/field-notes-redacting-personal-data-from-connected-cars-using-amazon-rekognition/)
+- [How
+to Create a Modern CPG Data Architecture with Data Mesh](https://aws.amazon.com/blogs/industries/how-to-create-a-modern-cpg-data-architecture-with-data-mesh/)
+- [Building
+a secure enterprise machine learning platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp05.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSEC04.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSEC04.md
@@ -1,0 +1,581 @@
+# MLSEC04
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLSEC04-BP01 Secure governed ML environment
+
+Creating a secure and governed ML environment allows you to protect
+valuable data and models while enabling teams to innovate
+efficiently. By implementing proper guardrails, monitoring, and
+security practices, you maintain control while providing the
+flexibility ML practitioners need to deliver business value.
+
+**Desired outcome:** You establish a
+secure ML operational environment using AWS managed services that
+incorporates best practices for security, governance, and
+monitoring. You create development environments that allow data
+scientists to explore data safely while maintaining organizational
+security standards. Your ML environments are centrally managed with
+proper access controls, yet offer self-service capabilities to
+improve productivity. This balance between security and flexibility
+enables your organization to innovate while protecting sensitive
+assets.
+
+**Common anti-patterns:**
+
+- Using a single shared account for ML workloads regardless of
+sensitivity or access requirements.
+- Allowing unrestricted access to ML infrastructure and production
+environments.
+- Implementing manual provisioning processes that create
+bottlenecks for data scientists.
+- Neglecting to isolate environments containing sensitive data.
+- Failing to implement continuous monitoring and detection
+controls for ML operations.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced security risks through proper isolation and access
+controls.
+- Improved governance with enforced security guardrails.
+- Enhanced productivity through self-service capabilities.
+- Improves adherence to regulatory requirements.
+- Simplified management of ML environments.
+- Faster time-to-market for ML initiatives.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Securing your ML environment requires thoughtful architecture that
+balances security with productivity. You need to consider how
+different teams interact with ML resources and implement controls
+appropriate to their roles and the sensitivity of data being
+processed. AWS provides managed services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) that can be configured with security best
+practices in mind.
+
+Begin by understanding your organization's access patterns and
+data sensitivity levels. This knowledge assists you when
+determining how to structure your AWS accounts and implementing
+appropriate security controls. For example, you might separate
+development, testing, and production environments across different
+accounts with increasing security restrictions. This multi-account
+strategy allows you to implement tailored security controls for
+each environment while maintaining proper isolation.
+
+Once you've established your account structure, implement
+preventive guardrails using
+[AWS Organizations](https://aws.amazon.com/organizations/) and service control policies (SCPs) to
+enforce security boundaries. Detective controls using services
+like [AWS Config](https://aws.amazon.com/config/) and
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) provide continuous monitoring to identify
+potential security issues. By combining preventive and detective
+controls, you create defense-in-depth protection for your ML
+environments.
+
+For environments handling sensitive data, implement additional
+security measures like network isolation, encryption, and
+fine-grained access controls. Amazon SageMaker AI can be deployed
+within a VPC to limit network access, while
+[AWS KMS](https://aws.amazon.com/kms/)
+provides robust encryption capabilities for data at rest and in
+transit. These measures protect sensitive information throughout
+the ML lifecycle.
+
+### Implementation steps
+
+- **Break out ML workloads by
+organizational unit access patterns**. Create a
+multi-account strategy that aligns with your organization's
+structure and security requirements. For example, create
+separate accounts for data science development, model
+training, and production model deployment. This separation
+allows you to implement role-based access control (RBAC)
+with appropriate permissions for each team. Use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to quickly define
+persona-based IAM roles for different user types (data
+scientists, MLOps engineers, business analysts) with
+preconfigured templates that provide least privilege access.
+Use
+[AWS Organizations](https://aws.amazon.com/organizations/) to manage your multi-account
+environment efficiently.
+- **Use guardrails and service control
+policies (SCPs) to enforce best practices**.
+Implement SCPs through
+[AWS Organizations](https://aws.amazon.com/organizations/) to establish preventive guardrails that
+restrict actions across accounts. For example, create
+policies that block the disabling of security services,
+limit the AWS regions that can be used, or restrict the
+creation of public resources. Complement SCPs with
+[AWS Config](https://aws.amazon.com/config/) rules to detect non-compatible resources and
+automatically remediate issues. Limit infrastructure
+management access to administrators while allowing data
+scientists to focus on model development.
+- **Verify that sensitive data has
+access through restricted, isolated environments**.
+Implement
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) within a private VPC to control network
+traffic to and from your ML environment. Configure security
+groups and network ACLs to restrict access to authorized
+sources. Use
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) to access AWS services without traversing
+the public internet. Enable encryption for sensitive data
+using [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) for both data at rest and in
+transit. Review service dependencies to verify that they
+meet your security requirements.
+- **Secure ML algorithm implementation
+using a restricted development environment**.
+Deploy
+[Amazon SageMaker AI Studio](https://aws.amazon.com/sagemaker/studio/) with appropriate security controls
+to provide data scientists with a secure development
+environment. Implement
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) roles with least
+privilege permissions for each development environment. Use
+[Amazon SageMaker AI Domain](https://docs.aws.amazon.com/sagemaker/latest/dg/gs-studio-onboard.html) configurations to manage user access
+to resources. Scan container images for vulnerabilities
+before deploying them for model training or hosting using
+[Amazon ECR image scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html).
+- **Implement centralized management and
+monitoring**. Use
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to track API activity across your ML
+environments. Deploy
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) for operational monitoring of your ML
+resources. Implement
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) to detect suspicious activity. Centralize
+logs in a dedicated security account for comprehensive
+visibility across your ML environments. Create automated
+alerts for security-related events that require
+investigation.
+- **Enable self-service provisioning
+with guardrails**. Implement
+[Service Catalog](https://aws.amazon.com/servicecatalog/) to provide pre-approved, secure
+templates for ML resources like SageMaker AI environments.
+Configure lifecycle policies to automatically shut down idle
+resources and reduce costs. Use
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to define infrastructure as code with security
+best practices built in. This allows data scientists to
+provision resources quickly while maintaining adherence to
+organizational standards.
+- **Secure model artifacts and ML
+pipelines**. Implement version control for models
+and code using
+[Amazon SageMaker AI MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html). Configure
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) with appropriate access controls
+to automate the ML lifecycle. Use
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) and
+[AWS CodeBuild](https://aws.amazon.com/codebuild/) to implement CI/CD for ML applications with
+security checks built into the deployment process.
+- **Implement foundation model security
+controls**. When using large language models (LLMs)
+or other foundation models, implement guardrails to block
+the generation of harmful content. Implement content
+filtering to verify responsible AI usage. For enterprise
+governance of foundation models, implement
+[SageMaker AI
+JumpStart Private Model Hub](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html) to create curated
+repositories of approved models with centralized access
+controls and version management. Use
+[SageMaker AI
+Catalog](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects-templates-custom.html) as a central metadata hub for secure sharing
+and governed access to ML assets across business units.
+Implement
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model limitations,
+ethical considerations, and intended uses. Monitor model
+outputs for drift and bias using
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html).
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Private
+curated hubs for foundation model access control in
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html)
+- [Admin
+guide for private model hubs in Amazon SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs-admin-guide.html)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Build
+a secure enterprise machine learning platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.html)
+- [Security
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Model
+governance to manage permissions and track model
+performance](https://docs.aws.amazon.com/sagemaker/latest/dg/governance.html)
+- [Setting
+up secure, well-governed machine learning environments on
+AWS](https://aws.amazon.com/blogs/mt/setting-up-machine-learning-environments-aws)
+- [Securing
+Amazon SageMaker AI Studio connectivity using a private
+VPC](https://aws.amazon.com/blogs/machine-learning/securing-amazon-sagemaker-studio-connectivity-using-a-private-vpc/)
+- [Enable
+self-service, secured data science using Amazon SageMaker AI and
+Service Catalog](https://aws.amazon.com/blogs/mt/enable-self-service-secured-data-science-using-amazon-sagemaker-notebooks-and-aws-service-catalog/)
+- [Accelerating
+Machine Learning Development with Data Science as a Service
+from Change Healthcare](https://aws.amazon.com/blogs/apn/accelerating-machine-learning-development-with-data-science-as-a-service-from-change-healthcare/)
+
+**Related videos:**
+
+- [Architectural
+best practices for machine learning applications](https://www.youtube.com/watch?v=fBytsYBVgbo)
+- [Secure
+and compliant machine learning for regulated industries](https://www.youtube.com/watch?v=8p-B3sTLmFg)
+- [Amazon SageMaker AI Model Development in a Highly Regulated
+Environment (SDD315)](https://youtu.be/cSYFqKRQ0j0?t=1051)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec04-bp01.html*
+
+---
+
+# MLSEC04-BP02 Secure inter-node cluster communications
+
+Machine learning frameworks require secure communications between
+computational nodes to maintain data integrity and protect sensitive
+information during model training. By implementing encryption for
+inter-node communications, you safeguard coefficient exchanges and
+protect synchronized information across distributed environments.
+
+**Desired outcome:** You establish
+encrypted communication channels between computational nodes in your
+machine learning clusters, protecting sensitive model data,
+parameters, and training information as it traverses networks. This
+improves data integrity and confidentiality during distributed
+training operations while maintaining the performance requirements
+of your machine learning workloads.
+
+**Common anti-patterns:**
+
+- Assuming internal network communications are inherently secure
+and don't require encryption.
+- Implementing encryption only for external communications but
+neglecting inter-node traffic.
+- Using outdated or weak encryption protocols for performance
+reasons.
+- Neglecting to rotate encryption certificates and credentials
+regularly.
+
+**Benefits of establishing this best
+practice:**
+
+- Protection of proprietary algorithms and model parameters during
+training.
+- Prevention of data leakage and unauthorized access to training
+data.
+- Improves adherence to data protection regulations and security
+requirements.
+- Consistent security posture across your ML infrastructure.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+For machine learning frameworks like TensorFlow that rely on
+distributed computing, secure inter-node communication is
+essential to protect the integrity and confidentiality of the
+training process. During distributed training, nodes exchange
+critical information like model coefficients, gradients, and
+parameter updates. This information contains valuable intellectual
+property about your models and potentially sensitive insights
+derived from your training data.
+
+When implementing distributed machine learning workloads, encrypt
+that data transmitted between computational nodes using
+industry-standard protocols. This is particularly important when
+your infrastructure spans across different networks, availability
+zones, or even Regions. Encryption in transit stops unauthorized
+parties from intercepting or tampering with model data as it moves
+between nodes.
+
+AWS services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) and
+[Amazon EMR](https://aws.amazon.com/emr/)
+provide built-in capabilities to secure inter-node communications,
+making it more straightforward to implement this best practice
+without extensive custom configuration.
+
+### Implementation steps
+
+- **Enable inter-node encryption in
+Amazon SageMaker AI**. Amazon SageMaker AI provides
+automatic encryption for inter-container communication
+during training jobs. When configuring your training job,
+enable encryption to verify that data passed between
+containers traverses over an encrypted tunnel. For
+large-scale distributed training, use
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html) which provides managed, resilient
+clusters with built-in security features including VPC
+integration, automatic health checks, and secure
+node-to-node communication for foundation model training.
+This protects your model parameters and gradients during the
+training process without requiring additional configuration.
+- **Configure TLS for distributed
+TensorFlow workloads**. For TensorFlow-based
+distributed training, implement Transport Layer Security
+(TLS) to secure communications between worker nodes.
+TensorFlow supports TLS configuration through environment
+variables and configuration parameters. Use properly signed
+certificates and configure both client and server-side
+authentication for maximum security.
+- **Enable encryption in transit in
+Amazon EMR**. When using
+[Amazon EMR](https://aws.amazon.com/emr/) for machine learning workloads, implement
+security configurations that enable encryption in transit.
+Amazon EMR makes it simple to create security configurations
+that specify the use of Transport Layer Security (TLS)
+certificates for encrypting data in transit between cluster
+nodes. This protects data whether it's stored locally on the
+cluster or in Amazon S3.
+- **Implement secure key
+management**. Use
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to manage the encryption
+keys used for securing inter-node communications. This
+provides centralized control, auditing, and automatic key
+rotation, enhancing your security posture while simplifying
+key management operations.
+- **Configure secure cluster
+authentication**. Implement strong authentication
+mechanisms to verify that only authorized nodes can join
+your cluster and participate in the distributed training
+process. Use certificate-based authentication where possible
+and implement node identity verification as part of your
+security configuration.
+- **Regularly rotate security
+credentials**. Establish a process for regularly
+rotating TLS certificates, encryption keys, and other
+security credentials used in your distributed training
+environment. This limits the potential impact of compromised
+credentials and aligns with security best practices.
+- **Monitor encrypted
+communications**. Implement logging and monitoring
+for your encrypted communications channels to detect
+potential security issues. Configure alerts for unusual
+traffic patterns or authentication failures that might
+indicate attempted security breaches.
+- **Secure foundation model
+communication**. When using distributed training
+for large language models or other foundation models,
+encrypt parameter server communications, as these contain
+valuable intellectual property. For AI workloads on Amazon SageMaker AI, enable inter-container encryption to protect
+model weights and gradients during the training process.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI HyperPod Prerequisites](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html)
+- [Protect
+Communications Between ML Compute Instances in a Distributed
+Training Job](https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html)
+- [Encryption
+options for Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-data-encryption-options.html)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Security
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Encrypt
+data in transit using a TLS custom certificate provider with
+Amazon EMR](https://aws.amazon.com/blogs/big-data/encrypt-data-in-transit-using-a-tls-custom-certificate-provider-with-amazon-emr/)
+- [Building
+secure machine learning environments with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/building-secure-machine-learning-environments-with-amazon-sagemaker/)
+- [Amazon SageMaker AI Studio Admin Best Practices](https://docs.aws.amazon.com/whitepapers/latest/sagemaker-studio-admin-best-practices/data-protection.html)
+
+**Related videos:**
+
+- [Architectural
+best practices for machine learning applications](https://www.youtube.com/watch?v=fBytsYBVgbo)
+- [Secure
+and compliant machine learning for regulated industries](https://www.youtube.com/watch?v=8p-B3sTLmFg)
+
+**Related examples:**
+
+- [Amazon SageMaker AI secure distributed training examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-python-sdk)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec04-bp02.html*
+
+---
+
+# MLSEC04-BP03 Protect against data poisoning threats
+
+Protect your machine learning models and data by implementing
+security measures against data poisoning attacks, which can
+compromise model performance and accuracy. Data poisoning occurs
+through data injection (adding corrupt training data) or data
+manipulation (changing existing data like labels), resulting in
+inaccurate and weakened predictive capabilities. By identifying and
+addressing corrupt data using security methods and anomaly detection
+algorithms, you can maintain data integrity and protect against
+threats including ransomware and malicious code in third-party
+packages.
+
+**Desired outcome:** You have
+implemented robust protection mechanisms for your machine learning
+training data and models. These protections include data validation
+procedures, monitoring for data drift, version control for both data
+and models, and rollback capabilities. Your ML systems can detect
+potential poisoning attempts and maintain model performance
+integrity through security best practices that protect data
+throughout its lifecycle.
+
+**Common anti-patterns:**
+
+- Collecting training data from untrusted or unverified sources
+without validation.
+- Neglecting to monitor data distributions for unexpected shifts.
+- Deploying updated models without thorough testing against
+baseline performance.
+- Failing to implement version control for both training data and
+models.
+- Not having a rollback strategy for compromised models.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model reliability and accuracy through clean, trusted
+data.
+- Early detection of potential security breaches targeting
+training data.
+- Reduced risk of deploying compromised models to production.
+- Ability to quickly recover from poisoning incidents through
+rollback mechanisms.
+- Enhanced overall ML system security and resilience.
+
+**Risk level for not implementing this
+practice:** High
+
+## Implementation guidance
+
+Data poisoning represents a security threat to machine learning
+systems. When malicious actors manipulate training data, they can
+compromise model integrity and cause downstream impacts on
+decisions or predictions made by those models. You need to
+implement comprehensive protections throughout your ML pipeline,
+from data collection to model deployment and monitoring.
+
+Start by establishing strict controls over data sources and
+implementing validation procedures to detect anomalies before
+training. During model development, implement monitoring for data
+drift that could indicate poisoning attempts. Before deployment,
+thoroughly compare new models against previous versions to
+identify unexpected behavior changes. Finally, maintain versioned
+copies of both training data and models to enable rapid recovery
+from compromise.
+
+By combining these defensive approaches, you create multiple
+layers of protection that make your ML systems resilient against
+data poisoning attempts.
+
+### Implementation steps
+
+- **Use only trusted data sources for
+training data**. Verify the provenance of data used
+for training and implement audit controls that allow you to
+track changes to training data. This includes recording who
+made changes, what changes were made, and when they
+occurred. Before using data for training, validate its
+quality to identify potential outliers and incorrectly
+labeled samples that could indicate poisoning attempts.
+- **Look for underlying shifts in the
+patterns and distributions in training data**.
+Implement continuous monitoring for data drift to detect
+unexpected changes in data distributions. Use tools like
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to track these changes
+automatically. Deviations from established patterns can
+serve as early warning signs of unauthorized access or
+manipulation targeting training data.
+- **Identify model updates that
+negatively impact the results before moving them to
+production**. Compare newly trained models against
+previous versions using consistent test datasets. Look for
+unexpected performance changes, especially degradations in
+specific areas that weren't present in earlier model
+iterations. Use
+[Amazon SageMaker AI MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to track model
+versions and their performance metrics.
+- **Have a rollback plan**.
+Implement versioning for both training data and models to
+enable quick recovery from compromised states. Use
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to maintain secure, versioned
+features for your ML models. The Feature Store provides a
+centralized repository for features with built-in security
+controls. Configure Amazon SageMaker AI MLflow Model Registry
+to support rollback capabilities so you can quickly revert
+to a known good model version if issues are detected with a
+newly deployed model.
+- **Use low-entropy classification
+cases**. Establish performance thresholds and
+monitor for unexpected classification patterns. Define
+boundaries for acceptable model behavior and create alerts
+when outputs deviate from expected patterns. This can
+identify subtle poisoning attempts that might otherwise go
+undetected through conventional testing.
+- **Implement end-to-end encryption for
+ML data**. Secure your training data, feature sets,
+and models using encryption both at rest and in transit. Use
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to manage encryption keys
+and apply them consistently across your ML pipeline.
+Encryption protects against unauthorized access that could
+lead to data poisoning.
+- **Regularly scan for vulnerabilities
+in ML dependencies**. Use tools like
+[Amazon Inspector](https://aws.amazon.com/inspector/) to detect vulnerabilities in the software
+packages and dependencies used in your ML environment. Data
+poisoning can occur through compromised third-party
+libraries, so regular scanning can identify potential entry
+points for bad actors.
+- **Implement input validation for AI
+systems**. For AI models, validate inputs for
+potential poisoning attempts. Implement filtering and
+sanitization of inputs to block adversarial inputs that
+could manipulate model behavior or extract sensitive
+information.
+
+## Resources
+
+**Related documents:**
+
+- [Bias
+drift for models in production](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-monitor-bias-drift.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Automated
+monitoring of your machine learning models with Amazon SageMaker AI Model Monitor and sending predictions to human
+review workflows using Amazon A2I](https://aws.amazon.com/blogs/machine-learning/automated-monitoring-of-your-machine-learning-models-with-amazon-sagemaker-model-monitor-and-sending-predictions-to-human-review-workflows-using-amazon-a2i/)
+- [Amazon SageMaker AI Model Monitor– Fully Managed Automatic Monitoring
+for Your Machine Learning Models](https://aws.amazon.com/blogs/aws/amazon-sagemaker-model-monitor-fully-managed-automatic-monitoring-for-your-machine-learning-models/)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Building
+secure machine learning environments with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/building-secure-machine-learning-environments-with-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+- [Inawisdom:
+Machine Learning and Automated Model Retraining with SageMaker AI](https://www.youtube.com/watch?v=1kbWvlHBYLk&t=7s)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Model Monitor Examples](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+- [Amazon SageMaker AI Feature Store Examples](https://github.com/aws-samples/amazon-sagemaker-feature-store-examples)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec04-bp03.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSEC05.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSEC05.md
@@ -1,0 +1,180 @@
+# MLSEC05
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSEC05-BP01 Protect against adversarial and malicious activities
+
+Machine learning systems must be robust against adversarial inputs
+designed to manipulate their behavior. Implementing protection
+mechanisms both inside and outside of your deployed models can
+detect malicious inputs that could lead to incorrect predictions,
+allowing you to automatically identify unauthorized changes, repair
+compromised inputs, and validate data before it's used for further
+training.
+
+**Desired outcome:** You can detect,
+mitigate, and protect your ML models from adversarial exploits that
+attempt to manipulate inputs, preserving model integrity and
+providing reliable predictions. Your ML systems incorporate robust
+validation processes, ensemble approaches, and monitoring
+capabilities that maintain consistent performance even when faced
+with deliberately perturbed or malicious inputs.
+
+**Common anti-patterns:**
+
+- Implementing ML models without considering potential adversarial
+threats.
+- Focusing solely on model performance metrics without evaluating
+robustness.
+- Using single model architectures that are vulnerable to targeted
+threats.
+- Retraining models with unvalidated inputs that may contain
+adversarial examples.
+- Exposing ML models through unsecured endpoints without
+monitoring capabilities.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model robustness against input manipulation attempts.
+- Enhanced detection of potential security threats targeting ML
+systems.
+- Greater reliability in model predictions even under adversarial
+conditions.
+- Protection against data poisoning during model retraining.
+- Reduced vulnerability to model extraction and inference threats.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Adversarial threats against machine learning models involve
+deliberately crafting inputs to cause incorrect predictions or
+undesirable behaviors. These threats can range from subtle
+perturbations that are imperceptible to humans but cause model
+errors, to more sophisticated techniques that exploit model
+vulnerabilities. Building protection against adversarial
+activities requires a multi-layered approach combining robust
+model design, comprehensive monitoring, and secure deployment
+strategies.
+
+When implementing defenses, you need to understand the specific
+vulnerabilities in your models and the potential impact of
+adversarial threats on your business outcomes. This requires
+conducting thorough evaluations of model behavior under different
+threats scenarios and implementing appropriate countermeasures
+based on your risk profile. Both pre-deployment testing and
+continuous monitoring during production are essential components
+of a comprehensive protection strategy.
+
+Adversarial robustness should be considered from the beginning of
+your ML development process rather than as an afterthought. By
+incorporating adversarial training, ensemble methods, and input
+validation techniques during model development, you can create
+systems that are inherently more resistant to threats.
+Additionally, implementing proper access controls, monitoring
+systems, and incident response procedures can establish a secure
+operational environment for your ML models.
+
+### Implementation steps
+
+- **Evaluate the robustness of your
+algorithm**. Conduct sensitivity analysis to
+understand how your model responds to perturbed inputs. Test
+your model with increasingly modified data points to
+identify decision boundaries that might be vulnerable to
+manipulation. Use adversarial testing frameworks to simulate
+potential threats and measure their impact on model
+performance. Document the types of perturbations that cause
+incorrect predictions to inform your defense strategy.
+- **Build for robustness from the
+start**. Select diverse features during model
+design to improve resilience against outliers and
+adversarial examples. Implement ensemble methods by
+combining multiple models with different architectures or
+training approaches to increase decision diversity. Consider
+techniques like adversarial training where you intentionally
+incorporate adversarial examples into your training data to
+make your models more resistant to threats.
+- **Identify repeats and suspicious
+patterns**. Deploy
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to continuously analyze
+inference data and detect unusual patterns such as repeated
+similar inputs that may indicate probing threats. Set up
+alerts for anomalous input distributions that differ from
+training data. Monitor for evidence of model brute-forcing,
+where bad actors systematically vary limited sets of input
+features to determine decision boundaries and derive feature
+importance.
+- **Implement experiment and model
+tracking**. Maintain comprehensive records of data
+provenance and model versions to trace model skew back to
+potentially compromised data sources. Before retraining
+models with new data, implement validation processes to
+identify and remove adversarial examples. Use
+[Amazon SageMaker AI MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to document relationships between
+datasets, algorithms, and model artifacts throughout the ML
+lifecycle.
+- **Use secure inference API
+endpoints**. Host models behind properly secured
+API endpoints that implement authentication, authorization,
+and input validation. Configure
+[Amazon SageMaker AI endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-manage.html) with appropriate security
+controls including VPC isolation,
+[AWS IAM](https://aws.amazon.com/iam/) roles with least privilege, and encryption for
+data in transit and at rest. Implement rate limiting and
+request validation to block abuse of model APIs. Monitor API
+usage patterns to detect potential exploitation attempts.
+- **Implement continuous model
+monitoring**. Set up
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to track data and concept
+drift that may indicate adversarial manipulation. Configure
+automatic alerts when inference data patterns deviate from
+training baselines. Periodically reevaluate model robustness
+as new threat techniques emerge in the security landscape.
+- **Establish incident response
+procedures**. Develop clear protocols for
+responding to detected adversarial threats against your ML
+systems. Define procedures for model rollback, data
+quarantine, and forensic analysis when suspicious activities
+are identified. Document lessons learned from security
+incidents to continuously improve protection strategies.
+- **Apply input validation
+guardrails**. For AI models, implement robust input
+validation and filtering mechanisms to block injection
+exploits. Implement custom guardrails to protect against
+harmful inputs that may manipulate model behavior. Monitor
+input patterns and responses to detect attempts to bypass
+security controls.
+
+## Resources
+
+**Related documents:**
+
+- [Deep
+ensembles](https://docs.aws.amazon.com/prescriptive-guidance/latest/ml-quantifying-uncertainty/deep-ensembles.html)
+- [Empirical
+demonstration of deterministic overconfidence](https://docs.aws.amazon.com/prescriptive-guidance/latest/ml-quantifying-uncertainty/app-b.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Security
+and compliance](https://docs.aws.amazon.com/whitepapers/latest/ml-best-practices-public-sector-organizations/security-and-compliance.html)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Run
+ensemble ML models on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/part-7-model-hosting-patterns-in-amazon-sagemaker-run-ensemble-ml-models-on-amazon-sagemaker/)
+- [Securing
+Amazon SageMaker AI Studio connectivity using a private
+VPC](https://aws.amazon.com/blogs/machine-learning/securing-amazon-sagemaker-studio-connectivity-using-a-private-vpc/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec05-bp01.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSEC06.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSEC06.md
@@ -1,0 +1,381 @@
+# MLSEC06
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLSEC06-BP01 Restrict access to intended legitimate consumers
+
+Use least privilege permissions to invoke the deployed model
+endpoint. For consumers who are external to the workload
+environment, provide access using a secure API.
+
+**Desired outcome:** You establish
+secure inference API endpoints that allow only authorized parties to
+access your ML models. You create a controlled environment where
+model access is restricted based on legitimate business needs, while
+maintaining monitoring capabilities to track interactions with your
+models. Your ML endpoints are protected using the same security
+principles applied to other HTTPS APIs, providing data protection in
+transit and proper authentication.
+
+**Common anti-patterns:**
+
+- Allowing public access to model endpoints without proper
+authentication.
+- Using overly permissive IAM roles for model endpoint access.
+- Failing to implement network controls for inference endpoints.
+- Not monitoring or logging model inference activities.
+- Using the same credentials for development and production model
+access.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of unauthorized model access and potential data
+exfiltration.
+- Enhanced control over who can use your ML models and when.
+- Improved monitoring and auditability of model usage.
+- Protection of intellectual property embedded in models.
+- Improves adherence to regulatory requirements for data security.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Securing your ML model endpoints is critical to protect both your
+intellectual property and the data processed by these models. By
+treating ML inference endpoints with the same security rigor as
+other HTTPS APIs, you can maintain a strong security posture while
+enabling legitimate business use. You need to implement proper
+authentication, network controls, and monitoring to verify that
+only authorized parties can access your models.
+
+When deploying machine learning models in production, you should
+consider the model as a valuable asset that requires protection.
+This means implementing layers of security controls including
+network isolation through VPC configuration, strong authentication
+mechanisms, and continuous monitoring of inference activities. For
+external consumers, create a dedicated API layer that enforces
+security policies and controls access.
+
+### Implementation steps
+
+- **Plan your access control
+strategy**. Define which users or applications need
+access to your model endpoints and what specific permissions
+they require. Follow the principle of least privilege,
+granting only the minimum permissions necessary for each
+consumer to perform their required tasks.
+- **Set up secure inference API
+endpoints**. Host your ML models so that consumers
+can perform inference against them securely. Use
+[Amazon SageMaker AI endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-manage.html) with proper authentication and
+authorization controls. Use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to automatically
+benchmark and optimize your model deployments for the best
+security-performance balance, and select optimal compute
+instances and configurations while maintaining security
+controls. This approach defines the relationship between the
+model and its consumers, restricts access to the base model,
+and provides monitoring capabilities for model interactions.
+- **Implement network security
+controls**. Configure your SageMaker AI inference
+endpoints within a VPC to isolate network traffic. Use
+security groups to define inbound and outbound traffic
+rules, and consider using
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) for private connectivity to your
+endpoints. Follow guidance from the
+[AWS Well-Architected Framework](https://aws.amazon.com/architecture/well-architected/) to implement proper
+network controls, such as restricting access to specific IP
+ranges and implementing bot protection.
+- **Configure authentication and
+authorization**. Sign HTTPS requests for API calls
+so that requester identity can be verified. Use
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) to control who has access
+to your SageMaker AI resources and what actions they can
+perform. Consider using
+[Amazon Cognito](https://aws.amazon.com/cognito/) for managing user identities if your API is
+accessed by external users.
+- **Deploy endpoints in a secure VPC
+configuration**. Use
+[VPC
+endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html) to privately connect your VPC to supported
+AWS services without requiring an internet gateway. Follow
+the guidance in
+[Give
+SageMaker AI Hosted Endpoints Access to Resources in Your
+Amazon VPC](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html) to configure your endpoint for VPC access.
+- **Implement encryption for data in
+transit and at rest**. Configure your endpoints to
+use HTTPS for API calls. Encrypt model artifacts and data at
+rest using
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/). Use client-side encryption
+for sensitive data when appropriate.
+- **Set up monitoring and
+logging**. Configure
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor your endpoints and
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to log API calls. Implement
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect drift and data quality issues
+in your production models.
+- **Use model registry for
+governance**. Implement
+[SageMaker AI
+MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to catalog and manage versions
+of your models, control which model versions are deployed,
+and maintain an audit trail of model approvals and
+deployments.
+- **Implement proper API design
+patterns**. Design your inference API following
+REST best practices. Include proper input validation, error
+handling, and rate limiting to protect against abuse.
+Consider implementing an
+[API Gateway](https://aws.amazon.com/api-gateway/) in front of your SageMaker AI endpoint for
+additional controls.
+- **Conduct regular security
+reviews**. Periodically review the security
+configuration of your endpoints, check for over-permissive
+policies, and validate that access logs show only expected
+patterns of usage.
+- **Implement guardrails for AI
+models**. For AI endpoints, implement content
+filtering and validation controls to provide responsible
+outputs, stop harmful content generation, and maintain
+appropriate use of the models.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Real-time
+Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html)
+- [Give
+SageMaker AI Hosted Endpoints Access to Resources in Your Amazon VPC](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Integrating
+machine learning models into your Java-based
+microservices](https://aws.amazon.com/blogs/awsmarketplace/integrating-machine-learning-models-into-your-java-based-microservices/)
+- [How
+Financial Institutions can use AWS to Address Regulatory
+Reporting](https://aws.amazon.com/blogs/architecture/how-banks-can-use-aws-to-meet-compliance/)
+- [Secure
+deployment of Amazon SageMaker AI resources](https://aws.amazon.com/blogs/security/secure-deployment-of-amazon-sagemaker-resources/)
+- [Accelerating
+Machine Learning Development with Data Science as a Service
+from Change Healthcare](https://aws.amazon.com/blogs/apn/accelerating-machine-learning-development-with-data-science-as-a-service-from-change-healthcare/)
+
+**Related videos:**
+
+- [End-to-End
+machine learning using Spark and Amazon SageMaker AI](https://www.youtube.com/watch?v=FKgivdwzO5g)
+
+**Related examples:**
+
+- [Amazon SageMaker AI secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec06-bp01.html*
+
+---
+
+# MLSEC06-BP02 Monitor human interactions with data for anomalous activity
+
+Implement comprehensive monitoring of data access events to detect
+unauthorized or suspicious activities. By auditing user interactions
+with data, you can identify potential security threats such as
+unusual access patterns, abnormal locations, or activity that
+exceeds normal baselines. Use specialized AWS services for anomaly
+detection alongside data classification to assess risks and protect
+your machine learning assets.
+
+**Desired outcome:** You have
+comprehensive visibility into human interactions with your data,
+with logging enabled for create, read, update, and delete
+operations. You can identify who accessed specific data elements,
+what actions they took, and when those actions occurred. Your
+monitoring system automatically flags anomalous activities based on
+established baselines and alerts you to potential security threats.
+Data classification is integrated with your monitoring approach to
+prioritize security events based on data sensitivity.
+
+**Common anti-patterns:**
+
+- Implementing logging without monitoring or analysis
+capabilities.
+- Focusing only on system-level access without tracking specific
+data interactions.
+- Failing to establish user activity baselines for anomaly
+detection.
+- Not classifying data to differentiate between access to
+sensitive and non-sensitive information.
+- Monitoring access events without automated alerting mechanisms.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of potential data breaches or insider threats.
+- Improved ability to investigate security incidents with
+comprehensive audit trails.
+- Improves adherence to data protection regulations and
+requirements.
+- Better visibility into how data is being used across your ML
+systems.
+- Reduced risk of unauthorized data access or exfiltration.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Protecting your machine learning data requires visibility into who
+is accessing it and how it's being used. By monitoring human
+interactions with your data, you can identify potential security
+threats before they lead to data breaches or misuse. This involves
+implementing comprehensive logging for data access events,
+classifying your data based on sensitivity, and using automated
+tools to detect anomalous behavior.
+
+Start by enabling logging for data interactions, particularly
+focusing on human access rather than just system-to-system
+communications. Your logs should capture details about who
+accessed the data, what specific elements they accessed, what
+actions they took, and when those interactions occurred. This
+creates an audit trail that serves as the foundation for your
+monitoring strategy.
+
+Next, classify your data based on sensitivity and importance. By
+knowing which datasets contain personally identifiable information
+(PII), intellectual property, or other sensitive information, you
+can prioritize monitoring efforts and apply appropriate security
+controls. This classification details the potential impact of
+unauthorized access to different datasets.
+
+Finally, implement anomaly detection to identify unusual patterns
+that might indicate security threats. These anomalies could
+include access from unusual locations, outside normal working
+hours, excessive access volume, or access to data that's not
+typically needed for an employee's role. When anomalies are
+detected, your system should generate alerts to prompt
+investigation.
+
+### Implementation steps
+
+- **Enable data access
+logging**. Verify that you have data access logging
+for human CRUD (create, read, update, and delete)
+operations, including the details of who accessed what
+elements, what action they took, and at what time. Leverage
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to capture API calls and user activities
+across your AWS environment. Configure CloudTrail to log
+data events for
+[Amazon S3](https://aws.amazon.com/s3/) buckets containing your training and inference
+data. For SageMaker AI environments, use
+[Amazon SageMaker AI Logging and Monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/logging-cloudwatch.html) capabilities to
+track access to ML models and datasets.
+- **Classify your data**. Use
+[Amazon Macie](https://aws.amazon.com/macie/) for protecting and classifying training and
+inference data in
+[Amazon S3](https://aws.amazon.com/s3/). Amazon Macie is a fully managed security service
+that uses ML to automatically discover, classify, and
+protect sensitive data in AWS. The service recognizes
+sensitive data, such as personally identifiable information
+(PII) or intellectual property. Configure Macie to perform
+regular automated scans of your S3 buckets to identify and
+tag sensitive data. Create custom data identifiers in Macie
+to recognize organization-specific sensitive data patterns
+beyond the standard patterns Macie detects.
+- **Monitor and protect**. Use
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) to monitor for malicious and unauthorized
+activities. This will enable protecting AWS accounts,
+workloads, and data stored in
+[Amazon S3](https://aws.amazon.com/s3/). Configure GuardDuty to analyze CloudTrail logs,
+VPC flow logs, and DNS logs to detect suspicious activities.
+Pay special attention to the
+[GuardDuty
+S3 Finding Types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-s3.html) which can detect anomalous access
+patterns to your S3-stored data.
+- **Set up anomaly detection**.
+Implement automated anomaly detection for data access
+patterns using
+[Amazon CloudWatch Anomaly Detection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html). Create CloudWatch
+metrics for access frequency, data volume transferred,
+access times, and other relevant metrics. Configure
+CloudWatch alarms to alert when anomalies are detected based
+on these metrics.
+- **Establish data access
+baselines**. Create baseline profiles of normal
+user access patterns using
+[AWS CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor access trends over time. Set up
+dashboards that visualize normal patterns of data access by
+team, role, or time period. Use these baselines to fine-tune
+anomaly detection thresholds and reduce false positives.
+- **Implement alerting
+mechanisms**. Configure
+[Amazon EventBridge](https://aws.amazon.com/eventbridge/) to trigger automated responses when
+suspicious access events are detected. Route alerts to your
+security team through notification channels like
+[Amazon SNS](https://aws.amazon.com/sns/) for immediate response. Create different alerting
+thresholds based on data classification and sensitivity.
+- **Centralize logging and
+monitoring**. Use
+[Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) (formerly Amazon OpenSearch Service) to create a centralized repository for log analysis
+and visualization. Build comprehensive dashboards to monitor
+data access patterns across your organization. Implement log
+retention policies that comply with your regulatory
+requirements.
+- **Control and audit data exploration
+activities**. Implement
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) with
+[Amazon SageMaker AI Studio](https://aws.amazon.com/sagemaker/studio/) to provide fine-grained access
+controls for data exploration. Configure Lake Formation
+permissions to restrict data access based on user roles and
+data classification. Use
+[AWS IAM](https://aws.amazon.com/iam/) to enforce least-privilege access to sensitive
+data.
+- **Monitor access to AI training
+data**. Implement specialized monitoring for
+datasets used to train AI models, as these may contain
+particularly sensitive information or be subject to greater
+privacy concerns. Use
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to detect drift in model
+behavior that might indicate data access issues. Implement
+enterprise-ready security and privacy controls for
+foundation models.
+
+## Resources
+
+**Related documents:**
+
+- [CloudWatch Logs for Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/logging-cloudwatch.html)
+- [GuardDuty
+S3 Protection finding types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-s3.html)
+- [AWS CloudTrail Documentation](https://docs.aws.amazon.com/cloudtrail/)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Building
+a Self-Service, Secure, & Continually Compliant
+Environment on AWS](https://aws.amazon.com/blogs/architecture/building-a-self-service-secure-continually-compliant-environment-on-aws/)
+- [How
+to Use New Advanced Security Features for Amazon Cognito user pools](https://aws.amazon.com/blogs/security/how-to-use-new-advanced-security-features-for-amazon-cognito-user-pools/)
+- [Best
+practices for setting up Amazon Macie with AWS Organizations](https://aws.amazon.com/blogs/security/best-practices-for-setting-up-amazon-macie-with-aws-organizations/)
+
+**Related videos:**
+
+- [Protect
+Your Data in S3 with Amazon Macie and Amazon GuardDuty - AWS
+Online Tech Talks](https://www.youtube.com/watch?v=lvPT71jAIXk)
+- [Protecting
+sensitive data with Amazon Macie and Amazon GuardDuty](https://www.youtube.com/watch?v=h7pq95RMuEQ)
+
+**Related examples:**
+
+- [AWS Security Hub CSPM automated response and remediation](https://github.com/aws-solutions/aws-security-hub-automated-response-and-remediation)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec06-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSUS01.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSUS01.md
@@ -1,0 +1,154 @@
+# MLSUS01
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSUS01-BP01 Define the overall environmental impact or benefit
+
+Measure your workload's impact and its contribution to the overall
+sustainability goals of the organization. Understand the
+environmental footprint of machine learning systems to make informed
+decisions about resource allocation and optimization.
+
+**Desired outcome:** You gain a clear
+understanding of how your ML workload impacts your organization's
+sustainability objectives, including energy consumption, carbon
+emissions, and resource utilization. You have established specific
+sustainability objectives and success criteria to measure against,
+which assists you when optimizing your ML workloads and
+demonstrating their environmental value proposition in relation to
+their impact.
+
+**Common anti-patterns:**
+
+- Focusing solely on model accuracy without considering
+environmental trade-offs.
+- Implementing ML systems without measuring their carbon
+footprint.
+- Overprovisioning resources for ML workloads.
+- Unnecessarily retraining models when not required.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved alignment between ML initiatives and organizational
+sustainability goals.
+- Enhanced ability to meet regulatory and reporting requirements.
+- Transparent assessment of the sustainability impact of ML
+projects.
+- Identification of opportunities to optimize ML systems for lower
+environmental impact.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Understanding the environmental impact of your ML workloads is
+essential for sustainable AI development. ML operations can be
+resource-intensive, requiring substantial computing power for
+training and inference, which translates to energy consumption and
+carbon emissions. By measuring and tracking this impact, you can
+make informed decisions about architecture choices, region
+selection, and optimization strategies.
+
+The cloud provides significant advantages for sustainable ML
+development through its economies of scale and renewable energy
+investments. By leveraging AWS's efficiency, you can reduce your
+carbon footprint compared to on-premises alternatives. However,
+you still need to make conscious decisions about how you design,
+deploy, and operate your ML workloads.
+
+Consider the full lifecycle of your ML system, from data
+collection and processing to model training, deployment, and
+ongoing operations. Each stage has different resource requirements
+and environmental impacts. For example, training large models is
+typically more computationally intensive than inference, but if
+your model serves millions of predictions daily, the inference
+stage might have a larger cumulative impact over time.
+
+### Implementation steps
+
+- **Establish sustainability objectives
+for ML workloads**. Begin by defining specific
+sustainability goals for your ML projects that align with
+your organization's broader environmental commitments.
+Determine what metrics you'll track (for example, carbon
+emissions per training run or energy efficiency per
+inference) and set concrete targets for improvement.
+- **Assess the environmental impact of
+data processing**. Evaluate how much data you're
+storing and processing for your ML workloads. Consider
+implementing data lifecycle management using
+[Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) policies to automatically transition
+infrequently accessed data to more efficient storage classes
+or archive data that's no longer needed for active training.
+- **Measure the impact of model
+training**. Calculate the computational resources
+and associated carbon emissions of your model training
+processes using tools like the
+[AWS Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/). Consider factors such
+as instance types, training duration, and region selection.
+Track these metrics over time to identify trends and
+opportunities for improvement.
+- **Optimize model training frequency
+and approach**. Determine how often retraining is
+truly necessary based on model drift monitoring. Implement
+incremental training where possible using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to update existing models with new data
+rather than retraining from scratch. Use techniques like
+transfer learning to leverage pre-trained models and reduce
+computational requirements.
+- **Assess inference
+efficiency**. Evaluate the environmental impact of
+your deployed models in production. Consider techniques like
+model compression, quantization, and distillation to reduce
+the computational requirements of inference while
+maintaining acceptable accuracy. Use
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize models for
+specific deployment targets.
+- **Calculate the net sustainability
+value**. Compare the environmental impact of your
+ML workload with its benefits, including the sustainability
+improvements it enables. For example, if your ML system
+optimizes energy usage in manufacturing processes, calculate
+the net reduction in emissions to demonstrate its overall
+positive impact.
+- **Implement ongoing monitoring and
+reporting**. Establish a regular cadence for
+reviewing sustainability metrics and reporting on progress
+toward your goals. Use
+[AWS CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor resource utilization and create
+dashboards to track your sustainability KPIs over time.
+- **For GenAI workloads, consider your
+model customization strategy**. When implementing
+generative AI solutions, evaluate whether fine-tuning
+existing foundation models like
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) models is more environmentally efficient than
+training custom models from scratch. Consider prompt
+engineering and retrieval-augmented generation (RAG)
+approaches that can achieve business goals with lower
+computational intensity than full model training.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/)
+- [AWS Sustainability Data Initiative](https://sustainability.aboutamazon.com/about/the-climate-pledge)
+- [AWS Well-Architected Framework: Sustainability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html)
+- [Corporate
+Climate Action - Science Based Targets initiative
+(SBTi)](https://sciencebasedtargets.org/)
+- [Greenhouse Gas
+Protocol](https://ghgprotocol.org/)
+- [Optimize
+AI/ML workloads for sustainability: Part 1, identify business
+goals, validate ML use, and process data](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-1-identify-business-goals-validate-ml-use-and-process-data/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus01-bp01.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSUS02.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSUS02.md
@@ -1,0 +1,278 @@
+# MLSUS02
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLSUS02-BP01 Consider AI services and pre-trained models
+
+Using AI services and pre-trained models can significantly reduce
+the resources needed for machine learning workloads, enabling you to
+quickly implement AI capabilities without developing custom models
+from scratch.
+
+**Desired outcome:** You identify
+opportunities to use managed AI services or pre-trained models
+instead of building custom models, reducing the environmental impact
+of training and deploying ML solutions while accelerating time to
+market. By using existing capabilities through APIs or fine-tuning
+pre-trained models, you minimize computational resources required
+for data preparation, model training, and deployment.
+
+**Common anti-patterns:**
+
+- Building custom models from scratch when suitable managed
+services already exist.
+- Collecting and processing large datasets unnecessarily when
+pre-trained models could be utilized.
+- Ignoring transfer learning opportunities that could reduce
+training time and computational resources.
+- Overlooking model optimization techniques that could reduce
+inference resource requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced environmental impact through decreased computational
+resource usage.
+- Lower operational costs for ML development and deployment.
+- Faster time-to-market for ML-powered solutions.
+- Access to state-of-the-art models without specialized ML
+expertise.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When developing machine learning solutions, evaluate whether you
+truly need to build a custom model or if existing services and
+pre-trained models can meet your requirements. Many common use
+cases like image recognition, natural language processing, or
+recommendation systems can use pre-built capabilities available
+through APIs. These managed services handle the underlying
+infrastructure, data processing, and model maintenance, reducing
+both environmental impact and operational overhead.
+
+If fully managed services don't meet your specific requirements,
+consider starting with pre-trained models that you can fine-tune
+with your data. This approach, known as transfer learning, allows
+you to benefit from models that have already undergone
+resource-intensive training on large datasets. By fine-tuning, you
+can achieve similar or better performance than training from
+scratch while using significantly fewer computational resources.
+
+For example, instead of training a computer vision model from
+scratch, you could use a pre-trained image recognition model from
+Amazon Rekognition or fine-tune a model available through
+SageMaker AI JumpStart with your specific images. This approach
+reduces the carbon footprint associated with extensive model
+training while delivering high-quality results.
+
+### Implementation steps
+
+- **Assess your ML use case
+requirements**. Before developing an ML solution,
+clearly define your requirements and success criteria.
+Understand the specific problem you're trying to solve, the
+data you have available, and the performance metrics that
+matter for your application.
+- **Explore AWS AI services**.
+[AWS AI services](https://aws.amazon.com/machine-learning/ai-services/) provide ready-to-use capabilities through
+APIs for common ML tasks. These services include
+[Amazon Rekognition](https://aws.amazon.com/rekognition/) for image and video analysis,
+[Amazon Comprehend](https://aws.amazon.com/comprehend/) for natural language processing,
+[Amazon
+Forecast](https://aws.amazon.com/forecast/) for time-series forecasting, and
+[Amazon Personalize](https://aws.amazon.com/personalize/) for personalization and recommendations.
+- **Evaluate foundation models in Amazon
+Bedrock**.
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) provides serverless access to leading
+foundation models from AI companies like Anthropic, Cohere,
+AI21 Labs, and Amazon's own Nova models through a single
+API. These models can handle tasks like text generation,
+summarization, chatbots, and content creation without
+requiring model training.
+- **Explore pre-trained models from AWS Marketplace**.
+[AWS Marketplace](https://aws.amazon.com/marketplace/b/c3714653-8485-4e34-b35b-82c2203e81c1) offers over 1,400 ML-related assets that
+you can subscribe to, including pre-trained models for
+various industry-specific use cases that can be deployed
+with minimal configuration.
+- **Leverage SageMaker AI
+JumpStart**.
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) provides pre-trained, open-source models
+for a wide range of problem types to get started with
+machine learning. You can incrementally train and fine-tune
+these models before deployment, reducing the computational
+resources needed compared to training from scratch.
+- **Consider Hugging Face
+models**.
+[Hugging
+Face with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/hugging-face.html) enables you to use
+thousands of pre-trained transformer models for NLP,
+computer vision, and audio tasks. These models can be
+fine-tuned with your specific data to achieve high-quality
+results with minimal training.
+- **Implement efficient fine-tuning
+techniques**. When customizing pre-trained models,
+use efficient fine-tuning methods like parameter-efficient
+fine-tuning (PEFT), low-rank adaptation (LoRA), or
+quantization to minimize computational resources while
+maintaining performance.
+- **Monitor resource usage and
+optimize**. After deploying your solution,
+continuously monitor its resource consumption and
+performance. Look for opportunities to optimize through
+model compression, quantization, or pruning to further
+reduce computational requirements.
+- **Leverage expanded pre-trained model
+libraries**. Use the expanded
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) catalog which now includes broader
+selection of pre-trained models and industry-specific
+solutions, reducing the need for custom model development
+and associated computational resources.
+- **For generative AI workloads,
+implement retrieval-augmented generation (RAG)**.
+For generative AI applications requiring domain-specific
+knowledge, consider using
+[retrieval-augmented
+generation](https://aws.amazon.com/what-is/retrieval-augmented-generation/) with SageMaker AI JumpStart foundation models
+instead of fine-tuning large models, which can significantly
+reduce computational resources while improving accuracy.
+
+## Resources
+
+**Related documents:**
+
+- [AWS AI Services](https://aws.amazon.com/machine-learning/ai-services/)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Choose
+the best data source for your Amazon SageMaker AI training
+job](https://aws.amazon.com/blogs/machine-learning/choose-the-best-data-source-for-your-amazon-sagemaker-training-job/)
+- [Pre-trained
+machine learning models available in AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning/pre-trained-models)
+- [Resources
+for using Hugging Face with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/hugging-face.html)
+- [Optimize
+AI/ML workloads for sustainability: Part 2, model
+development](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-2-model-development/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus02-bp01.html*
+
+---
+
+# MLSUS02-BP02 Select sustainable Regions
+
+Choose the Regions where you implement your workloads based on both
+your business requirements and sustainability goals.
+
+**Desired outcome:** You select AWS Regions that align with your organizational sustainability
+objectives while meeting your business requirements. By choosing
+Regions with renewable energy sources and lower carbon intensity,
+you reduce the environmental impact of your machine learning
+workloads while maintaining optimal performance for your business
+needs.
+
+**Common anti-patterns:**
+
+- Selecting Regions based solely on proximity without considering
+environmental impact.
+- Ignoring renewable energy availability when deploying machine
+learning workloads.
+- Deploying workloads across multiple Regions without considering
+their carbon footprints.
+
+**Benefits of establishing this best
+practice:**
+
+- Alignment with organizational sustainability goals and ESG
+initiatives.
+- Enhanced reputation as an environmentally responsible
+organization.
+- Potential cost savings through efficient Region selection.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When deploying your machine learning workloads, Region selection
+plays a crucial role in meeting both your operational requirements
+and sustainability goals. While factors such as latency, data
+residency, and service availability remain important,
+incorporating sustainability considerations into your Region
+selection process can minimize your environmental impact. AWS is
+continuously expanding its renewable energy projects globally,
+making it increasingly possible to host your workloads in Regions
+powered by sustainable energy sources.
+
+The cloud offers significant sustainability advantages compared to
+on-premises deployments due to higher utilization rates, more
+energy-efficient infrastructure, and AWS' commitment to renewable
+energy. By selecting Regions thoughtfully, you can further enhance
+these sustainability benefits while still meeting your business
+needs.
+
+### Implementation steps
+
+- **Understand your business
+requirements first**. Identify the non-negotiable
+requirements for your workload, including data sovereignty
+regulations, compliance-aligned needs, latency requirements,
+and service availability in specific Regions. Create a
+shortlist of Regions that meet these baseline requirements.
+- **Research AWS renewable energy
+projects**. Use the
+[Amazon
+Around the Globe](https://sustainability.aboutamazon.com/about/around-the-globe?energyType=true) resource to identify Regions that
+are near Amazon renewable energy projects. AWS achieved
+powering its operations with
+[100%
+renewable energy](https://www.aboutamazon.com/news/sustainability/amazon-renewable-energy-goal) in 2023, seven years ahead of their
+original 2030 commitment.
+- **Consider the grid's carbon
+intensity**. Look for Regions where the electrical
+grid has lower published carbon intensity. This information
+may be available through regional utility reports or
+sustainability documentation. Lower carbon intensity means
+reduced emissions even for non-renewable energy sources.
+- **Evaluate the trade-offs**.
+When selecting Regions, consider potential trade-offs
+between sustainability goals and business requirements such
+as latency or availability. In some cases, minor performance
+trade-offs may be acceptable to achieve significant
+sustainability improvements.
+- **Monitor sustainability
+metrics**. After deployment, track relevant
+sustainability metrics to verify that your Region selection
+is delivering the expected environmental benefits. Consider
+implementing dashboards with key performance indicators
+(KPIs) for sustainability tracking.
+- **Review and adjust
+periodically**. As AWS adds more renewable energy
+projects and as your business requirements evolve,
+periodically reassess your Region selections to continually
+align with your sustainability goals.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Global Infrastructure](https://aws.amazon.com/about-aws/global-infrastructure/)
+- [Delivering
+on net-zero carbon by 2040](https://sustainability.aboutamazon.com/about/around-the-globe)
+- [Climate
+solutions](https://sustainability.aboutamazon.com/about/the-climate-pledge)
+- [AWS Well-Architected Framework - Sustainability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html)
+- [How
+to select a Region for your workload based on sustainability
+goals](https://aws.amazon.com/blogs/architecture/how-to-select-a-region-for-your-workload-based-on-sustainability-goals/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus02-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSUS03.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSUS03.md
@@ -1,0 +1,403 @@
+# MLSUS03
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLSUS03-BP01 Minimize idle resources
+
+Minimize your environmental impact by efficiently managing compute
+resources in your ML data pipeline. Use serverless architectures
+that provision resources only when needed, reducing energy
+consumption and carbon footprint.
+
+**Desired outcome:** You implement a
+serverless, event-driven architecture for your ML data pipelines
+that only provisions resources when work needs to be done. This
+approach reduces idle resources, optimizes utilization of computing
+infrastructure, and reduces your organization's environmental impact
+while maintaining performance and scalability.
+
+**Common anti-patterns:**
+
+- Provisioning compute instances that run 24/7 regardless of
+workload requirements.
+- Overprovisioning resources rather than scaling dynamically.
+- Using traditional batch processing with fixed schedules instead
+of event-driven approaches.
+- Failing to monitor and optimize resource utilization metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower carbon footprint and energy consumption.
+- Improved resource efficiency across your ML pipeline.
+- Automatic scaling to match workload demands.
+- Simplified maintenance with managed services.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Adopting a serverless architecture for your ML data pipelines
+significantly reduces idle resources by allocating compute power
+only when needed. This approach uses AWS managed services that
+automatically scale based on workload, avoiding the need to
+maintain an always-on infrastructure. When you design your data
+pipeline using serverless technologies like AWS Glue and AWS Step Functions, you not only optimize resource utilization but also
+distribute the sustainability impact across the tenants of those
+services, reducing your individual environmental contribution.
+
+The key principle is to transition from a static infrastructure
+model to an event-driven approach where resources are provisioned
+in response to triggers. This verifies that compute resources are
+only active during actual processing tasks rather than sitting
+idle waiting for work. AWS managed services handle the underlying
+infrastructure optimization, allowing you to focus on your ML
+workloads while maintaining efficiency.
+
+### Implementation steps
+
+- **Evaluate your current
+infrastructure**. Assess your existing data
+pipeline architecture to identify components that run
+continuously but have low utilization. Look for workloads
+with predictable patterns or batch processes that could
+benefit from an event-driven approach using
+[AWS CloudWatch metrics](https://aws.amazon.com/cloudwatch/) to identify utilization patterns.
+- **Adopt managed services**.
+Replace self-managed infrastructure with AWS managed
+services to distribute sustainability impact across service
+tenants. Services like
+[AWS Glue](https://aws.amazon.com/glue/),
+[AWS Lambda](https://aws.amazon.com/lambda/), and
+[Amazon EMR Serverless](https://aws.amazon.com/emr/serverless/) provision resources on-demand and
+automatically scale with your workloads.
+- **Create serverless, event-driven data
+pipelines**. Use
+[AWS Glue](https://aws.amazon.com/glue/) for data processing and
+[AWS Step Functions](https://aws.amazon.com/step-functions/) for orchestration to build ETL and ELT
+pipelines that only consume resources when triggered. Step
+Functions can coordinate AWS Glue jobs efficiently,
+provisioning compute resources only when needed and
+releasing them immediately after completion.
+- **Implement efficient data
+storage**. Choose appropriate storage solutions
+like [Amazon S3](https://aws.amazon.com/s3/) for your data lake and
+[Amazon S3 Intelligent-Tiering](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/) to automatically move data
+between access tiers based on usage patterns, reducing
+storage costs and resource waste.
+- **Configure event-based
+triggers**. Set up event notifications through
+[Amazon EventBridge](https://aws.amazon.com/eventbridge/) to automatically launch processing jobs
+when new data arrives. This avoids the need for scheduled
+jobs that might run when no new data is available, reducing
+unnecessary compute usage.
+- **Optimize compute
+resources**. For AWS Glue jobs, configure
+appropriate worker types and dynamically allocate resources
+based on workload requirements. Use features like
+[AWS Glue Auto Scaling](https://docs.aws.amazon.com/glue/latest/dg/auto-scaling.html) to automatically adjust capacity as
+needed during jobs.
+- **Implement monitoring and
+metrics**. Set up comprehensive monitoring of your
+serverless infrastructure using
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track resource utilization, job
+execution time, and idle periods. Use these metrics to
+identify further optimization opportunities.
+- **Establish automatic cleanup
+processes**. Implement automated processes to
+remove temporary resources, intermediate data, and other
+artifacts after job completion to avoid unnecessary storage
+costs and reduce digital waste.
+- **Optimize data transfer**.
+Minimize data movement between services by processing data
+close to where it's stored when possible. Use
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) for data preparation tasks within the
+same environment as your data storage.
+- **Use AI-powered
+optimization**. Use Amazon Q data integration in
+AWS Glue to automatically generate optimized ETL jobs for
+common data sources. This reduces development time while
+implementing efficient resource utilization patterns from
+the start.
+
+## Resources
+
+**Related documents:**
+
+- [What
+is AWS Lambda?](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html)
+- [What
+is Amazon EMR Serverless?](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/emr-serverless.html)
+- [Using
+auto scaling for AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/auto-scaling.html)
+- [What
+is Amazon EventBridge?](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html)
+- [Start
+an AWS Glue job with Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-glue.html)
+- [Serverless
+Applications Lens - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/welcome.html)
+- [Optimize
+AI/ML workloads for sustainability: Part 3, deployment and
+monitoring](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-3-deployment-and-monitoring/)
+- [Fuel
+your data with Generative AI](https://aws.amazon.com/blogs/enterprise-strategy/fuel-your-data-with-generative-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus03-bp01.html*
+
+---
+
+# MLSUS03-BP02 Implement data lifecycle policies aligned with your sustainability goals
+
+Classify your data to identify its business relevance and implement
+efficient storage strategies that support your sustainability goals.
+By understanding your data's importance, you can appropriately tier
+storage, implement retention policies, and manage the entire
+lifecycle to reduce your environmental footprint while meeting
+business requirements.
+
+**Desired outcome:** You have a
+comprehensive data management strategy that classifies data based on
+business importance and implements automatic storage optimization.
+Your workloads store data in the most energy-efficient storage tiers
+possible, and data that no longer serves a business purpose is
+automatically purged, resulting in minimal storage footprint and
+reduced environmental impact.
+
+**Common anti-patterns:**
+
+- Storing data indefinitely without classification or lifecycle
+policies.
+- Using a single storage tier for data regardless of access
+patterns.
+- Manually managing data retention and deletion.
+- Keeping redundant or obsolete data that no longer serves
+business purposes.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced storage infrastructure and energy consumption.
+- Improved data governance and adherence.
+- Enhanced system performance with streamlined data management.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Implementing data lifecycle policies begins with understanding the
+relationship between your data and business outcomes. Each
+category of data has different requirements for retention, access
+patterns, and eventual disposal. By aligning these requirements
+with sustainability goals, you can optimize storage utilization
+while improving business continuity.
+
+Start by creating a data classification framework that categorizes
+data based on its criticality, frequency of access, and business
+value over time. This classification will guide your decisions
+about which storage tiers to use and when data should be moved or
+deleted. For instance, frequently accessed operational data might
+remain in high-performance storage, while rarely accessed archival
+data can be moved to more energy-efficient cold storage options.
+
+Once you've classified your data, use AWS storage features like S3
+Lifecycle policies to automate data transitions between storage
+tiers and eventual deletion. For example, you can configure
+policies that automatically transition data from S3 Standard to S3
+Intelligent-Tiering, S3 Standard-IA, S3 One Zone-IA, and
+eventually to Amazon Glacier or S3 Glacier Deep Archive based on
+access patterns and age.
+
+### Implementation steps
+
+- **Define your data classification
+framework.** Develop a comprehensive data
+classification system that categorizes data based on
+business importance, access frequency, and regulatory
+requirements. Include clear definitions for each data
+category and establish ownership for classification
+decisions.
+- **Map retention requirements to data
+classes.** For each data classification, determine
+appropriate retention periods that satisfy business needs,
+regulatory requirements, and sustainability goals. Document
+these requirements to guide policy implementation.
+- **Analyze current storage usage
+patterns.** Use
+[Amazon S3 Storage Lens](https://aws.amazon.com/s3/storage-analytics-insights/) to gain visibility into your current
+storage usage patterns, identifying opportunities for
+optimization and tracking progress on storage efficiency
+metrics.
+- **Implement S3 Lifecycle
+policies.** Configure
+[Amazon S3 Lifecycle policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) to automatically transition
+data between storage classes and enforce deletion timelines
+based on your defined retention requirements.
+- **Deploy intelligent storage
+tiering.** Implement
+[Amazon S3 Intelligent-Tiering storage class](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/) to automatically
+move data between access tiers based on changing access
+patterns, optimizing for both cost and sustainability.
+- **Establish monitoring and
+reporting.** Create dashboards to track storage
+optimization metrics, including total storage used, storage
+class distribution, and lifecycle transition metrics.
+Regularly review these metrics to identify further
+optimization opportunities.
+- **Continuously refine data
+classification.** Review and update your data
+classification framework regularly to align it with evolving
+business needs and sustainability goals.
+
+## Resources
+
+**Related documents:**
+
+- [Managing
+the lifecycle of objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+- [Managing
+storage costs with Amazon S3 Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)
+- [Comparing
+the Amazon S3 storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html#sc-compare)
+- [Assessing
+your storage activity and usage with Amazon S3 Storage
+Lens](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens.html)
+- [Setting
+an S3 Lifecycle configuration on a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html)
+- [Data
+discovery and cataloging in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus03-bp02.html*
+
+---
+
+# MLSUS03-BP03 Adopt sustainable storage options
+
+Reduce the volume of data to be stored and adopt sustainable storage
+options to limit the carbon impact of your workload. For artifacts
+like models and log files that must be kept for long-term regulatory
+and audit requirements, use efficient compression algorithms and use
+energy efficient cold storage.
+
+**Desired outcome:** You optimize
+your ML workload storage to minimize environmental impact while
+improving adherence to regulatory requirements. By implementing
+efficient storage practices, you reduce data redundancy, properly
+size resources, use energy-efficient storage options, and implement
+effective compression techniques. This results in reduced carbon
+footprint, lower storage costs, and improved overall sustainability
+of your ML systems.
+
+**Common anti-patterns:**
+
+- Storing redundant copies of datasets across multiple locations.
+- Over-provisioning storage resources for notebooks and instances.
+- Using inefficient file formats like CSV instead of columnar
+formats such as parquet.
+- Keeping data in high-performance storage regardless of access
+frequency.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower operational costs through efficient resource utilization.
+- Improved data access performance through appropriate format
+selection.
+- Improved ability to adhere to regulatory requirements through
+proper long-term storage planning.
+- Reduced waste through optimization of storage resources.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Storage is a critical component of ML workloads, with large
+datasets and model artifacts requiring significant resources. By
+optimizing how you store, compress, and manage this data, you can
+substantially reduce the environmental impact of your ML systems.
+Consider the entire lifecycle of your data, from initial
+collection through processing to long-term retention. For
+frequently accessed data, choose efficient formats and compression
+algorithms. For infrequently accessed data, use Amazon S3 storage
+tiers that minimize energy consumption while improving your
+adherence to regulatory requirements. By right-sizing your storage
+resources and removing redundant data, you can achieve both
+sustainability goals and cost optimization.
+
+### Implementation steps
+
+- **Reduce redundancy of processed
+data**. If you can re-create an infrequently
+accessed dataset, use the
+[Amazon S3 One Zone-IA](https://aws.amazon.com/s3/storage-classes/#__) class to minimize the total data
+stored. Implement S3 Lifecycle policies to automatically
+transition objects to more energy-efficient storage tiers
+based on access patterns.
+- **Right size block storage for
+notebooks**. Don't over-provision block storage of
+your notebooks and use centralized object storage services
+like [Amazon S3](https://aws.amazon.com/s3/) for common datasets to avoid data duplication.
+Monitor usage patterns and adjust storage allocations
+accordingly.
+- **Use efficient file
+formats**. Use
+[Parquet](https://parquet.apache.org/)
+to train your models. Compared to CSV, they can reduce
+[your
+storage by up to 87%](https://docs.aws.amazon.com/whitepapers/latest/building-data-lakes/monitoring-optimizing-data-lake-environment.html#data-lake-optimization2). These columnar formats not only
+reduce storage requirements but also improve query
+performance.
+- **Migrate to more efficient
+compression algorithms**. Evaluate different
+compression algorithms and select the most efficient for
+your data. For example,
+[Zstandard](https://github.com/facebook/zstd)
+produces 10–15% smaller files than
+[Gzip](https://www.gzip.org/) at the
+same compression speed.
+- **Implement storage lifecycle
+management**. Configure
+[S3
+Intelligent-Tiering](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/) to automatically move data
+between access tiers based on changing usage patterns. For
+long-term archival needs, use
+[S3 Glacier Deep Archive](https://aws.amazon.com/s3/storage-classes/glacier/) to minimize energy consumption
+for rarely accessed data.
+- **Monitor and optimize storage
+utilization**. Regularly review and clean up
+unnecessary data and snapshots. Use
+[Amazon S3 Storage Lens](https://aws.amazon.com/s3/storage-analytics-insights/) to gain visibility into usage
+patterns and identify optimization opportunities across your
+organization.
+- **Centralize and share
+datasets**. Implement a centralized data catalog
+using
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html) to make datasets discoverable and
+reusable, reducing the need for multiple copies of the same
+data.
+- **For generative AI workloads, use AI
+for intelligent data management**. Implement
+embeddings storage with efficient vector databases like
+[Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) to optimize storage of large language
+model context.
+
+## Resources
+
+**Related documents:**
+
+- [Understanding
+and managing Amazon S3 storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html)
+- [Managing
+storage costs with Amazon S3 Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)
+- [Amazon S3 Storage Analytics and Insights](https://aws.amazon.com/s3/storage-analytics-insights/)
+- [AWS Well-Architected Framework: Performance Efficiency Pillar -
+Data Management](https://docs.aws.amazon.com/wellarchitected/latest/performance-efficiency-pillar/data-management.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus03-bp03.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSUS04.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSUS04.md
@@ -1,0 +1,658 @@
+# MLSUS04
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLSUS04-BP01 Define sustainable performance criteria
+
+Creating machine learning models that balance accuracy with
+environmental impact is essential for sustainable AI development.
+When we focus exclusively on model accuracy, we overlook the
+economic, environmental, and social costs of achieving marginal
+performance improvements. Since the relationship between model
+accuracy and complexity is logarithmic at best, continuing to train
+a model longer or searching extensively for better hyperparameters
+often yields only minimal gains while significantly increasing
+resource consumption.
+
+**Desired outcome:** You establish
+balanced performance criteria for your ML models that satisfy your
+business requirements without excessive resource usage. You
+implement mechanisms to optimize training efficiency, reducing
+carbon footprint and costs while maintaining appropriate model
+performance. Your machine learning lifecycle incorporates
+sustainability as a core consideration alongside traditional metrics
+like accuracy.
+
+**Common anti-patterns:**
+
+- Pursuing maximum model accuracy without considering
+environmental impact.
+- Using oversized models when smaller models would be sufficient.
+- Allowing training jobs to run indefinitely with minimal
+performance improvements.
+- Ignoring resource utilization metrics during model development.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced energy consumption and carbon footprint from ML
+operations.
+- Lower computational costs for model training and deployment.
+- Faster development cycles with earlier training completion.
+- Better alignment between business requirements and model
+capabilities.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When developing machine learning models, balancing accuracy with
+sustainability requires deliberate consideration of how much
+performance is actually needed. The incremental gains in accuracy
+often diminish significantly beyond certain thresholds, while
+computational costs continue to rise. By defining sustainable
+performance criteria upfront, you create guardrails that reduce
+unnecessary environmental impact.
+
+These criteria should reflect your specific business needs rather
+than abstract notions of best possible performance. For many
+applications, a model that is 95% accurate may provide the same
+business value as one that is 96% accurate but requires twice the
+computational resources to train. Understand this relationship to
+make informed trade-offs.
+
+Early stopping mechanisms represent one practical implementation
+of sustainable criteria. These techniques automatically terminate
+training when improvement plateaus, avoiding wasted computation.
+Tools like SageMaker AI Debugger and Automatic Model Tuning
+provide built-in capabilities to implement early stopping without
+compromising model quality.
+
+Regularly measuring and monitoring resource utilization can
+identify opportunities for optimization. Tracking metrics like CPU
+and GPU utilization, memory consumption, and training duration
+provides visibility into your model development's environmental
+impact and can identify inefficiencies.
+
+### Implementation steps
+
+- **Establish sustainable performance
+criteria**. Define concrete performance thresholds
+that meet your business requirements without excessive
+resource consumption. Consider both the absolute performance
+levels needed and the point at which additional gains become
+negligible. Include both accuracy and efficiency metrics in
+your criteria, such as inference latency, model size, and
+training resource requirements.
+- **Analyze the accuracy-resource
+tradeoff**. Conduct experiments to understand the
+relationship between model performance and resource
+consumption for your specific use case. Plot accuracy
+against training time, model size, or computational
+resources to identify the point of diminishing returns. Use
+this data to set reasonable stopping criteria for your
+training jobs.
+- **Configure early stopping in training
+jobs**. Set up SageMaker AI Automatic Model Tuning
+with early stopping to terminate training jobs that are not
+showing significant improvement. Navigate to the SageMaker AI
+console, create a hyperparameter tuning job, and enable the
+early stopping option. Alternatively, configure early
+stopping programmatically using the SageMaker AI Python SDK by
+setting the early_stopping_type parameter
+to **Auto**.
+- **Implement debugging
+rules**. Use SageMaker AI Debugger to automatically
+stop training when specific conditions are met. Add rules
+like LossNotDecreasing to your training
+script to detect when your model stops improving. For
+example, configure the rule to stop training if the loss
+doesn't decrease by at least 0.01% over the last ten epochs.
+- **Monitor resource
+utilization**. Track the efficiency of your
+training jobs using CloudWatch metrics or SageMaker AI
+Debugger's Profiling Report. Monitor metrics such as
+CPUUtilization,
+GPUUtilization,
+GPUMemoryUtilization,
+MemoryUtilization, and
+DiskUtilization. Identify patterns of
+resource underutilization that might indicate opportunities
+for right-sizing your infrastructure.
+- **Right-size your training
+infrastructure**. Based on utilization metrics,
+adjust the instance types and counts for your training jobs.
+Select the most efficient instance type that meets your
+performance requirements rather than defaulting to the most
+powerful option. For distributed training jobs, verify that
+you're using an appropriate number of instances to maximize
+utilization.
+- **Validate against business
+requirements**. Before finalizing your model,
+verify that it meets the business requirements while
+adhering to your sustainable performance criteria. Document
+the tradeoffs made and the rationale behind them to provide
+transparency to stakeholders.
+- **Use no-code ML for rapid
+prototyping**. Use
+[SageMaker AI
+Canvas](https://aws.amazon.com/sagemaker/canvas/) with natural language support for data
+exploration and model development to quickly validate ML
+approaches before investing in resource-intensive custom
+development. Canvas can generate models with minimal
+computational overhead for initial feasibility testing.
+Export Canvas-generated models and code to notebooks for
+further optimization and sustainable development practices.
+- **Use AI-powered code generation for
+sustainable development**. Use AI-powered
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+efficient ML code, automate performance optimization
+scripts, and accelerate the implementation of sustainable ML
+practices while reducing development resource consumption.
+- **Consider smaller specialized
+models**. For generative AI applications, evaluate
+whether smaller, domain-specific models can meet your needs
+instead of using large general-purpose models. Techniques
+like retrieval-augmented generation (RAG) can enhance
+smaller models' capabilities while maintaining lower
+resource requirements. Fine-tuning a smaller base model on
+your specific data often provides better sustainability
+outcomes than using larger generic models.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Stop
+Training Jobs Early](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-early-stopping.html)
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Amazon SageMaker AI Debugger - Built-in Rules:
+LossNotDecreasing](https://docs.aws.amazon.com/sagemaker/latest/dg/debugger-built-in-rules.html#loss-not-decreasing)
+- [SageMaker AI job metrics](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html#cloudwatch-metrics-jobs)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp01.html*
+
+---
+
+# MLSUS04-BP02 Select energy-efficient algorithms
+
+Choosing energy-efficient algorithms minimizes resource usage while
+maintaining performance, reducing your machine learning workloads'
+environmental impact and operational costs.
+
+**Desired outcome:** You establish a
+systematic approach for selecting and optimizing algorithms that
+deliver the necessary performance while minimizing computational
+resources. Your ML workloads run more efficiently, reducing energy
+consumption, carbon footprint, and infrastructure costs without
+significant performance degradation.
+
+**Common anti-patterns:**
+
+- Defaulting to the most complex algorithm without evaluating
+simpler alternatives.
+- Ignoring model compression techniques that could reduce resource
+requirements.
+- Overlooking the environmental impact of computational resources.
+- Focusing solely on model accuracy without considering resource
+efficiency.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced energy consumption and carbon footprint.
+- Faster inference times and improved user experience.
+- Ability to deploy ML models on resource-constrained devices.
+- Extended battery life for edge devices running ML workloads.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Energy-efficient algorithm selection requires balancing model
+performance with resource consumption. When developing machine
+learning models, computational efficiency directly impacts
+sustainability and cost. Starting with simpler algorithms provides
+a baseline for comparison and often delivers sufficient results
+without excessive resource demands. Modern approaches like model
+distillation, pruning, and quantization enable you to achieve
+near-equivalent results using significantly fewer resources.
+
+The environmental impact of ML workloads increases with model
+complexity, making optimization techniques essential for
+sustainable AI development. By systematically evaluating algorithm
+efficiency alongside performance metrics, you can make informed
+decisions that reduce your carbon footprint while maintaining
+service quality.
+
+### Implementation steps
+
+- **Begin with a simple algorithm to
+establish a baseline:** Start your development
+process with straightforward algorithms that provide a
+reference point for performance and resource usage. Then
+[test
+different algorithms with increasing complexity](https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlper-07.html) to
+observe whether performance improvements justify additional
+resource consumption. Measure both model accuracy and
+resource utilization metrics to make informed decisions
+about complexity trade-offs.
+- **Explore simplified versions of
+popular algorithms:** Research and implement
+distilled or optimized versions of standard algorithms that
+deliver similar performance with reduced computational
+requirements. For example, DistilBERT, a distilled version
+of
+[BERT](https://en.wikipedia.org/wiki/BERT_(language_model)),
+has 40% fewer parameters, runs 60% faster, and preserves 97%
+of its performance. Similar approaches exist for many common
+model architectures.
+- **Implement model compression
+techniques:** Apply pruning to remove model weights
+that contribute minimally to predictions, reducing model
+size and computational requirements. Use quantization to
+represent numerical values with lower precision,
+significantly decreasing memory usage and processing demands
+while maintaining acceptable accuracy levels.
+- **Leverage AWS optimization
+services:** Deploy
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize your ML
+models for inference on cloud resources and edge devices.
+SageMaker AI Neo analyzes your model and generates optimized
+code that maximizes performance while minimizing resource
+consumption, allowing you to deploy more efficient models
+across diverse deployment targets.
+- **Monitor and optimize resource
+utilization:** Track the
+[resources
+provisioned](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ResourceConfig.html) for your training and inference jobs
+(InstanceCount, InstanceType, and VolumeSizeInGB) and their
+[efficient
+use](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html#cloudwatch-metrics-jobs) (CPUUtilization, GPUUtilization,
+GPUMemoryUtilization, MemoryUtilization, and
+DiskUtilization) through the
+[SageMaker AI
+Console](https://docs.aws.amazon.com/sagemaker/latest/dg/training-metrics.html#view-train-metrics-sm),
+[CloudWatch
+Console](https://docs.aws.amazon.com/sagemaker/latest/dg/training-metrics.html#view-train-metrics-cw) or your
+[SageMaker AI
+Debugger Profiling Report](https://docs.aws.amazon.com/sagemaker/latest/dg/debugger-profiling-report.html#debugger-profiling-report-walkthrough-system-usage). Use these insights to
+right-size your resources and identify optimization
+opportunities.
+- **Consider hardware-specific
+optimizations:** Choose appropriate instance types
+for training and inference based on your model's
+characteristics. Some algorithms perform better on GPU
+instances, while others may be more efficient on CPU or
+specialized accelerators like AWS Inferentia. Matching your
+algorithm to the optimal hardware can significantly improve
+energy efficiency.
+- **Use optimized foundation model
+containers:** Deploy models using SageMaker AI's
+optimized foundation model containers that include
+pre-configured environments with built-in quantization and
+optimization techniques. These containers support frameworks
+like Hugging Face Transformers and provide automatic
+performance optimizations.
+- **Use AI-powered code generation for
+algorithm optimization**. Use AI-powered
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+optimized algorithm implementations, automate model
+compression code, and accelerate the development of
+energy-efficient ML solutions.
+- **Apply efficient architectures for
+foundation models:** When working with generative
+AI models, consider parameter-efficient fine-tuning
+approaches like LoRA (Low-Rank Adaptation) or P-tuning
+instead of full fine-tuning. These techniques can reduce the
+computational resources required while achieving comparable
+performance. Leverage pre-trained foundation models
+available through SageMaker AI JumpStart to avoid the
+energy-intensive process of training from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [The
+AWS Inferentia Chip With DLAMI](https://docs.aws.amazon.com/dlami/latest/devguide/tutorial-inferentia.html)
+- [Prepare
+Model for Compilation](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-compilation-preparing-model.html)
+- [Optimize
+AI/ML workloads for sustainability: Part 2, model
+development](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-2-model-development/)
+
+**Related videos:**
+
+- [Deploy
+an ML model for best performance, cost, and prediction
+quality](https://www.youtube.com/watch?v=ftCFf57dQQY)
+- [SageMaker AI
+HyperPod: Revolutionizing Foundation Model Training with
+Resilience and Performance](https://aws.amazon.com/awstv/watch/c60e1437f63/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp02.html*
+
+---
+
+# MLSUS04-BP03 Archive or delete unnecessary training artifacts
+
+Remove training artifacts that are unused and no longer required to
+limit wasted resources. Determine when you can archive training
+artifacts to more energy-efficient storage or safely delete them.
+
+**Desired outcome:** You reduce your
+environmental footprint by removing unnecessary storage of ML
+training artifacts. Your organization maintains only essential
+training data and models, efficiently archives what might be needed
+later, and systematically removes what is no longer required. This
+approach not only conserves resources but also simplifies management
+of your machine learning assets.
+
+**Common anti-patterns:**
+
+- Keeping training artifacts indefinitely.
+- Ignoring the accumulation of unused logs, models, and experiment
+data.
+- Not implementing systematic cleanup processes for completed
+experiments.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced storage costs and resource consumption.
+- Improved organization and discoverability of important ML
+artifacts.
+- Enhanced security through reduced data surface area.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning workflows generate substantial volumes of
+artifacts during the development process. These include experiment
+data, logs, model checkpoints, and various intermediary outputs.
+While some of these artifacts are essential for long-term use,
+many become unnecessary after model deployment or project
+completion.
+
+Consider the lifecycle of your ML artifacts. Some might need
+preservation for compliance-aligned or reproducibility purposes,
+while others can be safely removed once they've served their
+immediate purpose. For artifacts that must be retained but are
+rarely accessed, consider using tiered storage options that
+balance accessibility with resource efficiency.
+
+### Implementation steps
+
+- **Organize your ML experiments with
+management tools**. Use
+[SageMaker AI Experiments](https://aws.amazon.com/sagemaker/ai/experiments/) to track, compare, and organize your
+machine learning experiments in a structured manner. This
+organization makes it more straightforward to identify which
+artifacts are essential and which can be archived or
+deleted.
+- **Implement regular cleanup
+procedures**. Follow the
+[clean
+up training resources](https://docs.aws.amazon.com/sagemaker/latest/dg/ex1-cleanup.html) guidance from AWS to
+systematically remove SageMaker AI resources you no longer
+need. Create automated cleanup workflows that run on a
+schedule to avoid the accumulation of unused artifacts.
+- **Set appropriate log retention
+policies**. By default, Amazon CloudWatch retains
+logs indefinitely, which consumes unnecessary resources.
+Implement
+[limited
+retention time](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SettingLogRetention) for your notebooks and training logs
+to automatically expire and delete logs after they're no
+longer needed.
+- **Establish storage lifecycle
+policies**. Configure
+[Amazon S3 lifecycle policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) to automatically transition
+training artifacts to more cost-effective and
+energy-efficient storage classes like Amazon Glacier or S3 Glacier Deep Archive based on access patterns.
+- **Monitor storage
+utilization**. Use
+[Amazon S3 Storage Lens](https://aws.amazon.com/s3/storage-analytics-insights/) to gain visibility into your storage
+usage patterns and identify opportunities for optimization.
+Track metrics regularly to verify that your cleanup
+procedures are effective.
+- **Implement container image
+cleanup**. Use
+[Amazon ECR lifecycle policies](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) to automatically clean up
+unused container images that may have been created during
+training jobs. This avoids the accumulation of outdated or
+unused container images.
+- **Establish artifact tagging
+standards**. Create a consistent tagging strategy
+for ML artifacts to identify their purpose, associated
+projects, and expiration dates. This makes it simpler to
+determine what can be archived or deleted during cleanup
+processes.
+- **Leverage managed MLflow for
+experiment tracking**. Use
+[managed
+MLflow on SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to create, manage, analyze, and
+compare your machine learning experiments with better
+organization and tracking capabilities, making it more
+straightforward to identify which experiments and associated
+artifacts can be safely archived or deleted.
+- **For GenAI foundation models,
+implement token usage monitoring and cleanup**. For
+generative AI projects, monitor token usage and intermediate
+outputs, which can quickly accumulate. Implement automated
+cleanup of temporary prompts, completions, and generated
+content that isn't required for the final model.
+
+## Resources
+
+**Related documents:**
+
+- [Clean
+up Amazon SageMaker AI notebook instance resources](https://docs.aws.amazon.com/sagemaker/latest/dg/ex1-cleanup.html)
+- [Cataloging
+and analyzing your data with S3 Inventory](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-inventory.html)
+- [What
+Is Amazon EventBridge?](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html)
+- [Working
+with log groups and log streams](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SettingLogRetention)
+- [Automate
+the cleanup of images by using lifecycle policies in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html)
+- [AWS Systems Manager for Automation](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation.html)
+- [What
+Is AWS Config?](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
+- [Optimizing
+MLOps for Sustainability](https://aws.amazon.com/blogs/machine-learning/optimizing-mlops-for-sustainability/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp03.html*
+
+---
+
+# MLSUS04-BP04 Use efficient model tuning methods
+
+Optimize your machine learning model's hyperparameters with
+resource-efficient strategies that minimize computational needs
+while improving performance. Efficient tuning methods can
+significantly reduce costs, energy consumption, and time-to-market
+compared to resource-intensive brute force approaches.
+
+**Desired outcome:** You can
+systematically find optimal hyperparameters for your machine
+learning models while minimizing computational resource consumption.
+By implementing intelligent search strategies and following best
+practices for optimization, you achieve better model performance
+with fewer resources, reduce your environmental footprint, and
+accelerate time-to-market for your ML solutions.
+
+**Common anti-patterns:**
+
+- Using grid search, which tests the most possible combinations of
+hyperparameters.
+- Running many concurrent training jobs without considering how
+results from previous jobs can inform later ones.
+- Specifying excessively broad hyperparameter ranges without
+proper understanding of their impact.
+- Using random search when more efficient options like Bayesian or
+Hyperband are available.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduce computational resources required for hyperparameter
+tuning by up to 10x compared to random search.
+- Decrease energy consumption and associated carbon emissions from
+ML training.
+- Find optimal hyperparameters faster, accelerating
+time-to-market.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Hyperparameter tuning is a crucial step in machine learning model
+development that directly impacts both model performance and
+resource utilization. Efficient tuning strategies can dramatically
+reduce the computational resources required while finding optimal
+or near-optimal parameter settings.
+
+When approaching hyperparameter tuning, consider the relationship
+between tuning strategy and resource consumption. Grid search,
+which exhaustively tests the most possible combinations, is the
+most resource-intensive approach and should generally be avoided.
+Random search provides better resource efficiency but lacks
+intelligence in selecting which configurations to test. More
+sophisticated approaches like Bayesian optimization and Hyperband
+can find optimal hyperparameters with significantly fewer training
+jobs, reducing both time and resource usage.
+
+The efficiency of your hyperparameter tuning is also affected by
+how you configure concurrent jobs and specify parameter ranges.
+Running too many concurrent jobs can waste resources when using
+methods that benefit from sequential exploration. Similarly,
+specifying unnecessarily wide parameter ranges increases the
+search space complexity without adding value.
+
+### Implementation steps
+
+- **Choose an efficient search
+strategy**. Implement Bayesian optimization or
+Hyperband search strategies instead of random or grid
+search. Bayesian search uses information from previous
+trials to make intelligent guesses about promising
+hyperparameter configurations, typically requiring 10 times
+fewer jobs than random search to find optimal parameters.
+For large models like deep neural networks addressing
+computer vision problems,
+[Amazon SageMaker AI Hyperband](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-how-it-works.html) can find optimal hyperparameters
+up to three times faster than Bayesian search.
+- **Optimize job concurrency
+settings**. Configure your hyperparameter tuning
+jobs with appropriate concurrency settings. With Bayesian
+optimization, running fewer concurrent jobs often yields
+better results since the algorithm benefits from information
+gathered in previous iterations. Balance the tradeoff
+between parallelism (which speeds up overall completion
+time) and sequential learning (which improves optimization
+efficiency) based on your specific requirements for
+time-to-completion versus resource efficiency.
+- **Define thoughtful parameter
+ranges**. Carefully select which hyperparameters to
+tune and their corresponding value ranges. Focus on
+parameters that significantly impact model performance and
+limit ranges to reasonable values based on domain knowledge
+or prior experiments. For parameters known to be log-scaled
+(learning rates, regularization strengths), convert them to
+log space to improve optimization efficiency. This focused
+approach reduces the search space complexity, discovering
+optimal configurations with fewer resources.
+- **Leverage early stopping
+capabilities**. Implement mechanisms to terminate
+underperforming training jobs early to avoid wasting
+resources on unpromising hyperparameter configurations. Use
+Amazon SageMaker AI's built-in early stopping functionality
+that automatically terminates training jobs that are
+unlikely to produce better models than previously completed
+jobs.
+- **Monitor resource
+utilization**. Track metrics related to resource
+provisioning and utilization for your hyperparameter tuning
+jobs. Use Amazon SageMaker AI's integration with Amazon CloudWatch to monitor CPU utilization, GPU utilization,
+memory usage, and other resource metrics. Analyze these
+metrics to identify optimization opportunities in your
+tuning strategy.
+- **Integrate with your MLOps
+pipeline**. Incorporate efficient hyperparameter
+tuning as a standard component of your MLOps workflow.
+Automate the process of selecting optimal hyperparameters
+and retraining models when necessary. This verifies the
+consistent application of efficient tuning practices across
+your machine learning projects.
+- **Leverage pre-trained models to
+reduce tuning scope**. Start with pre-trained
+models from the expanded
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) catalog or
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) foundation models, which often require
+minimal hyperparameter tuning for your use case,
+significantly reducing computational resources compared to
+training from scratch.
+- **Leverage AI-powered code generation
+for tuning automation**. Use AI-powered development
+tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+efficient hyperparameter tuning scripts, automate
+optimization workflows, and accelerate the implementation of
+resource-efficient tuning strategies.
+- **Consider warm-starting tuning
+jobs**. Use the results from previous
+hyperparameter tuning jobs to initialize new jobs when
+incrementally improving models or adapting to changing data
+patterns. This approach reduces the resources required to
+find good hyperparameters compared to starting from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [Best
+Practices for Hyperparameter Tuning](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html)
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Amazon SageMaker AI Training Compiler](https://docs.aws.amazon.com/sagemaker/latest/dg/training-compiler.html)
+- [Choosing
+the Best Number of Concurrent Training Jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html#automatic-model-tuning-parallelism)
+- [Choosing
+Hyperparameter Ranges](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html#automatic-model-tuning-choosing-ranges)
+- [Amazon SageMaker AI Hyperband Search Strategy](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-sagemaker-automatic-model-tuning-provides-faster-hyperparameter-tuning-hyperband-search-strategy/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp04.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSUS05.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSUS05.md
@@ -1,0 +1,533 @@
+# MLSUS05
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLSUS05-BP01 Align SLAs with sustainability goals
+
+Define service level agreements (SLAs) that support your
+sustainability goals while meeting your business requirements.
+Define SLAs to meet your business requirements, not exceed them.
+Make trade-offs that significantly reduce environmental impacts in
+exchange for acceptable decreases in service levels.
+
+**Desired outcome:** You establish
+SLAs that balance business requirements with sustainability
+objectives, optimizing resource utilization while maintaining
+acceptable service levels. By implementing appropriate inference
+methods based on latency tolerance, availability needs, and response
+time requirements, you can reduce idle resources, minimize energy
+consumption, and lower your machine learning workload's
+environmental impact.
+
+**Common anti-patterns:**
+
+- Maintaining always-on inference endpoints for workloads with
+sporadic or batch processing needs.
+- Setting unnecessarily stringent response time requirements when
+users can tolerate some latency.
+- Configuring excessive redundancy beyond what's needed for
+business continuity.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced infrastructure costs through optimized resource
+utilization.
+- Lower carbon footprint from minimized idle computing resources.
+- Alignment of technical operations with organizational
+sustainability goals.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When designing machine learning systems, your SLA choices directly
+impact resource consumption and environmental sustainability. By
+carefully analyzing your actual business requirements rather than
+automatically opting for maximum performance, you can identify
+opportunities to make sustainable trade-offs without compromising
+essential functionality.
+
+Consider your application's true latency requirements,
+availability needs, and processing patterns. For example, if your
+users can tolerate a response time of seconds rather than
+milliseconds, asynchronous or batch processing approaches can
+dramatically reduce resource usage compared to always-on real-time
+endpoints. Similarly, if your application can gracefully handle
+occasional unavailability during instance failures, you can avoid
+overprovisioning redundant capacity.
+
+The goal is to make conscious trade-offs that balance
+sustainability with business needs, focusing on what's truly
+required rather than defaulting to full time maximum performance.
+
+### Implementation steps
+
+- **Queue incoming requests and process
+them asynchronously**. If your users can tolerate
+some latency, deploy your model on
+[serverless](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+or
+[asynchronous
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html) to reduce resources that are idle between
+tasks and minimize the impact of load spikes. These options
+will automatically scale the instance or endpoint count to
+zero when there are no requests to process, so you only
+maintain an inference infrastructure when your endpoint is
+processing requests.
+- **Adjust availability**. If
+your users can tolerate some latency in the rare case of a
+failover, don't provision extra capacity. If an outage
+occurs or an instance fails, Amazon SageMaker AI
+[automatically
+attempts to distribute your instances across Availability
+Zones](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html#deployment-best-practices-availability-zones). Adjusting availability is an example of a
+[conscious
+trade off](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-as-a-non-functional-requirement.html) you can make to meet your sustainability
+targets.
+- **Adjust response time**.
+When you don't need real-time inference, use
+[SageMaker AI Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html). Unlike a persistent endpoint,
+clusters are decommissioned when batch transform jobs finish
+so you don't continuously maintain an inference
+infrastructure.
+- **Conduct workload
+analysis**. Assess your machine learning workload's
+usage patterns and latency requirements to determine the
+most sustainable deployment option. Identify periods of peak
+activity versus low or no usage to determine if on-demand
+scaling is appropriate for your needs.
+- **Define sustainability
+metrics**. Establish key metrics to track your
+sustainability improvements, such as compute hours saved,
+idle time reduced, or overall carbon footprint reduction.
+Include these metrics alongside traditional performance
+indicators in your operational dashboards.
+- **Leverage enhanced serverless
+inference capabilities**. Use improved
+[SageMaker AI
+Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) with increased memory
+configurations and better cold-start performance for
+variable workloads that don't require always-on
+infrastructure.
+- **Optimize large language model
+deployments with serverless deployment or batch
+processing**. For generative AI workloads using
+large language models (LLMs), consider serverless model
+inference through SageMaker AI or implement
+[Bedrock
+batch processing](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html) for non-interactive generation tasks
+like content summarization or document analysis to reduce
+resource consumption.
+
+## Resources
+
+**Related documents:**
+
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Batch
+transform for inference with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Best
+practices for deploying models on SageMaker AI Hosting
+Services](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Sustainability
+as a non-functional requirement](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-as-a-non-functional-requirement.html)
+- **Related services:**
+- [Amazon
+Bedrock](https://aws.amazon.com/bedrock/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp01.html*
+
+---
+
+# MLSUS05-BP02 Use efficient silicon
+
+Choosing the right compute architecture for your machine learning
+workloads can significantly reduce energy consumption and carbon
+footprint while maintaining high performance.
+
+**Desired outcome:** You select and
+deploy the most energy-efficient instance types for your machine
+learning workloads, resulting in reduced power consumption, lower
+costs, and a more sustainable ML infrastructure without compromising
+performance or functionality.
+
+**Common anti-patterns:**
+
+- Using general-purpose instances for specialized ML workloads.
+- Selecting hardware based primarily on performance without
+considering power efficiency.
+- Not optimizing ML models to work efficiently on specialized
+hardware.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced energy consumption by up to 60% with purpose-built ML
+accelerators.
+- Decreased carbon footprint of your ML operations.
+- Improved performance-per-watt metrics for your ML
+infrastructure.
+- Better alignment with organizational sustainability goals.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+The energy efficiency of your ML infrastructure directly impacts
+both your operating costs and environmental footprint. By
+selecting purpose-built hardware accelerators designed
+specifically for ML workloads, you can achieve significant
+sustainability improvements while maintaining or even improving
+performance.
+
+AWS has developed several specialized compute architectures
+optimized for different ML workload types, from training to
+inference. Each is designed to deliver maximum performance per
+watt to assist in meeting sustainability goals while effectively
+running your ML applications. These purpose-built solutions are
+particularly important for large-scale ML deployments where small
+efficiency improvements can result in substantial energy savings
+when scaled across your infrastructure.
+
+When choosing compute resources for your ML workloads, consider
+not only the raw performance but also the energy efficiency of the
+hardware. The most powerful instance sometimes isn't the most
+sustainable choice, as matching the hardware capabilities to your
+specific workload requirements can often lead to better
+sustainability outcomes.
+
+### Implementation steps
+
+- **Assess your ML workload
+requirements**. Before selecting compute resources,
+analyze your ML workload characteristics including model
+size, batch processing capabilities, latency requirements,
+and throughput needs. This assessment can determine which
+specialized hardware will provide the optimal balance
+between performance and sustainability.
+- **Use AWS Graviton3 for CPU-based ML
+inference**.
+[AWS Graviton3](https://aws.amazon.com/ec2/graviton/) processors offer the best performance per
+watt in Amazon EC2, using up to 60% less energy than
+comparable instances. They deliver up to three times better
+performance compared to Graviton2 processors for ML
+workloads and support bfloat16, making them ideal for
+efficient CPU-based inference.
+- **Deploy AWS Inferentia for deep
+learning inference**. Amazon EC2
+[Inf2
+instances](https://aws.amazon.com/machine-learning/inferentia/) offer up to 50% better performance per watt
+over comparable Amazon EC2 instances. These instances are
+purpose-built to run deep learning models at scale and
+assist in meeting sustainability goals when deploying
+ultra-large models.
+- **Leverage AWS Trainium for ML
+training**. Amazon EC2
+[Trn2
+instances](https://aws.amazon.com/machine-learning/trainium/) based on custom-designed AWS Trainium chips
+offer up to 50% cost-to-train savings over comparable
+instances. When using a Trainium-based instance cluster,
+total energy consumption for training BERT Large from
+scratch is approximately 25% lower compared to same-sized
+clusters of comparable accelerated EC2 instances.
+- **Optimize your models for the target
+hardware**. Use the
+[AWS Neuron SDK](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/) to compile and optimize your ML models
+specifically for AWS Inferentia and Trainium chips. This
+verifies that your models can take full advantage of the
+hardware's power-efficient design and specialized ML
+acceleration features.
+- **Monitor and measure power
+efficiency**. Use Amazon CloudWatch metrics to
+track the resource utilization of your ML workloads. Compare
+performance-per-watt metrics across different instance types
+to validate your efficiency improvements and identify areas
+for further optimization.
+- **Leverage purpose-built training
+infrastructure**. For large-scale model training,
+use
+[SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) which provides purpose-built infrastructure
+for distributed training with automatic checkpoint storage
+and recovery, optimizing resource utilization for
+long-running training jobs.
+- **Evaluate serverless options for
+intermittent workloads**. For ML inference
+workloads with variable traffic patterns, consider
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) to automatically scale
+compute resources based on traffic, reducing idle resource
+waste.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon EC2 instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+- [Specifications
+for Amazon EC2 accelerated computing instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html#aws-inferentia-instances)
+- [AWS Neuron SDK Documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+
+**Related examples:**
+
+- [AWS Graviton Technical Guide](https://github.com/aws/aws-graviton-getting-started)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp02.html*
+
+---
+
+# MLSUS05-BP03 Optimize models for inference
+
+Optimize machine learning models for inference to achieve higher
+performance with lower computational resources, reducing both costs
+and environmental impact.
+
+**Desired outcome:** You achieve more
+efficient machine learning inference with optimized models that use
+less computational resources, consume less energy, and deliver
+faster predictions. This optimization can reduce operational costs
+and carbon footprint while improving the user experience through
+faster response times.
+
+**Common anti-patterns:**
+
+- Deploying models directly from training without optimization.
+- Using generic frameworks for inference when optimized
+alternatives exist.
+- Selecting oversized models when smaller ones would suffice for
+the task.
+- Ignoring hardware-specific optimizations for deployment targets.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced inference costs through more efficient resource
+utilization.
+- Improved response times for better user experience.
+- Extended battery life for edge device deployments.
+- Ability to deploy complex models on resource-constrained
+devices.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Model optimization for inference represents a critical step in the
+machine learning lifecycle that is often overlooked. While data
+scientists typically focus on model accuracy during development,
+the computational efficiency of these models during deployment
+significantly impacts costs, energy consumption, and user
+experience.
+
+Model compilation transforms your trained models into optimized
+forms that can run more efficiently on specific hardware. This
+process analyzes your model's computational graph, applies various
+optimizations like operator fusion and memory layout
+transformations, and generates optimized code that takes advantage
+of hardware-specific capabilities. The result is a model that
+delivers the same predictions but requires less computational
+resources and energy.
+
+The optimization approach varies based on your model type and
+deployment target. For tree-based models like XGBoost, specialized
+compilers can significantly reduce inference latency. For deep
+learning models, frameworks can avoid training-specific operations
+and optimize the execution path. For edge deployments, additional
+optimizations like quantization can reduce model size while
+maintaining acceptable accuracy.
+
+### Implementation steps
+
+- **Select appropriate model
+architectures**. Choose model architectures that
+naturally lend themselves to efficient inference. Consider
+simpler architectures or distilled versions of larger models
+when possible. Balance accuracy requirements against
+efficiency needs for your specific use case.
+- **Use open-source model
+compilers**. Use specialized tools like
+[Treelite](https://treelite.readthedocs.io/en/latest/)
+for decision tree ensembles such as XGBoost, LightGBM, and
+RandomForest. These compilers transform models into
+optimized C code that improves prediction throughput through
+more efficient memory access patterns and computational
+optimizations.
+- **Leverage Amazon SageMaker AI
+Neo**. Use
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to optimize models for inference on
+Amazon SageMaker AI in the cloud and supported edge devices.
+Neo automatically optimizes models trained in TensorFlow,
+PyTorch, MXNet, and other frameworks, delivering up to 25
+times the performance improvement while maintaining
+accuracy. The Neo runtime consumes only a fraction of the
+resources required by full deep learning frameworks.
+- **Consider quantization
+techniques**. Apply post-training quantization to
+reduce model precision from 32-bit floating point to 16-bit
+or 8-bit integers where appropriate. This reduces model size
+and improves computational efficiency, particularly on
+hardware with specialized integer arithmetic capabilities.
+- **Optimize for specific hardware
+targets**. Configure your model compilation process
+to target the specific hardware where inference will run.
+Different optimizations apply to CPUs, GPUs, and specialized
+accelerators like AWS Inferentia or AWS Trainium.
+- **Use efficient model serving
+architectures**. Implement
+[SageMaker AI
+multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html) and inference pipelines to
+build modular inference architectures that efficiently share
+resources across models and processing stages, allowing for
+improved resource utilization and optimization.
+- **Leverage AI-powered code generation
+for optimization automation**. Use AI-powered
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+model optimization code, automate inference pipeline
+creation, and accelerate the implementation of efficient
+deployment strategies.
+- **Test performance under realistic
+conditions**. Measure inference latency,
+throughput, and resource utilization under realistic
+workloads before deploying to production. Compare optimized
+models against baselines to quantify improvements and verify
+that optimization doesn't impact accuracy.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Edge
+Devices](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-edge-devices.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp03.html*
+
+---
+
+# MLSUS05-BP04 Deploy multiple models behind a single endpoint
+
+Host multiple models behind a single endpoint to improve endpoint utilization. Sharing
+endpoint resources is more sustainable and less expensive than deploying a single model behind
+one endpoint.
+
+**Desired outcome:** Your organization achieves greater efficiency
+in your model deployments by consolidating multiple models on shared infrastructure. This can
+reduce costs by increasing utilization of your endpoint resources, minimize environmental impact
+through reduced carbon emissions, and simplify your model deployment architecture.
+
+**Common anti-patterns:**
+
+- Deploying each model on its own dedicated endpoint regardless of utilization patterns.
+- Over-provisioning resources for endpoints that serve infrequently accessed models.
+- Creating separate infrastructure for similar models that could share resources.
+
+**Benefits of establishing this best practice:**
+
+- Reduced costs through better utilization of compute resources.
+- Decreased carbon footprint by up to 90% compared to single-model deployments.
+- Improved scalability for serving multiple models.
+- Enhanced operational efficiency for inference workloads.
+
+**Level of risk exposed if this best practice is not established:**
+Medium
+
+## Implementation guidance
+
+Model deployment architecture significantly impacts both cost and sustainability. By
+hosting multiple models behind a single endpoint, you can substantially improve resource
+utilization, reducing both expenses and environmental impact. Amazon SageMaker AI provides several
+approaches to implement this practice, each suitable for different scenarios depending on your
+model types, access patterns, and processing requirements.
+
+Consider your workload characteristics when selecting a deployment approach. For a large
+collection of similar models that aren't accessed simultaneously, multi-model endpoints (MME)
+offer the most efficient solution. When you need to deploy different model types with varying
+framework requirements, multi-container endpoints (MCE) provide flexibility. For sequential
+processing workflows, inference pipelines allow you to chain preprocessing, prediction, and
+postprocessing steps.
+
+### Implementation steps
+
+- **Assess your model deployment needs**. Evaluate your
+current deployment architecture, focusing on model similarity, access patterns, and
+resource requirements. Identify opportunities to consolidate models based on these
+characteristics.
+- **Select the appropriate deployment method**. Choose from
+one of SageMaker AI's three approaches based on your workload requirements:
+
+Multi-model endpoints for similar models with varied access patterns
+- Multi-container endpoints for heterogeneous models requiring different
+frameworks
+- Inference pipelines for sequential processing workflows
+
+- **Implement multi-model endpoints**. Use SageMaker AI's multi-model
+endpoint capability to host multiple models within a single container. This approach is
+ideal when you have many similar models that use the same framework and don't need to be
+accessed simultaneously. Configure the endpoint to dynamically load and unload models
+based on usage patterns to optimize memory utilization.
+- **Deploy multi-container endpoints**. When your models
+require different containers or frameworks, use [SageMaker AI multi-container
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html) to host up to 15 containers on a single endpoint. Configure each
+container with its specific model and framework requirements while sharing the
+underlying infrastructure resources.
+- **Create inference pipelines**. For workflows that require
+sequential processing, implement a [SageMaker AI inference pipeline](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html) to
+chain multiple containers. Define the sequence to handle preprocessing, model inference,
+and postprocessing steps as a unified flow, passing outputs from one container as inputs
+to the next.
+- **Monitor and optimize resource utilization**. Use [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track endpoint metrics
+including CPU utilization, memory usage, and invocation patterns. Analyze this data to
+further optimize your deployment by adjusting instance types or scaling configurations
+based on actual usage.
+- **Implement cost tracking**. Set up cost allocation tags to
+monitor the efficiency gains from your consolidated endpoint deployment. Compare the
+costs before and after implementation to quantify savings and justify the architectural
+approach.
+- **Leverage modular deployment architectures**. Use [SageMaker AI
+multi-container endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html) and [inference pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html) to
+create modular inference architectures that can efficiently share resources across
+different model components and processing stages.
+- **Consider sustainability metrics**. Track carbon emission
+reductions resulting from your optimized deployment architecture. Using [AWS
+Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/), you can measure the environmental impact of
+your workloads and report on sustainability improvements.
+
+## Resources
+
+**Related documents:**
+
+- [Multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Multi-container endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html)
+- [Inference
+pipelines in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp04.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/machine-learning/MLSUS06.md
+++ b/powers/wa-review/steering/references/lenses/machine-learning/MLSUS06.md
@@ -1,0 +1,281 @@
+# MLSUS06
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLSUS06-BP01 Measure material efficiency
+
+Measure efficiency of your workload in provisioned resources per
+unit of work to determine not only the business success of the
+workload, but also its material efficiency. Use this measure as a
+baseline for your sustainability improvement process.
+
+**Desired outcome:** You can quantify
+and track the resources required by your machine learning workload
+to deliver its business outcomes. By measuring resources per unit of
+work, you create a sustainable baseline that allows you to track
+improvements over time, make data-driven decisions about resource
+optimization, and demonstrate the environmental impact of your
+sustainability efforts.
+
+**Common anti-patterns:**
+
+- Focusing exclusively on business metrics without considering
+resource consumption.
+- Measuring total resource usage without normalizing by business
+outcomes.
+- Making optimization decisions without quantitative data on
+resource efficiency.
+
+**Benefits of establishing this best
+practice:**
+
+- Creates a clear way to measure sustainability progress over
+time.
+- Enables comparison of different implementations based on
+material efficiency.
+- Provides data to demonstrate ROI on sustainability improvements.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Material efficiency is a critical aspect of sustainable machine
+learning workloads. By measuring the resources provisioned per
+unit of work, you gain visibility into how efficiently your
+workload uses cloud resources to deliver business value. This
+approach normalizes your sustainability metrics across different
+workload sizes, usage patterns, and business outcomes.
+
+When implementing material efficiency measurements, you should
+first determine what constitutes a *unit of
+work* for your specific ML workload. This could be a
+model training run, a prediction request, a processed transaction,
+or another relevant business outcome. Then, establish which
+resources to track. Typically, this is compute (vCPU minutes),
+storage (GB), and network (GB transferred). By dividing your
+provisioned resources by these units of work, you create a
+normalized efficiency metric that can be tracked over time.
+
+For example, a recommendation engine might track vCPU minutes per
+recommendation delivered, or a fraud detection system could
+measure GB of storage per fraudulent transaction identified.
+Tracking these metrics can determine if changes to your
+architecture, algorithms, or deployment strategies are improving
+efficiency or creating waste.
+
+### Implementation steps
+
+- **Define your unit of work**.
+Identify what business outcomes your ML workload produces,
+such as model training completions, predictions made,
+insights generated, or transactions processed. Verify that
+this metric directly relates to business value delivered.
+- **Establish resource
+metrics**. Track key resource consumption metrics
+using Amazon CloudWatch. For ML workloads, important metrics
+include compute utilization (vCPU minutes), memory usage,
+storage consumption (GB), and network transfer (GB). AWS Cost Explorer can identify key cost drivers in your ML
+workload.
+- **Calculate baseline
+efficiency**. Divide your resource consumption
+metrics by your units of work to create efficiency ratios
+(for example, vCPU minutes per prediction, GB storage per
+model training run, or network transfer per transaction).
+Document these values as your baseline for future
+comparisons.
+- **Set improvement targets**.
+Based on your baseline measurements, set realistic targets
+for reducing resource consumption per unit of work. Consider
+both absolute reductions (total resources) and percentage
+improvements over the baseline.
+- **Implement monitoring and
+reporting**. Use Amazon CloudWatch dashboards to
+visualize your efficiency metrics over time. Set up alerts
+for significant deviations from expected efficiency. Amazon SageMaker AI provides built-in monitoring capabilities for ML
+workloads to track resource utilization.
+- **Quantify improvement
+benefits**. When implementing changes, calculate
+both the immediate resource savings and the projected
+long-term benefits. Include the return on investment from
+your improvement activities to demonstrate value to
+stakeholders.
+- **Review and optimize
+regularly**. Schedule regular reviews of your
+efficiency metrics to identify new optimization
+opportunities. As your workload evolves, your baseline and
+targets may need adjustment.
+
+## Resources
+
+**Related documents:**
+
+- [Analyzing
+your costs and usage with AWS Cost Explorer](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/ce-what-is.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [AWS Trusted Advisor](https://docs.aws.amazon.com/awssupport/latest/user/trusted-advisor.html)
+- [Measure
+results and replicate successes](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/measure-results-and-replicate-successes.html)
+- [AWS Well-Architected Framework - Sustainability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html)
+- [Cloud
+Financial Management with AWS](https://aws.amazon.com/aws-cost-management/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus06-bp01.html*
+
+---
+
+# MLSUS06-BP02 Retrain only when necessary
+
+Because of model drift, robustness requirements, or new ground truth
+data being available, models usually need to be retrained. Instead
+of retraining arbitrarily, monitor your ML model in production,
+automate your model drift detection and only retrain when your
+model's predictive performance has fallen below defined KPIs.
+
+**Desired outcome:** You will
+establish a data-driven approach to model retraining that optimizes
+computational resources while maintaining model performance. By
+implementing automated monitoring and drift detection systems, you
+can identify when your model's performance degrades below acceptable
+thresholds and retrain only when necessary. This reduces unnecessary
+computational overhead while verifying that your models remain
+accurate and relevant.
+
+**Common anti-patterns:**
+
+- Retraining models on a fixed schedule regardless of performance.
+- Manual monitoring of model performance leading to delayed
+detection of drift.
+- Retraining without clear performance thresholds or KPIs.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced computational resources and carbon footprint.
+- Lower operational costs for model maintenance.
+- More efficient use of data science team resources.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning models deployed in production environments
+naturally experience degradation in performance over time due to
+changes in data patterns, user behaviors, or business
+environments. This phenomenon, known as model drift, requires
+retraining to maintain optimal performance. However, retraining a
+model consumes significant computational resources, which impacts
+both operational costs and environmental sustainability.
+
+By implementing automated monitoring systems and establishing
+clear performance thresholds, you can make data-driven decisions
+about when to retrain your models. This approach verifies that
+you're using computational resources efficiently while maintaining
+the effectiveness of your ML systems. Through continuous
+monitoring, you can detect both concept drift (changes in the
+relationship between input and output variables) and data drift
+(changes in the distribution of input data).
+
+Your monitoring strategy should incorporate both technical metrics
+(such as accuracy, precision, recall) and business-relevant KPIs
+that directly tie to organizational outcomes. By correlating these
+metrics with specific thresholds for retraining, you create a
+sustainable approach to model maintenance that optimizes both
+performance and resource utilization.
+
+### Implementation steps
+
+- **Determine key performance
+indicators**. Work with business stakeholders to
+identify minimum acceptable accuracy levels and maximum
+acceptable error rates for your models. These KPIs should
+directly connect to business outcomes and provide clear
+thresholds for when retraining becomes necessary. Consider
+both technical metrics (precision, recall, F1 score) and
+business metrics (conversion rates, user engagement, revenue
+impact) when establishing these thresholds.
+- **Monitor your model deployed in
+Production**. Implement
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously evaluate your
+deployed models. SageMaker AI Model Monitor provides
+capabilities for data quality monitoring, model quality
+monitoring, bias drift monitoring, and feature attribution
+drift monitoring. Configure alerts based on your established
+KPIs to automatically notify your team when performance
+begins to degrade.
+- **Set up baseline metrics**.
+Create a baseline of your model's performance metrics
+immediately after deployment. This serves as a reference
+point against which future performance can be measured.
+SageMaker AI Model Monitor can automatically generate these
+baselines from your training data or initial inference data.
+- **Configure drift detection
+thresholds**. Define specific threshold values that
+indicate when drift has occurred to a degree that warrants
+retraining. These thresholds should be based on your KPIs
+and statistical measures of data or concept drift. Configure
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) alarms to go off when these thresholds are
+exceeded.
+- **Automate your retraining
+pipelines**. Use
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/),
+[AWS Step Functions for Amazon SageMaker AI](https://docs.aws.amazon.com/step-functions/latest/dg/connect-sagemaker.html), or third-party
+tools to create automated workflows that can be initiated
+when drift is detected. These pipelines should handle data
+preparation, model training, evaluation, and deployment with
+minimal manual intervention.
+- **Optimize retraining
+frequency**. Based on historical drift patterns,
+adjust monitoring sensitivity and retraining thresholds to
+optimize the frequency of retraining. Finding the right
+balance keeps models performant while minimizing
+computational overhead.
+- **Establish canary
+deployments**. When deploying retrained models, use
+[SageMaker AI
+deployment options](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails.html) like canary deployments to
+gradually shift traffic to the new model while monitoring
+performance, allowing for quick rollback if issues arise.
+- **Leverage enhanced bias and drift
+detection**. Use improved
+[SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) capabilities with enhanced bias detection,
+new fairness metrics, and better visualization tools to more
+accurately detect when retraining is necessary.
+- **Implement feedback loops for
+generative models**. Establish mechanisms to
+collect user feedback and engagement metrics to detect when
+outputs become less relevant or helpful. Use
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) for fine-tuning foundation models
+when drift is detected in generative applications.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Model Monitor documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Pipelines documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [AWS Step Functions for Data Science](https://docs.aws.amazon.com/step-functions/latest/dg/connect-sagemaker.html)
+- [SageMaker AI
+Deployment Guardrails](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails.html)
+- [SageMaker AI Governance](https://aws.amazon.com/sagemaker/ai/ml-governance/)
+- [Optimizing
+MLOps for Sustainability](https://aws.amazon.com/blogs/machine-learning/optimizing-mlops-for-sustainability/)
+
+**Related videos:**
+
+- [SageMaker AI
+HyperPod: Revolutionizing Foundation Model Training with
+Resilience and Performance](https://aws.amazon.com/awstv/watch/c60e1437f63/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus06-bp02.html*
+
+---

--- a/powers/wa-review/steering/references/lenses/serverless-applications/sustainability.md
+++ b/powers/wa-review/steering/references/lenses/serverless-applications/sustainability.md
@@ -1,0 +1,17 @@
+# Sustainability
+
+**Pages**: 1
+
+---
+
+# Sustainability pillar
+
+The sustainability pillar includes the ability to continually improve sustainability impacts by reducing energy
+consumption and increasing efficiency across all components of a workload by maximizing the benefits from the
+provisioned resources and minimizing the total resources required.
+
+There are no sustainability practices unique to this lens. For information on Sustainability, refer to the [Sustainability Pillar whitepaper](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/sustainability.html*
+
+---

--- a/powers/wa-review/steering/wa-review.md
+++ b/powers/wa-review/steering/wa-review.md
@@ -177,6 +177,7 @@ Available lenses:
 - `references/lenses/migration/` — Assess, Mobilize, Migrate phases per pillar
 - `references/lenses/devops-guidance/` — CI/CD, automated governance, development lifecycle, observability, security testing
 - `references/lenses/machine-learning/` — ML lifecycle (MLOPS), model training/deployment, data engineering, responsible ML
+- `references/lenses/data-analytics/` — data pipelines, governance, data catalogs, lineage, analytics performance and cost
 
 ## Step 5: Risk Assessment
 

--- a/powers/wa-review/steering/wa-review.md
+++ b/powers/wa-review/steering/wa-review.md
@@ -176,6 +176,7 @@ Available lenses:
 - `references/lenses/hybrid-networking/` — Direct Connect, VPN, Transit Gateway, DNS
 - `references/lenses/migration/` — Assess, Mobilize, Migrate phases per pillar
 - `references/lenses/devops-guidance/` — CI/CD, automated governance, development lifecycle, observability, security testing
+- `references/lenses/machine-learning/` — ML lifecycle (MLOPS), model training/deployment, data engineering, responsible ML
 
 ## Step 5: Risk Assessment
 

--- a/scripts/crawl-wa-framework.py
+++ b/scripts/crawl-wa-framework.py
@@ -451,20 +451,33 @@ def discover_leaf_pages(toc_json: dict, pillar_sections: list[str] | None = None
     Returns a list of dicts with keys: section, title, href.
     """
     results = []
-    target_sections = pillar_sections or [
+    # Pillar names we want as section buckets. The generic "Pillars of the
+    # Well-Architected Framework" wrapper is intentionally NOT here — it's a
+    # container above the real pillars, not a bucket itself.
+    pillar_names = pillar_sections or [
         "Operational excellence", "Security", "Reliability",
         "Performance efficiency", "Cost optimization", "Sustainability",
-        "Pillars of the Well-Architected Framework",
     ]
+
+    def matches_pillar(title):
+        tl = title.lower()
+        return next((p for p in pillar_names if p.lower() in tl), None)
 
     def walk(contents, section=None, depth=0):
         for item in contents:
             title = item.get("title", "")
             href = item.get("href", "")
 
-            # Check if this node is a pillar section header we should track
-            is_section = any(t.lower() in title.lower() for t in target_sections)
-            current_section = title if is_section else section
+            # Adopt a pillar name as the section bucket, but only the FIRST
+            # (shallowest) pillar match wins — so a deeper numbered question
+            # that repeats a pillar keyword (e.g. the analytics lens's
+            # "15 - Sustainability implementation guidance" under the
+            # "Sustainability" pillar) can't overwrite the clean pillar name.
+            matched = matches_pillar(title)
+            if matched and section is None:
+                current_section = matched
+            else:
+                current_section = section
 
             if "contents" in item:
                 # Branch node — recurse deeper, passing along the current section context

--- a/scripts/crawl-wa-framework.py
+++ b/scripts/crawl-wa-framework.py
@@ -16,12 +16,16 @@ Architecture:
     clean markdown, and group all BPs belonging to the same WA question into a
     single consolidated file.
 
-Two content modes are supported:
-    1. BP-style (modern pillars + newer lenses like GenAI, Agentic AI):
+Three content modes are supported:
+    1. BP-style (modern pillars + newer lenses like GenAI, Agentic AI, ML):
        TOC titles follow the pattern "{PREFIX}{NUM}-BP{NUM} Title".
        Output: one file per question, containing all BPs for that question.
 
-    2. Topic-page-style (older lenses like Serverless, Migration):
+    2. Dotted-BP-style (e.g. DevOps Guidance):
+       TOC titles follow the bracketed dotted pattern "[AREA.SUB.N] Title".
+       Output: one file per best practice, named by its ID (OA.LS.1 -> OALS01.md).
+
+    3. Topic-page-style (older lenses like Serverless, Migration, Data Analytics):
        TOC has no BP-pattern titles. Instead, content is organized under
        pillar section headings with leaf pages containing guidance.
        Output: one file per pillar section, containing all pages for that section.
@@ -443,10 +447,12 @@ def discover_leaf_pages(toc_json: dict, pillar_sections: list[str] | None = None
     actual guidance. This function finds all leaf pages (pages with no
     children) that live under a recognized pillar section heading.
 
-    A page qualifies if:
-    - It has no "contents" key (it's a leaf, not a branch)
-    - It's nested at depth >= 2 (under a pillar section, not top-level nav)
-    - Its ancestor section matches one of the known pillar names
+    A page qualifies if it is a leaf (no "contents") whose section resolves to
+    a known pillar name, AND either:
+    - it's nested at depth >= 2 (a leaf under a pillar section — the common case), or
+    - the leaf IS the pillar node itself (a pillar expressed as a single content
+      page with no child best practices, e.g. the serverless lens's
+      "Sustainability" at depth 1).
 
     Returns a list of dicts with keys: section, title, href.
     """
@@ -653,14 +659,18 @@ def crawl_lens(lens_url: str, lens_name: str, output_dir: Path, delay: float, dr
     Crawl a WA Lens and produce reference files.
 
     Lenses use the same toc-contents.json pattern as pillars. This function
-    auto-detects the content format:
+    auto-detects the content format (the three modes are mutually exclusive —
+    a title matches at most one pattern):
 
-    - If the TOC contains BP-pattern entries (e.g., "GENSEC01-BP01"), it uses
-      the same BP-style crawling as pillars: group by question, one file per question.
+    - Dotted-BP-style: TOC has bracketed dotted IDs (e.g. "[OA.LS.1] ...", DevOps
+      Guidance). One file per best practice, named by ID (OA.LS.1 -> OALS01.md).
 
-    - If no BP entries are found (older lenses like Serverless), it falls back to
-      topic-page-style: finds leaf pages under pillar section headings, groups them
-      by section, and writes one file per section.
+    - BP-style: TOC has "{PREFIX}{NUM}-BP{NUM}" entries (e.g. "GENSEC01-BP01").
+      Same crawling as pillars: group by question, one file per question.
+
+    - Topic-page-style: no BP-pattern titles (older lenses like Serverless,
+      Migration, Data Analytics). Finds leaf pages under pillar section headings,
+      groups them by section, and writes one file per section.
 
     The lens URL can point to any page in the lens docs (welcome.html, the lens
     main page, etc.) — the script derives the base URL and toc-contents.json path
@@ -784,8 +794,8 @@ def crawl_lens(lens_url: str, lens_name: str, output_dir: Path, delay: float, dr
         print(f"\n  Done: {written} files, {total} best practices -> {output_dir}/")
 
     else:
-        # --- Topic-page-style lens (Serverless, Migration, DevOps Guidance) ---
-        # These older lenses don't use individual BP pages. Instead, guidance is
+        # --- Topic-page-style lens (Serverless, Migration, Data Analytics) ---
+        # These lenses don't use individual BP-ID pages. Instead, guidance is
         # organized as topic pages under pillar section headings.
         leaf_pages = discover_leaf_pages(toc_data)
         print(f"  Mode: Topic-page-style ({len(leaf_pages)} pages)")

--- a/scripts/crawl-wa-framework.py
+++ b/scripts/crawl-wa-framework.py
@@ -482,8 +482,13 @@ def discover_leaf_pages(toc_json: dict, pillar_sections: list[str] | None = None
             if "contents" in item:
                 # Branch node — recurse deeper, passing along the current section context
                 walk(item["contents"], current_section, depth + 1)
-            elif current_section and href and depth >= 2:
-                # Leaf page under a pillar section — this is content we want
+            elif current_section and href and (depth >= 2 or matched):
+                # Capture this leaf when either:
+                #  - it sits under a pillar section (depth >= 2), the common case; or
+                #  - the leaf IS the pillar (matched): some lenses express a whole
+                #    pillar as a single content page with no child best practices
+                #    (e.g. the serverless lens's "Sustainability" at depth 1).
+                #    Without this, that pillar's content is silently dropped.
                 results.append({
                     "section": current_section,
                     "title": title,

--- a/skills/wa-review/SKILL.md
+++ b/skills/wa-review/SKILL.md
@@ -177,6 +177,7 @@ Available lenses:
 - `references/lenses/migration/` — Assess, Mobilize, Migrate phases per pillar
 - `references/lenses/devops-guidance/` — CI/CD, automated governance, development lifecycle, observability, security testing
 - `references/lenses/machine-learning/` — ML lifecycle (MLOPS), model training/deployment, data engineering, responsible ML
+- `references/lenses/data-analytics/` — data pipelines, governance, data catalogs, lineage, analytics performance and cost
 
 ## Step 5: Risk Assessment
 

--- a/skills/wa-review/SKILL.md
+++ b/skills/wa-review/SKILL.md
@@ -176,6 +176,7 @@ Available lenses:
 - `references/lenses/hybrid-networking/` — Direct Connect, VPN, Transit Gateway, DNS
 - `references/lenses/migration/` — Assess, Mobilize, Migrate phases per pillar
 - `references/lenses/devops-guidance/` — CI/CD, automated governance, development lifecycle, observability, security testing
+- `references/lenses/machine-learning/` — ML lifecycle (MLOPS), model training/deployment, data engineering, responsible ML
 
 ## Step 5: Risk Assessment
 

--- a/skills/wa-review/references/lenses/data-analytics/cost-optimization.md
+++ b/skills/wa-review/references/lenses/data-analytics/cost-optimization.md
@@ -1,0 +1,420 @@
+# Cost optimization
+
+**Pages**: 11
+
+---
+
+# Best practice 11.1 – Decouple storage from compute
+
+It’s common for data assets to grow exponentially year over
+year. However, your compute needs might not grow at the same
+rate. Decoupling storage from compute allows you to manage
+the cost of storage and compute separately, and implement
+different cost optimization features to minimize cost.
+
+## Suggestion 11.1.1 – Use services that decouple compute from storage
+
+Services that allow independent scaling of storage and compute allow for greater flexibility when handling workloads. This means when your workload is compute intensive you do not need to deploy a large storage array to meet the compute power for running your workload.
+
+## Suggestion 11.1.2 – Use Amazon Redshift RA3 instances types
+
+Amazon Redshift RA3 instance types support the ability to
+decouple the compute and storage. This allows your Amazon Redshift storage to scale independently from your compute
+resources, which improves cost efficiencies for your data
+warehousing workloads.
+
+## Suggestion 11.1.3 – Use a decoupled ﬁle system for Big Data workloads
+
+The EMR file system (EMRFS) is an implementation of HDFS
+that all Amazon EMR clusters use for reading and writing
+regular files from Amazon EMR directly to Amazon S3. By
+using EMRFS, your organization is only charged for the
+storage used, rather than paying for overprovisioned and
+underutilized HDFS EBS storage.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.1---decouple-storage-from-compute..html*
+
+---
+
+# Best practice 11.2 – Plan and provision capacity for predictable workload usage
+
+For well-defined workloads, planning capacity ahead based on
+average usage pattern helps improve resource utilization and
+avoid over provisioning. For a spiky workload, set up
+automatic scaling to meet user and workload demand.
+
+## Suggestion 11.2.1 – Choose the right instance type based on workload pattern and growth ratio
+
+Consider resource needs, such as CPU, memory, and
+networking that meet the performance requirements of your
+workload. Choose the right instance type and avoid
+overprovisioning. An optimized EC2 instance runs your
+workloads with optimal performance and infrastructure
+cost. For example, choose the smaller instance if your
+growth ratio is low as this allows more granular
+incremental change.
+
+## Suggestion 11.2.2 – Choose the right sizing based on average or medium workload usage
+
+Right sizing is the process of matching instance types and
+sizes to your workload performance and capacity
+requirements at the lowest possible cost. It’s also the
+process of looking at deployed instances and identifying
+opportunities to downsize without compromising capacity or
+other requirements that will result in lower costs.
+
+## Suggestion 11.2.3 – Use automatic scaling capability to meet the peak demand instead of over provisioning
+
+Analytics services can scale dynamically to meet demand. Then, after the demand has dropped below a certain threshold, the service will remove the resources that are no longer needed. The automatic scaling of serverless services enables applications to handle sudden traffic spikes without capacity planning, reducing costs and improving availability.
+
+There are a number of services that can automatically scale, and other services that you need to configure the scaling for. For example, AWS services like Amazon EMR, AWS Glue, and Amazon Kinesis can auto-scale seamlessly in response to usage spikes and remove resources without any configuration.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.2---plan-and-provision-capacity-for-predictable-workload-usage..html*
+
+---
+
+# Best practice 11.3 – Use on-demand instances or serverless capacity for unpredictable workload usage
+
+Serverless services typically only charge for the compute used, or the use of other measures like data processed, but only when there is a workload actively using the service. In contrast, allocating infrastructure yourself often means paying for idle resources.
+
+## Suggestion 11.3.1 – Use Amazon Athena for ad hoc SQL workloads
+
+Amazon Athena is a serverless query service that makes it
+easy to analyze data directly in Amazon S3 using standard
+SQL. With Amazon Athena, you only pay for the queries that
+you run. You are charged based on the amount of data
+scanned per query.
+
+## Suggestion 11.3.2 – Use AWS Glue or Amazon EMR Serverless instead of Amazon EMR on EC2 for infrequent ETL jobs
+
+AWS Glue is a fully managed ETL (extract, transform, and
+load) service that makes it simple and cost-effective to
+categorize your data, clean it, enrich it, and move it
+reliably between various data stores and data streams.
+With AWS Glue jobs, you pay only for the resources used
+during the ETL process. In contrast, Amazon EMR on EC2 is
+typically used for frequently running jobs requiring
+semipersistent data storage.
+
+Amazon EMR Serverless provides a highly cost-effective way to run EMR clusters and data pipelines on an infrequent or intermittent basis. Unlike provisioned clusters that incur hourly charges even when idle, Serverless allows you to spin up a cluster on-demand when a job is submitted, and tear it down automatically once the job completes. This means you only pay for the actual time the cluster is running to process your workload, optimizing costs for infrequent ETL, data processing, or when-necessary analysis jobs.
+
+## Suggestion 11.3.3 – Use serverless resources for unpredictable or spiky workloads
+
+Use serverless analytics services, such as Amazon Redshift Serverless, Amazon EMR, Amazon Athena, Amazon Quick Serverless, and Amazon Managed Streaming for Apache Kafka (Amazon MSK) Serverless, to perform analytical queries, processing and streaming, with pay-as-you-go pricing. This helps remove the cost associated with idle resources.
+
+You can also use serverless resources for development and testing needs.
+
+For more details, see [AWS serverless data analytics pipeline reference architecture](https://aws.amazon.com/blogs/big-data/aws-serverless-data-analytics-pipeline-reference-architecture/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.3---use-on-demand-instance-capacity-for-unpredictable-workload-usage..html*
+
+---
+
+# Best practice 12.1 – Measure data storage and processing costs per user of the workload
+
+Data analytics workloads have recurring stable costs and
+per-use costs, for example, a weekly reporting job with
+relatively static data storage fees or periodic
+unpredictable processing runtime fees. Your organization
+should establish a financial attribution mechanism that
+captures data storage and workload usage when analytics
+systems are run. Using this approach, your end users
+(business unit, team, or individual) can be notified of their
+consumption at regular intervals.
+
+## Suggestion 12.1.1 – Use tagging or other attribution methods to identify workload and data storage ownership
+
+Collaboration between business, IT, and finance team to
+agree on cost allocation, cost ownership, cost charging,
+and budget management. Create budget tracking policy for
+storage and workload using tagging. Agree on the
+governance approach to implement policy (that is, central
+and decentralize), billing allocation, charge back, and
+budget reporting.
+
+For more details, refer to the following information:
+
+- AWS Cloud Financial Management Blog: Cost
+[Tagging
+and Reporting with AWS Organizations](https://aws.amazon.com/blogs/aws-cloud-financial-management/cost-tagging-and-reporting-with-aws-organizations/)
+- AWS Billing and Cost Management and Cost Management User Guide:
+[Reporting
+your budget metrics with budget reports](https://docs.aws.amazon.com/cost-management/latest/userguide/reporting-cost-budget.html),
+[Configuring
+AWS Budgets actions](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-controls.html) and
+[Creating
+an Amazon SNS topic for budget notifications](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-sns-policy.html)
+
+## Suggestion 12.1.2 – Implement cost-visibility and internal bill-back method to aggregate your teams' use of analytics resources
+
+Notify teams of their analytics usage costs periodically. Build dashboards that provide teams visibility into how their work impacts costs to the business using a self-service approach.
+
+You can view and optimize your costs through the AWS Cost and Usage Report and the Cost and Usage Dashboards Operations Solution (CUDOS) reports.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-12.1---measure-data-storage-and-processing-costs-per-user-of-the-workload..html*
+
+---
+
+# Best practice 12.2 – Build local or build centralized data analytics platforms
+
+Teams can establish their own data analytics resources that support their analytical needs locally, rather than extracting information and transferring it to a central location. Decide when teams benefit from building local analytics resources, balancing required agility and team skillset with the need for a centralized analytics platform.
+
+## Suggestion 12.2.1 – Perform regular reviews of analytics operations to determine if the business can benefit from teams managing their own infrastructure
+
+Teams may prefer to own and manage their own infrastructure, as this allows for more flexibility and agility in system design with fewer dependencies. Individual ownership also provides clear cost visibility. In other cases, a shared processing system can be more efficient, where teams send data requests to a central provider. Tracking request volume by team enables cost attribution. A centralized team managing infrastructure benefits multiple groups through increased resource utilization and concentrated expertise. Centralized data repositories make enriching data simpler and provide a single access point. Organizations find centralized analytics helps meet compliance and governance needs.
+
+In summary, there are trade-offs between decentralized team-owned infrastructure providing more flexibility compared to centralized shared infrastructure increasing utilization and governance. Teams and centralized providers can also coordinate, with centralized systems handling some processing and team systems providing customization. The best approach depends on the specific organizational needs and structure.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-12.2-build-local-or-centralized-data-analytics-platforms.html*
+
+---
+
+# Best practice 12.3 – Restrict and record resource allocation permissions using AWS Identity and Access Management (IAM)
+
+To better control costs, create distinct IAM roles that authorize users to provision certain resources. This ensures that only permitted individuals can provision the resources they are allowed to, preventing unauthorized and unnecessary spending.
+
+## Suggestion 12.3.1 – Create a cost governance framework that uses specialized IAM roles, rather than individual users, to provision costly infrastructure
+
+Restrict the authorization to launch costly resources to
+specific IAM roles. For example, certain instances types
+can only be provisioned by certain teams to reduce
+unnecessary expenditure.
+
+## Suggestion 12.3.2 – Track AWS CloudTrail logs to determine overall usage-per-user and role
+
+Track the usage across users and roles to get a clear understanding of resource
+usage. As part of your cost-allocation governance, automatically process the AWS CloudTrail logs so
+that cost allocation is properly attributed to the relevant department.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-12.3---restrict-and-record-resource-allocation-permissions-using-aws-identity-and-access-management-iam..html*
+
+---
+
+# Best practice 13.1 – Remove unused data and infrastructure
+
+Delete data that is out of its retention period, or not
+needed anymore. Delete intermediate-processed data that can
+be removed without business impacts. If the output of
+analytics jobs is not used by anyone, consider removing such
+jobs so that you don't waste resources.
+
+## Suggestion 13.1.1 – Track data freshness
+
+In many cases, maintaining a metadata repository for
+tracking data movement will be worthwhile. This is not
+only to instill confidence in the quality of the data, but
+also to identify infrequently updated data, and unused
+data.
+
+## Suggestion 13.1.2 – Delete data that is out of its retention period
+
+Data that is past its retention period should be deleted
+to reduce unnecessary storage costs. Identify data through
+the metadata catalog that is outside its retention period.
+To reduce human effort, automate the data removal process.
+If data is stored in Amazon S3, use Amazon S3 Lifecycle
+configurations to expire data automatically.
+
+## Suggestion 13.1.3 – Delete intermediate-processed data that can be removed without business impacts
+
+Many steps in analytics processes create intermediate or
+temporary datasets. Ensure that intermediate datasets are
+removed if they have no further business value.
+
+## Suggestion 13.1.4 – Remove unused analytics jobs that consume infrastructure resources but no one uses the job results
+
+Periodically review the ownership, source, and downstream
+consumers of all analytics infrastructure resources. If
+downstream consumers no longer need the analytics job,
+stop the job from running and remove unneeded resources.
+
+## Suggestion 13.1.5 – Use the lowest acceptable frequency for data processing
+
+Data processing requirements must be considered in the business context. There is no value in processing data faster than it is consumed or delivered. For example, in a sales analytics workload, it might not be necessary to perform analytics on each transaction as it arrives. In some cases, only hourly reports are needed by business management. Batch processing the transactions is more eﬃcient and can reduce unnecessary infrastructure costs between batch processing jobs.
+
+## Suggestion 13.1.6 – Compress data to reduce cost
+
+Data compression can significantly reduce storage and query costs. Columnar data formats like Apache Parquet stores data in columns rather than rows, allowing similar data to be stored contiguously. Using Parquet over CSV format can reduce storage costs significantly. Since services like Amazon Redshift Spectrum and Amazon Athena charge for bytes scanned, compressing data lowers the overall cost of using those services.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-13.1-remove-unused-data-and-infrastructure..html*
+
+---
+
+# Best practice 13.2 – Continuously evaluate your provisioned resources and identify overprovisioned workloads
+
+Workload resource utilization can change over time,
+especially with the growth of data or after process
+optimization has occurred. Your organization should review
+resource usage patterns and determine if you require the
+same infrastructure footprint to meet your business goals.
+
+## Suggestion 13.2.1 – Evaluate whether compute resources can be downsized
+
+Investigate your resource utilization by inspecting the
+metrics provided by Amazon CloudWatch. Evaluate whether
+the resources can be downsized to one-level smaller within
+the same instance class. For example, reduce Amazon EMR
+cluster nodes from m5.16xlarge to m5.12xlarge, or the
+number of instances that make up the cluster.
+
+## Suggestion 13.2.2 – Move infrequently used data out of a data warehouse into a data lake
+
+Data that is infrequently used can be moved from the data
+warehouse into the data lake. From there, the data can be
+queried in place or joined with data in the warehouse. Use
+services such as Amazon Redshift Spectrum to query and
+join data in the Amazon S3 data lake, or Amazon Athena to
+query data at rest in Amazon S3.
+
+## Suggestion 13.2.3 – Merge low utilization infrastructure resources
+
+If you have several workloads that all have
+low-utilization resources, determine if you can combine
+those workloads to run on shared infrastructure. In many
+cases, using a pooled resource model for analytics
+workloads will save on infrastructure costs.
+
+## Suggestion 13.2.4 – Move infrequently accessed data into low-cost storage tiers
+
+When designing a data lake or data analytics project,
+consider required access patterns, transaction
+concurrency, and acceptable transaction latency. These
+will inﬂuence where data is stored. It is equally
+important to consider how often data will be accessed.
+Have a data lifecycle plan to migrate data tiers from
+hotter storage to colder, less-expensive storage, while
+still meeting all business objectives.
+
+Transitioning between storage tiers is achieved using
+Amazon S3 Lifecycle policies. These automatically
+transition objects into another tier with lower cost, and
+will even delete expired data. Amazon S3
+Intelligent-Tiering will analyze the data access patterns
+and automatically move objects between tiers.
+
+## Suggestion 13.2.5 – Move to serverless when you don't need always-on infrastructure
+
+For analytics workloads that have intermittent or unpredictable usage patterns, moving to AWS serverless can provide significant cost savings compared to provisioned servers. AWS serverless analytics services like Amazon Athena, EMR Serverless, and Amazon Redshift Serverless are great options that provide on-demand access without having to provision always-on resources. These services automatically start up when needed and shut down when not in use so you don't have to pay for idle capacity.
+
+For example, with Amazon Redshift Serverless, you pay for compute only when the data warehouse is in use. By using Amazon Redshift Serverless for tasks such as loading data and leveraging Amazon Redshift data sharing, you can scale down your main cluster and still maintain the same performance for end users.
+
+For more detail, refer to the following:
+
+- [Easy analytics and cost optimization with Amazon Redshift Serverless](https://aws.amazon.com/blogs/big-data/easy-analytics-and-cost-optimization-with-amazon-redshift-serverless/)
+- [Amazon EMR Serverless cost estimator](https://aws.amazon.com/blogs/big-data/amazon-emr-serverless-cost-estimator/)
+- [Run queries 3x faster with up to 70% cost savings on the latest Amazon Athena engine](https://aws.amazon.com/blogs/big-data/run-queries-3x-faster-with-up-to-70-cost-savings-on-the-latest-amazon-athena-engine/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-13.2---reduce-overprovisioning-infrastructure..html*
+
+---
+
+# Best practice 13.3 – Evaluate and adopt new cost-effective solutions
+
+As AWS releases new services and features, it’s a best
+practice to review your existing architectural decisions to
+ensure that they remain cost effective. If a new or updated
+service can support the same workload but in a much cheaper
+way, consider implementing the change to reduce cost.
+
+## Suggestion 13.3.1 – Set Service Quotas to control resource usage
+
+Some AWS services allow setting Service Quotas per
+account. Service Quotas should be established to prevent
+runaway infrastructure deployment by accident. Ensure that
+Service Quotas are set high enough to cover the expected
+peak usage.
+
+## Suggestion 13.3.2 – Pause and resume resources if the workload is not always required
+
+Use automation to pause and resume resources when the
+resource is unneeded. For example, stop development and
+test Amazon RDS instances that are not used after working
+hours.
+
+## Suggestion 13.3.3 – Switch to a new service or take advantage of new features that can reduce cost
+
+AWS consistently adds new capabilities to enable your
+organization to leverage the latest technologies to
+experiment and innovate more quickly. Your organization
+should review new service releases frequently to
+understand the price and performance, and determine if
+such features can improve cost reduction.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-13.3---evaluate-and-adopt-new-cost-effective-solutions..html*
+
+---
+
+# Best practice 14.1 – Evaluate the infrastructure usage patterns and choose your payment options accordingly
+
+On-demand resources provide immense ﬂexibility with
+pay-as-you-go payment models across multiple scenarios and
+scales. Alternately, Reserved Instances provide significant
+cost saving for workloads that have steady resource
+utilization and serverless options for unpredictable demand. Perform regular workload resource usage
+analysis. Choose the best pricing model to ensure that you
+don’t miss cost optimization opportunities and maximize your
+discounts.
+
+## Suggestion 14.1.1 – Evaluate available payment options of the infrastructure resources of your choice
+
+Review the pricing page for specific AWS services. Each
+service will list the billing metrics, such as runtime or
+gigabytes processed, as well as any discount options for
+dedicated usage. In addition, many AWS analytics services
+offer discounted payment terms, Reserved Instances, or
+Savings Plans, in exchange for a specific usage commitment.
+Almost all AWS services offer the payment for usage on
+demand, meaning you only pay for what you use.
+
+## Suggestion 14.1.2 – For steady, permanent workloads, obtain Reserved Instances or Savings Plans price discounts instead of paying On-Demand Instance pricing
+
+Reserved Instances give you the option to reserve some AWS
+resources for a one- or a three-year term. In turn, you
+will receive a significant discount compared with the
+On-Demand Instance pricing. Workloads that have consistent
+long-term usage are good candidates for the Reserved
+Instance payment option.
+
+## Suggestion 14.1.3 – Use either on-demand, spot or serverless resources during development and in pre-production environments
+
+Development and pre-production environments frequently change and often do not require 100% availability. Use on-demand instances with start and stop resources, or serverless resources in cases where workload utilization is unpredictable, frequently changes, or is only used for portions of the day. You can use spot instances for fault-tolerant and flexible big data analytics applications. Spot instances are available at up to a 90% discount compared to on-demand prices. Spot instances are not suitable for workloads that are inflexible, stateful, fault-intolerant, or tightly coupled between instance nodes.
+
+For more detail, refer to the following:
+
+- [Optimize Cost by Automating the Start or Stop of Resources in Non-Production Environments Spot Instance Best Practices](https://aws.amazon.com/blogs/architecture/optimize-cost-by-automating-the-start-stop-of-resources-in-non-production-environments/)
+- [Optimizing Amazon EC2 Spot Instances with Spot Placement Scores](https://aws.amazon.com/blogs/compute/optimizing-amazon-ec2-spot-instances-with-spot-placement-scores/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-14.1---evaluate-the-infrastructure-usage-patterns-and-choose-your-payment-options-accordingly..html*
+
+---
+
+# Best practice 14.2 – Consult with your finance team and determine optimal payment models
+
+If you use reserved-capacity pricing options, you can reduce
+the infrastructure cost without modifying your workload
+architectures. Collaborate with your finance team on the
+planning and use of purchase discounts.
+
+Make informed decisions regarding various cost factors.
+These include the amount of capacity to reserve, the reserve
+term length, and the choice of upfront payments for their
+corresponding discount rates. The finance team should assist
+your team in determining the best long-term and
+reserved-capacity pricing options. This is because these
+options affect your IT budget plans, such as which month is
+the right moment to pay an upfront charge.
+
+## Suggestion 14.2.1 – Consolidate the infrastructure usage to maximize the coverage of reserved capacity price options
+
+Reserved Instances and Savings Plan purchases apply
+automatically to the resources that will receive the
+largest discount benefit. To maximize your discount
+utilization, consolidate resources in accounts within an
+AWS Organization structure. Allow the purchase commitments
+to apply to other AWS accounts within your organization if
+they are unused in the account for which they are
+purchased.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-14.2---consult-with-your-finance-team-and-determine-optimal-payment-models..html*
+
+---

--- a/skills/wa-review/references/lenses/data-analytics/operational-excellence.md
+++ b/skills/wa-review/references/lenses/data-analytics/operational-excellence.md
@@ -1,0 +1,247 @@
+# Operational excellence
+
+**Pages**: 6
+
+---
+
+# Best practice 1.1 – Validate the data quality of source systems before transferring data for analytics
+
+Data quality can have an intrinsic impact on the success or
+failure of your organization’s data analytics projects. To
+avoid committing significant resources to process potentially
+poor-quality data, your organization should understand the
+quality of the source data, and monitor the changes to data
+quality throughout the data pipeline.
+
+Data source validation can often be performed quickly on a
+subset of the latest data range to look for data defects.
+Such defects include missing values, anomalous data, or
+wrong data types that could fail the analytics job
+completion or lead to completion of the job with inaccurate
+results.
+
+For more details refer to following document:
+
+- AWS Blog:
+[How
+to Architect Data Quality on the AWS Cloud](https://aws.amazon.com/blogs/industries/how-to-architect-data-quality-on-the-aws-cloud/)
+- AWS Blog: [Getting started with AWS Glue Data Quality from the AWS Glue Data Catalog](https://aws.amazon.com/blogs/big-data/getting-started-with-aws-glue-data-quality-from-the-aws-glue-data-catalog/)
+
+## Suggestion 1.1.1 – Implement data quality validation mechanisms
+
+The critical attributes of data quality that should be measured and tracked
+through your environment are completeness, accuracy, and uniqueness. Validating and
+measuring your data quality using metrics is important to build trust in your data, which
+increases data adoption throughout your organization.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog: [Set up advanced rules to validate quality of multiple datasets with AWS Glue Data
+Quality](https://aws.amazon.com/blogs/big-data/set-up-advanced-rules-to-validate-quality-of-multiple-datasets-with-aws-glue-data-quality/)
+- AWS Big Data Blog: [Getting started with AWS Glue Data Quality for ETL Pipelines](https://aws.amazon.com/blogs/big-data/getting-started-with-aws-glue-data-quality-for-etl-pipelines/)
+- AWS Big Data Blog: [Set up alerts and orchestrate data quality rules with AWS Glue Data Quality](https://aws.amazon.com/blogs/big-data/set-up-alerts-and-orchestrate-data-quality-rules-with-aws-glue-data-quality/)
+- AWS Big Data Blog:
+[Enforce
+customized data quality rules in AWS Glue DataBrew](https://aws.amazon.com/blogs/big-data/enforce-customized-data-quality-rules-in-aws-glue-databrew/).
+- AWS Big Data Blog:
+[Build
+a data quality score card using AWS Glue DataBrew,
+Amazon Athena, and Quick](https://aws.amazon.com/blogs/big-data/build-a-data-quality-score-card-using-aws-glue-databrew-amazon-athena-and-amazon-quicksight/).
+
+## Suggestion 1.1.2 – Notify stakeholders and use business logic to determine how to remediate data that is not valid
+
+Alerts and notifications play a crucial role in maintaining data quality because they facilitate prompt and efficient responses to any data quality issues that may arise within a dataset. By establishing and configuring alerts and notifications, you can actively monitor data quality and receive timely alerts when data quality issues are identified. This proactive approach helps mitigate the risk of making decisions based on inaccurate information.
+
+It’s usually more efficient to impute missing values, but in
+other cases it’s more efficient to block processing until
+the data quality issue can be resolved at source.
+
+## Suggestion 1.1.3 – Score and share the quality of your datasets
+
+To improve the ongoing trust in data quality and adoption
+of your organization’s datasets, consider creating a data
+quality matrix that can be accessed by the relevant teams
+advertising the quality score of your datasets and
+potential issues with the data. This information can be
+incorporated in your Data Catalog.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-1.1---validate-the-data-quality-of-source-systems-before-transferring-data-for-analytics..html*
+
+---
+
+# Best practice 1.2 – Monitor operational metrics of data processing jobs and the availability of source data
+
+Data processing pipelines often consist of multiple steps that all need to run in sequence to output the desired data sets and meet business deadlines. Monitoring each job in the pipeline is key to ensure operational excellence. The operational metrics of the jobs themselves should be monitored, as well as the availability of source data, and that results are produced.
+
+For example, if your pipeline runs on a fixed schedule, and there is no new source data to process, the pipeline may still appear healthy because it runs without failures. Similarly, if the pipeline runs when new source data becomes available, it can appear healthy when no new source data becomes available if you only alert on failed runs.
+
+## Suggestion 1.2.1 – Alert when new data has not arrived or become available within the expected time
+
+You should monitor the time when new data arrives or becomes available, and alert when too much time has passed since the last occurrence. Even if the jobs in your data processing pipeline runs flawlessly, the quality of the results depend on the quality and availability of the source data.
+
+In a complex data pipeline it can also be necessary to monitor that one stage produces results within an expected time frame as it affects downstream stages.
+
+## Suggestion 1.2.2 – Alert when data processing jobs don’t complete on time or don’t produce results
+
+You should monitor the running time of data processing jobs and alert when too much time has passed since the last completed run. You should also alert if a job does not produce a result. With monitoring and alerts you can discover jobs that fail, and also jobs that fail silently by not producing results.
+
+The expected completion time should be based on the normal running time of the job, with some margin. The margin is needed because the running time of data processing jobs depend on the amount of data they process. Jobs that start as a result of new data becoming available also don’t have a set starting time, which should be factored into the margin.
+
+For very long running jobs it can also be necessary to monitor the start time of jobs, and alert when too much time has passed since the last start. Sometimes it can cause too much delay to wait until the expected completion time before the failure is discovered.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-1.2---monitor-operational-metrics-of-data-processing-jobs-and-the-availability-of-source-data..html*
+
+---
+
+# Best practice 2.1 – Use version control for job and application changes
+
+Version control systems support tracking changes and the
+ability to revert to previous versions of an analytics
+system should changes cause unintended consequences. Your
+team should version control code repositories for both
+analytics infrastructure as code (IaC) and analytics
+applications logic.
+
+## Suggestion 2.1.1 – Use infrastructure as code and version control systems so that a failed deployment can be rolled back to a previous good state
+
+Follow software development best practices when building
+analytics systems. For example, deploy resources using
+code templates, such as AWS CloudFormation or Hashicorp
+Terraform, so that all deployments occur exactly as
+intended. Use version control systems (for example, code
+repositories such as GitHub) to hold
+current and previous versions of your code templates.
+Using these tools, if a new change results in unwanted
+outcomes, you can easily roll back to the previous code
+template.
+
+For more details, refer to the following information:
+
+- AWS Whitepaper:
+[Introduction
+to DevOps on AWS](https://docs.aws.amazon.com/whitepapers/latest/introduction-devops-aws/infrastructure-as-code.html)
+- AWS Blog:
+[Automate
+building an integrated analytics solution with AWS
+Analytics Automation Toolkit](https://aws.amazon.com/blogs/big-data/automate-building-an-integrated-analytics-solution-with-aws-analytics-automation-toolkit/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.1---use-version-control-for-job-and-application-changes..html*
+
+---
+
+# Best practice 2.2 – Create test data and provision staging environment
+
+Using a known and unchanging dataset for test purposes helps
+ensure that when changes are made to the analytics
+environment or analytics application code, test results can
+be compared to previous versions.
+
+Confirming that the test datasets accurately represent
+real-world data allows the analytics workload developer to
+confirm the outcomes from the analytics job, as well as
+comparing test results to previous versions.
+
+Your organization should use a staging environment for user
+access testing. Your organization should create logically separated AWS accounts for your development, test, staging, and production
+environments depending upon your development standards.
+
+For more details, refer to the following information:
+
+AWS Whitepaper:
+[Establishing
+your best practice AWS environment](https://docs.aws.amazon.com/whitepapers/latest/organizing-your-aws-environment/organizing-your-aws-environment.html)
+
+## Suggestion 2.2.1 – Use a curated dataset to test application logic and performance improvements
+
+Analytics projects that are being developed should use the
+same curated dataset to compare results between tests of
+different versions of your code. Using the same dataset for
+all tests allows demonstrating improvement over time, as
+well as making it easier to recognize regressions in your
+code.
+
+To help control access to sensitive data, your
+organization should use data masking techniques when
+restoring development data to non-production environments.
+More information on data minimization techniques can be
+found in [Security](./security.html).
+
+For more details, refer to the following information:
+
+- AWS Database Blog: [Data Masking using AWS DMS (AWS
+Data Migration Service)](https://aws.amazon.com/blogs/database/data-masking-using-aws-dms/)
+- Amazon Redshift Data Masking: [Dynamic data masking
+(DDM) in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/t_ddm.html)
+
+## Suggestion 2.2.2 – Use a random sample of recent data to validate application edge cases and help ensure that regressions have not been introduced
+
+Use a statistically valid random sample of recent data to
+confirm that the analytics solution continues to perform
+under real-world conditions. Using a sample of recent data
+also allows you to recognize whether your dataset
+characteristics have shifted, or whether anomalous data
+has recently been introduced to your data.
+
+For more information, see the AWS Machine Learning Blog: [Create random and stratified samples of data with Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/blogs/machine-learning/create-random-and-stratified-samples-of-data-with-amazon-sagemaker-data-wrangler/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.2---create-test-data-and-provision-staging-environment..html*
+
+---
+
+# Best practice 2.3 – Test and validate analytics jobs and application deployments
+
+Before making changes in production environments, use
+standard and repeatable automated tests to validate
+performance and accuracy of results.
+
+## Suggestion 2.3.1 – Establish separate staging environments to test changes before going live
+
+Use separate environments, such as development, test, and
+production, to allow feature development to be introduced
+without disrupting production systems. Test changes for
+accuracy and performance before changes are deployed into
+the production environment.
+
+## Suggestion 2.3.2 – Automate the deployment and testing when infrastructure and applications changes are introduced
+
+The deployment of data pipelines and data infrastructure changes should be an automated process. When code is checked into version control, a CI/CD process should run tests and apply the changes to the staging environment, and once tested and confirmed correct, it should be deployed to the production environment.
+
+You can use the AWS CodePipeline service to define a CI/CD process.
+
+For more details refer to the following information:
+
+- AWS Perspective Guidance:
+[Deploy
+an AWS Glue job with an AWS CodePipeline CI/CD
+pipeline](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/deploy-an-aws-glue-job-with-an-aws-codepipeline-ci-cd-pipeline.html)
+- AWS DevOps Blog:
+[How
+to unit test and deploy AWS Glue jobs using AWS CodePipeline](https://aws.amazon.com/blogs/devops/how-to-unit-test-and-deploy-aws-glue-jobs-using-aws-codepipeline/)
+- AWS DevOps Blog: [10 ways to build applications faster with Amazon CodeWhisperer](https://aws.amazon.com/blogs/devops/10-ways-to-build-applications-faster-with-amazon-codewhisperer/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.3---test-and-validate-analytics-jobs-and-application-deployments..html*
+
+---
+
+# Best practice 2.4 – Build standard operating procedures for deployment, test, rollback, and backfill tasks
+
+Standard operating procedures for deployment, test,
+rollback, and data backfill tasks allow faster deployments,
+reduce the number of errors that reach production. Using a
+standard approach also makes remediation easier if a
+deployment results in unintended consequences.
+
+## Suggestion 2.4.1 – Document and use standard operating procedures for implementing changes in your analytics workload
+
+Standard operating procedures allow teams to make changes
+confidently, thus avoiding repeatable mistakes and reducing
+the chance of human error.
+
+## Suggestion 2.4.2 – Use automation to perform changes to underlying analytics infrastructure or application logic
+
+Automated tests can determine when changes have unintended
+consequences and can roll back without human intervention.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-2.4---build-standard-operating-procedures-for-deployment-test-rollback-and-backfill-tasks..html*
+
+---

--- a/skills/wa-review/references/lenses/data-analytics/performance-efficiency.md
+++ b/skills/wa-review/references/lenses/data-analytics/performance-efficiency.md
@@ -1,0 +1,292 @@
+# Performance efficiency
+
+**Pages**: 10
+
+---
+
+# Best practice 8.1 – Identify analytics solutions that best suit your technical challenges
+
+AWS has multiple analytics processing services that are
+built for specific purposes. These include Amazon Redshift
+for data warehousing, Amazon Kinesis for streaming data, and
+Quick for data visualization. Your organization
+should consider each step of the data analytics process as
+an opportunity to identify the right tool for the job.
+
+## Suggestion 8.1.1 – Identify the requirements based on the collected business metrics
+
+Applications and services are designed to overcome
+specific challenges. It’s essential that your organization
+identifies the right tool for the right job to meet your
+business and technical requirements. Choosing inappropriate technology can introduce performance issues,
+especially when processing data at scale.
+
+For more details, refer to the following information:
+
+- AWS Right Tool for the Job:
+[Databases
+on AWS: The Right Tool for the Right Job](https://www.youtube.com/watch?v=WE8N5BU5MeI)
+- AWS Right Tool for the Job:
+[How
+to Choose the Right Database](https://aws.amazon.com/startups/start-building/how-to-choose-a-database/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.1-identify-analytics-solutions-that-best-suit-your-technical-challenges..html*
+
+---
+
+# Best practice 8.2 – Provision the compute resources to the location of the data storage
+
+Data analytics workloads require moving data through a
+pipeline, either for ingesting data, processing intermediate
+results, or producing curated datasets. It is often
+more efficient to select the location of data processing
+services near where the data is stored. This approach is
+preferred instead of copying or streaming large amounts
+of data to the processing location. For example, if an
+Amazon Redshift cluster frequently ingests data from a data
+lake, ensure that the Amazon Redshift cluster is in the same
+Region as your data lake S3 buckets.
+
+This extends to considering where your compute and storage are located at the Availability Zone level. Co-locating in the same Availability Zone allows fast, lower latency access. It is still important, however, to replicate data across zones when required.
+
+## Suggestion 8.2.1 – Migrate or copy primary data stores from on-premises environments to AWS so that cloud compute and storage are closely located
+
+Minimize duplication of data when transferring datasets from on-premises storage to the cloud. Instead, create copies of your data near the analytics platform to avoid data transfer latency and improve overall performance of the analytics solution. For optimal performance, keep your data and analytics systems in the same AWS Region. If they are in separate Regions, relocate one of them.
+
+## Suggestion 8.2.2 – Consider where your analytics resources are placed
+
+For optimal performance, your organization should align the location of the data with the location of the resources that process it. Where possible, your organization should
+consider using a permanent Region for all data analytics
+processing as this will help with data transferring
+overhead.
+
+## Suggestion 8.2.3 – Consider the use of provisioned compared to serverless offerings to match your workload pattern
+
+When considering services for ingesting, transforming, and analyzing your data, there is often the choice between provisioned or serverless solutions. There are many trade-offs and potential advantages of each, but from a performance perspective, it can be beneficial to use serverless offerings when your workloads are consistently and unpredictably spikey. Whereas provisioned deployments may offer advantages when you have more stable, predictable workloads.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.2---provision-the-compute-resources-to-the-location-of-the-data-storage..html*
+
+---
+
+# Best practice 8.3 – Define and measure the computing performance metrics
+
+Define how you will measure performance of the analytics
+solutions for each step in the process. For example, if the
+computing solution is a transient Amazon EMR cluster, you
+can take the following approach. Define the performance as
+the Amazon EMR job runtime from the launch of the EMR
+cluster, process the job, then shut down the cluster. As
+another example, if the computing solution is an Amazon Redshift cluster that is shared by a business unit, you can
+define the performance as the runtime duration for each SQL
+query.
+
+## Suggestion 8.3.1 – Define performance efficiency metrics
+
+Collect and use metrics to scale the resources to meet
+business requirements. By doing so, your team can track
+unexpected spikes to make future improvements.
+
+## Suggestion 8.3.2 – Continually identify under-performing components and ﬁne-tune the infrastructure or application logic
+
+After you have deﬁned the performance measurement, you should identify which infrastructure components or jobs are running below the performance criteria. Performance ﬁne-tuning varies for each AWS service, but generally, optimizing queries or workloads can enhance performance without necessitating infrastructure modifications. For example, if it is an Amazon EMR cluster running a Spark application, you could explore tuning your Spark configuration. If after fine-tuning you still need more performance, you can change to a larger cluster instance type, or increase the number of cluster nodes.
+
+For an Amazon Redshift cluster, you can ﬁne-tune the SQL queries that are running below the performance criteria and if required, increase the number of cluster nodes to increase parallel computing capacity.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.3---define-and-measure-the-computing-performance-metrics..html*
+
+---
+
+# Best practice 9.1 – Identify critical performance criteria for your storage workload
+
+In data analytics, throughput is often a constraining
+factor to enable your workloads to run effectively.
+Throughput is measured by the amount of information that has
+successfully moved through the network, compute, or storage
+layers. Improving throughput in each of these layers
+generally results in better query performance.
+
+## Suggestion 9.1.1 – Use performance monitoring tools to determine if the analytics system performance is limited by compute, storage, or networking
+
+Use a metric collection and reporting system, such as
+Amazon CloudWatch, to analyze the performance
+characteristics of the analytics system. Evaluate the
+measured performance metrics relative to system reference
+documentation to characterize the system constraints for
+the workload as a percentage of maximum performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-9.1---identify-critical-performance-criteria-for-your-storage-workload..html*
+
+---
+
+# Best practice 9.2 – Identify and evaluate the available storage options for your compute solution
+
+Many AWS data analytics services allow you to use more than
+one type of storage. For example, Amazon Redshift allows
+access to data stored in the compute nodes in addition to
+data stored in Amazon S3. When performing research on each
+data analytics service, evaluate relevant storage options
+to determine the most performance efficient solution that
+meets business requirements.
+
+## Suggestion 9.2.1 – Review the available storage options for the analytics services being considered
+
+There are often multiple storage options available for each service, each offering different characteristics and potentially performance benefits. It is important to review these available options and determine which may best fit your requirements.
+
+For example, Amazon EMR provides local storage via HDFS
+file system and Amazon S3 as an external storage via EMRFS.
+For more information, refer to the AWS documentation for
+your compute solution:
+
+- Amazon EMR Management Guide:
+[Work
+with storage and file systems](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-file-systems.html)
+- Amazon Redshift Cluster Management Guide:
+[Overview
+of Amazon Redshift clusters](https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#working-with-clusters-overview)
+- Amazon OpenSearch Service Developer Guide:
+[Managing](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managing-indices.html)
+[indices
+in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managing-indices.html)
+- Amazon Aurora User Guide:
+[Overview
+of Aurora storage](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.StorageReliability.html#Aurora.Overview.Storage)
+
+## Suggestion 9.2.2 – Evaluate the performance of the selected storage option
+
+To ensure that the overall analytics system design meets
+your non-functional requirements, evaluate the performance
+by running simulated real-world tests in a test
+environment.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-9.2-identify-evaluate-available-storage-options.html*
+
+---
+
+# Best practice 9.3 – Choose the optimal storage based on access patterns, data growth, and the performance requirements
+
+Storage options for data analytics can have performance
+tradeoffs based on access patterns and data size. For
+example, in Amazon S3, can be much more efficient to retrieve a smaller number of larger objects, as opposed to a larger number of smaller objects.
+
+Evaluate your workload needs and usage patterns
+to determine if the method or location of storing your data
+can improve the overall efficiency of your solution.
+
+## Suggestion 9.3.1 – Identify available solution options for the performance improvement
+
+When data I/O is limiting performance and business
+requirements are not being met, improve I/O through the
+options available within that service. For example, with
+EBS volumes of GP3 type, increase Provisioned IOPS or
+throughput, or for Amazon Redshift, increase the number of
+nodes.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-9.3---choose-the-optimal-storage-based-on-access-patterns-data-growth-and-the-performance-metrics..html*
+
+---
+
+# Best practice 10.1 – Select format based on data write frequency and patterns for append-only compared to in-place update
+
+Review your data storage write patterns and performance requirements for streaming and batch workloads. Streaming workloads may require you to write smaller files at a higher frequency compared to batch workloads. This enables your streaming applications to reduce latency but can impact read and write performance of the data.
+
+## Suggestion 10.1.1 – Understand your analytics workload data’s write characteristics
+
+If storing data in Amazon S3, evaluate if an append-only
+method, such as Apache Hudi, is right for your needs.
+
+There are also table formats available, such as Apache Hudi, Apache Iceberg and Delta Lake that can, amongst other capabilities, provide transactional semantics over data tables in Amazon S3. These formats can also provide improved query times through the use of additional metadata. For more detail on getting started with these formats, see [Introducing native support for Apache Hudi, Delta Lake, and Apache Iceberg on AWS Glue for Apache Spark, Part 1: Getting Started](https://aws.amazon.com/blogs/big-data/part-1-getting-started-introducing-native-support-for-apache-hudi-delta-lake-and-apache-iceberg-on-aws-glue-for-apache-spark/).
+
+## Suggestion 10.1.2 – Avoid querying data stored in many small files
+
+Rather than running queries over many small data ﬁles, periodically combine the small ﬁles into a single larger compressed ﬁle for analytics. This approach provides better data retrieval performance when using analytics services. Keep in mind that in streaming use cases there is a tradeoff between latency and throughput, as time is required to batch records. The production of larger files can be done as a post process job rather than necessarily at the point of ingestion.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.1-select-format-based-on-data-write-frequency-and-patterns-for-append-only-vs.-in-place-update..html*
+
+---
+
+# Best practice 10.2 – Choose data formatting based on your data access pattern
+
+Choosing the right data type for your workload is important. There are many different data types available to support your workload. Choosing the right format is a key step in the performance optimization of your analytics workloads.
+
+## Suggestion 10.2.1 – Decide the correct data format for your analytics workload
+
+You can work on unstructured, semi-structured, and structured data formats (CSV,
+JSON, or columnar formats such as Apache Parquet and Apache ORC) with your data stored in Amazon S3 by using Amazon Athena, which lends itself to querying data as-is without the need for data preparation or ETL processes.
+
+You should also consider compression when choosing data formats. Efficient compression can help queries run faster and reduce cost. It can also lead to reductions in the amount of data stored in a storage layer, alongside improved network and I/O throughput. For more information on when to use compression, see 10.3.2.
+
+Using splittable formats is also an option. These formats allow individual files to be broken up so that they can be processed in parallel by multiple workers. Similarly to compression, this can also lead to reductions in query time. Often, you need to choose between compression or splittable formats because applying both is currently not well supported for analytics workloads.
+
+## Suggestion 10.2.2 – API-driven data access pattern constraints, such as the amount of data retrieved per API call, can impact overall performance
+
+If you are calling APIs to ingest, transform or access data, many implement a maximum amount of data or records that can be returned in a call. So, your solution may need to page through and make subsequent API calls to retrieve all results. If a large amount of data is returned this can lead to a long amount of time being spent retrieving the data in this manner. Most APIs have limits and constraints, such as number of calls in a particular time limit, so it is important to consider this, and relevant strategies for dealing with these conditions.
+
+Result caching on API sources can help speed up reads if the same or similar data is frequently queried. Using asynchronous methods can help avoid blocking calls in your processing that would otherwise have to wait for synchronous operations to complete.
+
+## Suggestion 10.2.3 – Use data, results, and query cache to improve performance and reduce reads from the storage tier
+
+Caching services can speed up the responses to common
+queries and reduce the load on the storage tier. Use
+Amazon ElastiCache, DynamoDB Accelerator (DAX), API
+gateway caching, Athena query result reuse, Amazon Redshift Advanced Query Accelerator (AQUA), or other relevant caching services.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.2-choose-data-formatting-based-on-your-data-access-pattern..html*
+
+---
+
+# Best practice 10.3 – Utilize compression techniques to both decrease storage requirements and enhance I/O efficiency
+
+Store data in a compressed format to reduce the burden on
+the underlying storage host and network. For example, for
+columnar data stored in Amazon S3, use a compatible
+compression algorithm that supports parallel reads.
+
+We recommend that your organization test the performance and
+storage overhead of both uncompressed and compressed
+datasets to determine best fit prior to implementing this
+approach.
+
+## Suggestion 10.3.1 – Compress data to reduce the transfer time
+
+When storage read/write performance becomes a bottleneck,
+use compression to reduce data transfer time. Consider the
+tradeoffs between compute time needed to perform compression
+and decompression versus the storage I/O bottleneck in your
+estimates of overall improvements in performance efficiency.
+
+## Suggestion 10.3.2 – Evaluate the available compression options for each resource of the workload
+
+Compressing data can improve the performance as there are
+fewer bytes transferred between the disk and compute
+layers. The trade-off using this approach is that it
+requires more compute for data compression and
+decompression. You can, however, obtain a net efficiency
+improvement if compression performs as well as or better
+than uncompressed data transfer time. Compression also
+requires much less storage, depending on the data type in
+use, thus saving on data storage latency and costs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.3---use-file-compression-to-reduce-number-of-files-and-to-improve-file-io-efficiency..html*
+
+---
+
+# Best practice 10.4 – Partition your data to enable efficient data pruning and reduce unnecessary file reads
+
+Storing your data in structured partitions will allow compute to identify the location of only that portion of the data relevant to the query. Determine the most frequent query parameters and store this data in the appropriate location suited to your data retrieval needs. For example, if an analytics workload regularly generates daily, weekly, and monthly reports, then store your data using partitions with a year/month/day format.
+
+## Suggestion 10.4.1 – Partition data to support the most common query predicates
+
+When your query uses a particular predicate in a WHERE clause, if your data is partitioned according to the field then the query engine can prune the data that it needs to look at and go directly to the relevant data partition. This means a full table scan is avoided, meaning faster performance and lower query cost.
+
+## Suggestion 10.4.2 – Store data partitioned based on time attributes with earlier data stored in tiers that are accessed infrequently
+
+Use the tiering capabilities of the storage service to put
+infrequently-accessed data into the tier that is most
+appropriate for the workload. For example, in an Amazon Redshift data warehouse, data that is accessed
+infrequently can be stored in Amazon S3. Then you can
+query it with Amazon Redshift Spectrum, while more
+frequently-accessed data can be stored in local Amazon Redshift storage.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-10.4---partition-your-data-to-avoid-unnecessary-file-reads..html*
+
+---

--- a/skills/wa-review/references/lenses/data-analytics/reliability.md
+++ b/skills/wa-review/references/lenses/data-analytics/reliability.md
@@ -1,0 +1,254 @@
+# Reliability
+
+**Pages**: 8
+
+---
+
+# Best practice 6.1 – Create an illustration of data flow dependencies
+
+Work with business stakeholders to create a visual illustration of the data pipeline. Identify the systems that interact with each dependency. The key architecture components that are expected to be captured are data acquisition, ingestion, data transformation, data processing, data storage, data protection and governance, and data consumption. All system dependencies need owners. Agree within your organization who owns which dependency.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.1-create-an-illustration-of-data-flow-dependencies..html*
+
+---
+
+# Best practice 6.2 – Monitor analytics systems to detect analytics or extract, transform and load (ETL) job failures
+
+Detect extract, transform, and load (ETL) and analytics job failures as soon as possible. Pinpointing where and how the error occurred is critical for notiﬁcations and corrective actions.
+
+## Suggestion 6.2.1– Monitor and track job errors from different levels, including infrastructure, ETL workﬂow, and ETL application code
+
+Failures can occur at all levels of the analytics system. Each task in the analytics workload should be instrumented to provide metrics indicating the health of the task. Monitor the emitted metrics and raise alarms if any components fail. Create dashboards to visualize metrics and govern access to them.
+
+For more details, refer to the following:
+
+- [Visualize data warehouse metrics: Query and visualize Amazon Redshift operational metrics using the Amazon Redshift plugin for Grafana](https://aws.amazon.com/blogs/big-data/query-and-visualize-amazon-redshift-operational-metrics-using-the-amazon-redshift-plugin-for-grafana/)
+- [Visualize Amazon EMR metrics: Monitor Amazon EMR on Amazon EKS with Amazon Managed Prometheus and Amazon Managed Grafana](https://aws.amazon.com/blogs/mt/monitoring-amazon-emr-on-eks-with-amazon-managed-prometheus-and-amazon-managed-grafana/)
+
+## Suggestion 6.2.2 – Establish end-to-end monitoring for the complete analytics and ETL pipeline
+
+End-to-end monitoring allows tracking the ﬂow of data as
+it passes through the analytics system. In many cases,
+data processing might be dependent on application logic,
+such as sampling a subset of data from a data stream to
+check accuracy. Properly identifying and monitoring the
+end-to-end ﬂow of data allows detecting at which step the
+analytics and ETL job fails.
+
+## Suggestions 6.2.3 – Determine what data was processed when the job failed
+
+Failures in data processing systems can cause data integrity or data quality issues. Determine what data was being processed at the time of failure and perform quality checks of both the input and output data. If possible, roll-back the committed data and restart your job.
+
+For more details, see AWS Glue: [Overview of Data Quality in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/workflows_overview.html).
+
+## Suggestions 6.2.4 – Classify the severity of the job failures based on the type of failure and the business impact
+
+Classifying the severity of different job failures helps you prioritize remediation and guide the notiﬁcation requirements to key stakeholders. Classification of jobs can be agreed upon based on importance and the impact the failure has on meeting internal and external SLAs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.2---monitor-analytics-systems-to-detect-analytics-or-etl-job-failures..html*
+
+---
+
+# Best practice 6.3 – Notify stakeholders about analytics or ETL job failures
+
+Analytics and ETL job failures can impact the SLAs for
+delivering the data on time for downstream analytics
+workloads. Failures might cause data quality or data
+integrity issues as well. Notifying all stakeholders about
+the job failure as soon as possible is important for
+remediation actions needed. Stakeholders may include IT
+operations, help desk, data sources, analytics, and
+downstream workloads.
+
+For more details, see
+AWS Well-Architected:
+[Design
+your Workload to Withstand Component Failures](https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/design-your-workload-to-withstand-component-failures.html)
+
+## Suggestions 6.3.1 – Establish automated notifications to predefined recipients
+
+Use services such Amazon Simple Notification Service
+(Amazon SNS) to send automated emails, SMS alerts, or both
+in the event of failure. Store the alert logs in an
+immutable data store for future reference.
+
+## Suggestions 6.3.2 – Do not include sensitive data in notifications
+
+Automated alerts often include indicators of useful information for troubleshooting the failure. Ensure PII and sensitive information, such as personal, medical, or ﬁnancial information is not shared in failure notiﬁcations.
+
+For more details, see AWS Glue: [Detect and process sensitive data](https://docs.aws.amazon.com/glue/latest/dg/detect-PII.html).
+
+## Suggestions 6.3.3 – Integrate the analytics job failure notification solution with the enterprise operation management system
+
+Where possible, integrate automated notifications into
+existing operations management tools. For example, an
+operations support ticket can be automatically filed in the
+event of a failure. That same ticket can automatically be
+resolved if the analytics system recovers on retry.
+
+## Suggestions 6.3.4 – Notify IT operations and help desk teams of any ETL job failures
+
+Normally, the IT operations team should be the first
+contact for production workload failures. The IT
+operations team troubleshoots and attempts to recover the
+failed job, if possible. It is also helpful to notify the
+IT help desk of system failures that have an end user
+impact. These can include issues with the data warehouse
+used by the business intelligence (BI) analysts.
+
+## Suggestions 6.3.5 – Notify downstream systems of data freshness
+
+Monitor data updates as this gives process and application information when data becomes stale. Stale data can lead to misreporting due to the correct values being stale and not current.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.3---notify-stakeholders-about-analytics-or-etl-job-failures..html*
+
+---
+
+# Best practice 6.4 – Automate the recovery of analytics and ETL job failures
+
+Many factors can cause analytics and ETL jobs to fail. Job
+failures can be recovered using automated recovery
+solutions, however, others might require manual
+intervention. Designing and implementing an automated
+recovery solution can help reduce the impact of the job
+failures and streamline IT operations.
+
+## Suggestions 6.4.1– Discover recovery procedures that work for multiple failure types
+
+Conﬁgure automatic retries to handle intermittent network disruptions. Conﬁgure managed scaling to ensure that there are sufficient resources available for jobs to complete within speciﬁc time limits.
+
+## Suggestions 6.4.2 – Limit the number of automatic reruns and create log entries for the automatic recovery attempts and results
+
+Track the number of reruns an automated recovery process has attempted. Limit the number of reruns to avoid unnecessary reruns and resources. Track the number of recovery attempts and outcomes to identify failure trends and drive future improvements.
+
+## Suggestion 6.4.3 – Design the job recovery solution based on the delivery SLA
+
+Build systems that can meet SLA requirements even if jobs must be retried or manually recovered. Consider the service-level agreements of the different services that you use, and monitor the performance of your jobs against your organization’s internal SLAs.
+
+## Suggestion 6.4.4 – Consider idempotency when designing ETL jobs
+
+To avoid unexpected outcomes when automatically rerunning pipelines such as duplicated or stale data, enforce idempotency where possible. Idempotent ETL jobs can be rerun with the same result or outcome. Some strategies to achieve this are the overwriting method (for example, Spark overwrite) and the delete-write method (deleting existing data prior to writing it to ensure that there are no duplicates or stale data), although deletion should be applied with caution.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.4-automate-the-recovery-of-analytics-and-etl-job-failures..html*
+
+---
+
+# Best practice 6.5 – Build a disaster recovery (DR) plan for the analytics infrastructure and the data
+
+Discuss with business stakeholders to understand maximum
+amount of data loss (RPO) and maximum amount of service loss
+(RTO).
+
+## Suggestion 6.5.1 – Confirm the business requirement of the disaster recovery (DR) plan
+
+Agree with the business shareholders what the internal and
+external SLAs are for your analytics processes. For
+example, not all business reports are business critical so
+it’s important that your DR plans are aligned with the
+severity of the outage.
+
+## Suggestion 6.5.2 – Design the disaster recovery (DR) solution for each layer of the solution
+
+Review the architecture for your data and analytics pipeline and select the DR pattern that meets your DR requirements, working backwards from the most important information that must be saved in the event of a DR scenario, to the least important.
+
+## Suggestion 6.5.3 – Implement and test your backup solution based on the RPO and RTO
+
+Backup solutions must be implemented to reduce data loss. Test your backup to ensure it is performing correctly by periodically restoring the data and validating the results.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-6.5---build-a-disaster-recovery-dr-plan-for-the-analytics-infrastructure-and-the-data..html*
+
+---
+
+# Best practice 7.1 – Build a central Data Catalog to store, share, and track metadata changes
+
+Building a central Data Catalog to store, share, and manage metadata across the organization is an integral part of data governance. This will promote standardization and reuse. Tracing metadata change history in the central Data Catalog helps you manage and control version changes in the metadata. A Data Catalog is often required for auditing and compliance but by incorporating business context to a Data Catalog, it allows users in the organization to discover data assets using business terms rather than technical naming conventions.
+
+## Suggestion 7.1.1 – Changes on the metadata in the Data Catalog should be controlled and versioned
+
+Use the Data Catalog change tracking features. For example, when the schema
+changes, AWS Glue Data Catalog will track the version change. You can use AWS Glue to compare
+schema versions, if needed. In addition, we recommend a change control process that only
+allows those authorized to make schema changes in your Data Catalog. The AWS Glue Schema registry allows you to centrally discover and control data schemas. You can create a schema contract between producers and consumers to improve data consumer awareness to data format changes.
+
+## Suggestion 7.1.2 – Capture and publish business metadata of your data assets
+
+Capturing business metadata and publishing it with metadata assets is essential for data consumers and data stewards alike. Metadata such as regulatory compliance statuses, data classification, and other important data governance characteristics, guides consumers on how to best process the data and informs data governance processes conducted by data stewards. Establishing a business glossary across the organization creates a collection of business terms that can be associated with the data assets. This ensures that business definitions are common across the organization.
+
+For more details, see AWS Data Zone: [Governed Analytics](https://aws.amazon.com/datazone/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-7.1---build-a-central-data-catalog-to-store-share-and-track-metadata-changes..html*
+
+---
+
+# Best practice 7.2 – Monitor for data quality anomalies
+
+Data quality is critical for organizations to accurately measure important business metrices, bad data can impact the accuracy of analytics insights and ML predictions. Monitor data quality and detect data anomalies as early as possible.
+
+For more details, see AWS Glue: [Getting started with AWS Glue Date Quality](https://aws.amazon.com/blogs/big-data/getting-started-with-aws-glue-data-quality-from-the-aws-glue-data-catalog/).
+
+## Suggestion 7.2.1 – Include a data quality check stage in the ETL pipeline as early as possible
+
+A data quality check helps ensure that bad data is
+identified and fixed as soon as possible to prevent bad data
+from propagating downstream.
+
+## Suggestion 7.2.2 – Understand the nature of your data and determine the types of data anomalies that must be monitored and fixed based on the business requirements
+
+The analytics workload can process various types of data,
+such as structured, unstructured, picture, audio, and
+video formats. Some data might arrive to the workload
+periodically, or some might constantly arrive in real
+time. It is pragmatic to assume that data does not always
+arrive to the analytics workload in perfect shape, and
+only a portion – not the whole set – of data matters to
+your workload.
+
+Understand the characteristics of data, and determine what forms of data anomalies you want to remediate. For example, if you expect the data always contains an important attribute like customer ID, you can deﬁne that a datum is abnormal if it doesn’t contain the `customer_id` attribute. Common data anomalies include duplicate data, missing data, incomplete data, incorrect data format, and diﬀerent measurement units.
+
+## Suggestion 7.2.3 – Select an existing data quality solution or develop your own based on the requirements
+
+There are data quality solutions that can only detect single ﬁeld data quality issues. Other solutions can handle complex stateful data quality issues related to multiple ﬁelds.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-7.2---monitor-for-data-quality-anomalies..html*
+
+---
+
+# Best practice 7.3 – Trace data lineage
+
+Have a clear understanding about where your organization’s
+data is coming from, how the data is transformed, who and
+what systems have access to the data, and how the data is
+used, is critical to increasing the business value of data.
+To achieve this goal, data lineage should be tracked,
+managed, and visualized.
+
+## Suggestion 7.3.1 – Track and control data lineage information
+
+Data lineage information should include where data has
+come from, where the data is going, and who has access to
+the data. Data changes and the business logic used should
+also be tracked in the data lineage.
+
+## Suggestion 7.3.2 – Use visualization tools to investigate data lineage
+
+Data lineage can become complicated when multiple systems
+are interacting with each other. Building a data lineage
+tool to visualize data lineage can reduce troubleshooting
+time and help identify downstream dependencies.
+
+## Suggestion 7.3.3 – Build a data lineage report to satisfy compliance and audit requirements
+
+If some derestriction data lineage is required for
+compliance or audit purposes, your organization should
+either build a data lineage process using AWS services or
+investigate third-party applications.
+
+For more details, refer to the following information:
+
+- AWS data lineage blog**:**
+[Build data lineage for data lakes using AWS Glue, Amazon Neptune, and
+Spline](https://aws.amazon.com/blogs/big-data/build-data-lineage-for-data-lakes-using-aws-glue-amazon-neptune-and-spline/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-7.3---trace-data-lineage..html*
+
+---

--- a/skills/wa-review/references/lenses/data-analytics/security.md
+++ b/skills/wa-review/references/lenses/data-analytics/security.md
@@ -1,0 +1,1026 @@
+# Security
+
+**Pages**: 17
+
+---
+
+# Best practice 3.1 – Privacy by Design
+
+Privacy by Design is an approach in system engineering that
+takes privacy into account throughout the whole engineering
+process. It especially focuses on systems or applications
+that capture and process personal data.
+
+There is an increased focus on ensuring that personal data
+is processed lawfully, fairly, and in a transparent manner
+in relation to the data subject. Another concern is that the
+data processing is adequate, relevant, and limited in
+relation to the purpose for which the information is used.
+
+## Suggestion 3.1.1 – Data minimization
+
+Organizations should only receive, process, and store information that is relevant for the task rather than processing all information when only a portion of the file is required. For example, if a client provided a full extract of all information from their source system containing sensitive personal information, and if a portion of the file is deemed irrelevant in meeting the overall project requirements, the remainder of the file should not be stored or processed.
+
+Data minimization coincides with data access controls in that applying data minimization rules can be implemented using data access controls. A suggestion is to create and maintain a data access matrix aligned with your data classification catalogs. This helps ensure that the correct groups of people have access to the right data. As most compliant frameworks encourage evidence that rules have been applied, a data access matrix can demonstrate to auditors that your organization has gone through the proper thought process to determine who can access what information.
+
+Data minimization can be applied at the point of capture. It can also be applied at the point of access by presenting a restricted data model or implementing role-based access controls (RBAC). For more information on controlling data access, see [4 – Implement data access control](./design-principle-4.html).
+
+Test and user acceptance test (UAT) environments, as well
+as training model datasets, must have a restricted dataset
+and not contain any personal information. If the structure
+of the data model must remain the same as production, then
+consider anonymizing or masking information to meet your
+data minimization requirements.
+
+It is common practice to create test and development
+environments using a backup of production and restore to
+the respective development or test environment. If this is
+the case, anonymization of personally identifiable
+information (PII) and other sensitive information must
+occur using inbuilt logic or services such as AWS Glue DataBrew to obfuscate the information.
+
+For more details, refer to the following documentation:
+
+- Amazon Redshift RBAC -
+[Amazon Redshift role-based access control](https://docs.aws.amazon.com/redshift/latest/dg/t_Roles.html)s
+- AWS Lake Formation RBAC -
+[Lake Formation role-based access controls](https://docs.aws.amazon.com/lake-formation/latest/dg/access-control-overview.html)
+- Amazon Athena RBAC -
+[Amazon Athena fine-grained access controls](https://docs.aws.amazon.com/athena/latest/ug/fine-grained-access-to-glue-resources.html)
+- AWS Glue DataBrew -
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) Visual Data Preparation
+
+## Suggestion 3.1.2 – Anonymization, pseudonymization, and tokenization
+
+Anonymization, pseudonymization, or tokenisation refers to the method of either rendering data anonymous or encoding data in such a manner that the data is no longer identifiable
+
+### Suggestion 3.1.2.1 – Anonymization
+
+**Anonymization is defined as the process of turning data into a
+form that does not identify individuals and where identification is not likely to take
+place.**
+
+This results in changing personal data into data that is no longer personal. An
+important factor in this process is that the anonymization must be irreversible. The
+anonymized value should be supported by the current field data type, have similar
+length, and retain some characteristics of the original value. For example, if a Vehicle
+Registration Number such as `OU51 SMR` was being anonymized, the result would
+look similar to `BB88 9AA`.
+
+Organizations need the ability to anonymize full datasets as well as single records.
+Single record anonymization functionality can help deliver right to erasure and meet
+data retention requirements. In this case, full batch anonymization is typically used
+when obfuscating development and UAT environments.
+
+The function to anonymize information should support the flexibility to anonymize
+certain fields, but not all.
+
+Operational databases, reporting databases, and analytical data marts should all be
+considered for anonymization, although reports and analytical cubes should never
+typically contain PII information regardless.
+
+Audit the reason why information was anonymized, for example, data portability, or
+data retention removal. The time, date, and user ID of when and who the anonymization
+process has affected should be recorded in an audit table.
+
+For more details, see AWS Big Data Blog: [Anonymize and manage data in your data lake with Amazon Athena and AWS Lake Formation](https://aws.amazon.com/blogs/big-data/anonymize-and-manage-data-in-your-data-lake-with-amazon-athena-and-aws-lake-formation/)
+
+### Suggestion 3.1.2.2 – Pseudonymization
+
+**Pseudonymized data is not the same as anonymized data.**
+
+When data has been pseudonymized, it still retains a level of detail in the target
+data that allows tracking back of the data to its original state. With anonymized data,
+the level of detail is reduced rendering a reverse compilation impossible.
+Pseudonymization is the processing of personal data in such a way that the data can only
+be attributed to a specific data subject by using additional information. To
+pseudonymize a dataset, the additional information must be kept separately and subject
+to technical and organizational measures to ensure non-attribution to an identified or
+identifiable person.
+
+In summary, pseudonymized data is a privacy-enhancing technique where directly
+identifying data, such as IP addresses and contact information, are held separately and
+securely from processed data to ensure non-attribution. Similar to anonymization,
+referential integrity must not be affected. Therefore, both of the following are
+required: an audit trail of the pseudonymization process, and a pseudonymization
+function that supports both single item and batch processing.
+
+For more detail, see [Amazon Redshift Data Masking](https://docs.aws.amazon.com/redshift/latest/dg/t_ddm.html).
+
+### Suggestion 3.1.2.3 – Tokenization
+
+*Tokenization*, when applied to data security, is
+the process of substituting a sensitive data element with a non-sensitive equivalent.
+This is referred to as a token, which has no extrinsic or exploitable meaning or value.
+The token is a reference that maps back to the sensitive data through a tokenization
+system. Tokenization is typically used in finance to tokenize the payment account number
+(PAN).
+
+For more details, refer to the following information:
+
+- AWS Blog – [AWS Glue DataBrew detection data masking transformations](https://aws.amazon.com/about-aws/whats-new/2021/11/aws-glue-databrew-detection-data-masking-transformations/)
+- AWS Blog - [Data Tokenization with Amazon Redshift and Protegrity](https://aws.amazon.com/blogs/apn/data-tokenization-with-amazon-redshift-and-protegrity/)
+
+## Suggestion 3.1.3 – Rights of the individual, citizen, or subject
+
+Your organization should consider the process to address
+the rights of the individual, citizen, or subject for
+their respective regional regulation.
+
+### Suggestion 3.1.3.1 – Subject Access Request (SAR)
+
+This particular right is for an individual to request
+information from the data controller, that is, how their
+personal data is being processed. If an individual’s
+information is being processed, the personal data and
+associated metadata must be provided to that individual.
+
+If the individual’s information is stored in a database, then an automated process, such as a stored procedure or User-Defined Function (UDF), should be developed to answer the Subject Access Request (SAR). There will, however, be situations when the individual’s information is stored in Amazon S3. If the information is stored in Amazon S3, the proposed solution to identify which S3 object contains the respective information is to build a lookup table in a database containing the reference number, individual contact details, and the S3 object location. This approach allows your organization to ingest the information into Amazon EMR, infer the schema using Apache Spark, and extract the information required to fulfill the request. Alternatively, your organization must process all S3 objects to identify the information to fulfill the request.
+
+If your regional regulations require that your organization handle a right to data portability request, then the SAR logic can double up to support that as well.
+
+For more details, see Apache Spark Documentation -
+[Inferring
+the Schema Using Reflection](https://spark.apache.org/docs/2.3.0/sql-programming-guide.html#:~:text=Inferring%20the%20Schema%20Using%20Reflection,-Scala&text=The%20Scala%20interface%20for%20Spark,the%20names%20of%20the%20columns.)
+
+### Suggestion 3.1.3.2 – Right to be forgotten or erasure
+
+Individuals have the right to erasure (the right to be forgotten), where an
+individual can request that all of their personal data is erased by the data controller
+organization. In some countries, there are instances where the data controller can
+refuse to comply with a right to erasure request, such as where the data is used for
+financial governance.
+
+The right to erasure does not strictly mean that the individual’s information must
+be deleted. Instead, it can be permanently masked so that the personal data is no longer
+in the clear and the update is irreversible.
+
+The organization must consider all data repositories when responding to a SAR as an
+individual’s information can reside in back up and source system databases. All these
+records must have the individual’s information removed or anonymized.
+
+If there are concerns about the impact of database referential integrity being
+affected by removing the individual’s information, then you can consider anonymization
+of the specific data attributes for the given individual. There are benefits to
+anonymization, such as being able to maintain an audit history of what actions have been
+performed against the individual by referencing a system ID. The same steps that are
+performed in production environments must also be run in UAT, development, OLTP, and
+back up repositories.
+
+The schedule of running the procedure in the other environments depends on the
+refresh schedules of those other environments.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.1-privacy-by-design..html*
+
+---
+
+# Best practice 3.2 – Classify and protect data
+
+**How do you classify and protect data
+in analytics workload?** Because analytics
+workloads ingest data from source systems, the owner of the
+source data should define the data classifications. As the
+analytics workload owner, you should honor the source data
+classifications and implement the corresponding data
+protection policies of your organization. Share the data
+classifications with the downstream data consumers to permit
+them to honor the data classifications in their
+organizations and policies as well.
+
+Data classification helps to categorize organizational data
+based on sensitivity and criticality, which then helps
+determine appropriate protection and retention controls on
+that data.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.2---classify-and-protect-data..html*
+
+---
+
+# Best practice 3.3 – Understand data classifications and their protection policies
+
+Data classification in your organization is key to
+determining how data must be protected while at rest and in
+transit. For example, since an analytics workload
+necessarily copies and shares data between operations and
+systems, we recommend that access be controlled to certain
+data classifications. Such a data protection strategy helps
+to prevent data loss, theft, and corruption, and helps to
+minimize the impact caused by malicious activities or
+unintended access.
+
+## Suggestion 3.3.1 – Identify classification levels
+
+Use the
+[Data
+Classification whitepaper](https://docs.aws.amazon.com/whitepapers/latest/data-classification/data-classification.html) to help you identify
+different classification levels. Four common levels used
+are restricted, confidential, internal, and public,
+however, these levels can vary based on the industry and
+compliance requirements of your organization.
+
+## Suggestion 3.3.2 – Define access rules
+
+The data owners should define the data access rules based
+on the sensitivity and criticality of the data. For
+example, with AWS Lake Formation, you can define and
+enforce access controls that operate at the table, column,
+row, and cell level for all the users that access your
+data lake.
+
+For more details, refer to the following information:
+
+- AWS Security Blog:
+[How
+to scale your authorization needs by using
+attribute-based access control with](https://aws.amazon.com/blogs/security/how-to-scale-authorization-needs-using-attribute-based-access-control-with-s3/)
+[S3](https://aws.amazon.com/blogs/security/how-to-scale-authorization-needs-using-attribute-based-access-control-with-s3/).
+- AWS Big Data Blog:
+[Create
+a secure data lake by masking, encrypting data, and
+enabling fine-grained access with AWS Lake Formation.](https://aws.amazon.com/blogs/big-data/create-a-secure-data-lake-by-masking-encrypting-data-and-enabling-fine-grained-access-with-aws-lake-formation/)
+- AWS Big Data Blog:
+[Control
+data access and permissions with AWS Lake Formation and
+Amazon EMR](https://aws.amazon.com/blogs/big-data/control-data-access-and-permissions-with-aws-lake-formation-and-amazon-emr/).
+- AWS Big Data Blog:
+[Enforce
+column-level authorization with Quick and
+AWS Lake](https://aws.amazon.com/blogs/big-data/enforce-column-level-authorization-with-amazon-quicksight-and-aws-lake-formation/)
+[Formation](https://aws.amazon.com/blogs/big-data/enforce-column-level-authorization-with-amazon-quicksight-and-aws-lake-formation/).
+
+## Suggestion 3.3.3 – Identify security zone models to isolate data based on classification
+
+Design the security zone models from AWS account levels
+down to AWS resource levels. For example, consider
+building AWS multi-account models to isolate different
+classes of data from AWS account level. Or, you can
+consider separating out development and test resources
+from production ones from AWS account level or from
+resource levels.
+
+For more details, refer to the following information:
+
+- AWS Whitepaper:
+[An
+Overview of the AWS Cloud Adoption Framework](https://docs.aws.amazon.com/whitepapers/latest/overview-aws-cloud-adoption-framework/welcome.html).
+- AWS Whitepaper:
+[Organizing
+Your AWS Environment Using Multiple Accounts](https://docs.aws.amazon.com/whitepapers/latest/organizing-your-aws-environment/organizing-your-aws-environment.html).
+- AWS Whitepaper:
+[Security
+Pillar – AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html).
+
+## Suggestion 3.3.4 – Identify sensitive information and define protection policies
+
+Discover sensitive data by using custom data identifiers in Amazon Macie or using AWS Glue sensitive data detection. Based on
+the sensitivity and criticality of the data, implement data protection policies to prevent
+unauthorized access. Due to compliance requirements, data might be masked or deleted after
+processing in some cases.
+
+For more details, refer to the following information:
+
+- AWS Blog:
+[Introducing
+PII data identification and handling using AWS Glue DataBrew](https://aws.amazon.com/blogs/big-data/introducing-pii-data-identification-and-handling-using-aws-glue-databrew/)
+- AWS Blog:
+[Create
+a secure data lake by masking, encrypting data, and
+enabling fine-grained access with AWS Lake Formation](https://aws.amazon.com/blogs/big-data/create-a-secure-data-lake-by-masking-encrypting-data-and-enabling-fine-grained-access-with-aws-lake-formation/)
+- AWS Info: [AWS Glue detect and process sensitive data](https://docs.aws.amazon.com/glue/latest/dg/detect-PII.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.3---understand-data-classifications-and-their-protection-policies..html*
+
+---
+
+# Best practice 3.4 – Identify the source data owners and have them set the data classifications
+
+Identify the owners of the source data, like business data owners, and agree what level of protection is required for the data within the analytics platform.
+
+Data classifications follow the data as it moves throughout
+the analytics workﬂow to ensure that the data is protected,
+and to determine who and what systems are allowed to access
+the data. By following the organization’s classification
+policies, the analytics workload should be able to
+differentiate the data protection implementations for each
+class of data. Because each organization has different kinds
+of classification, the analytics workload should provide a
+strong logical boundary between processing data of different
+sensitivity levels. These classifications include
+*restricted*,
+*confidential*, and
+*sensitive*.
+
+## Suggestion 3.4.1 – Assign owners per each dataset
+
+A dataset, or a table in relational database, is a collection of data. A Data Catalog is a collection of metadata that helps centralize share and search information about the data within your platform. In addition to assigned classifications, this capability allows teams to search for data assets and decide whether the data asset is valuable for their analyze or data science workload.
+
+The administrator of the analytics workload should know who are the owners for each dataset, and should assign the dataset ownership in the Data Catalog.
+
+## Suggestion 3.4.2 – Define attestation scope and reviewer as additional scope for sensitive data
+
+As the owner of the analytics workload, you should know
+the data owner for each dataset. For example, when a
+dataset classified as highly sensitive has permission
+issues within the organization, you might have to talk to
+the dataset owners and have them resolve the issues.
+
+## Suggestion 3.4.3 – Set expiry for data ownership and attestation, and have owners reconfirm periodically
+
+As businesses change, the data owners and the data
+classifications might change as well. Run campaigns
+periodically, such as quarterly or yearly, to request each
+of the dataset owners to reconfirm that they are still the
+right owners, and that the data classifications are still
+accurate.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.4---identify-the-source-data-owners-and-have-them-set-the-data-classifications..html*
+
+---
+
+# Best practice 3.5 – Record data classifications into the Data Catalog so that analytics workloads can understand
+
+Allow processes to update the Data Catalog so it can provide
+a reliable record of where the data is located and its
+precise classification. To protect the data effectively,
+analytics systems should know the classifications of the
+source data so that the systems can govern the data
+according to business needs. For example, if the business
+requires that confidential data be encrypted using team-owned
+private keys, such as from AWS Key Management Service (AWS KMS), then the analytics workload should be able to
+determine which data is classified as confidential by
+referencing its data catalog.
+
+## Suggestion 3.5.1 – Use tags to indicate the data classifications
+
+Use a tagging ontology to designate the classiﬁcation of sensitive data in data stores with a data catalog. A tagging ontology allows discoverability of data sensitivity without directly exposing the underlying data.
+They also can be used to authorize access in
+[tag-based access control (TBAC)](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_attribute-based-access-control.html) schemes.
+
+For more details, refer to the following information:
+
+- AWS Lake Formation Developer Guide:
+[What
+Is AWS Lake Formation?](https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html)
+- AWS Whitepaper: [Tagging
+Best Practices](https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/tagging-best-practices.html)
+- AWS Lake Formation: [Easily manage your data lake at scale using AWS Lake Formation Tag-based access control](https://aws.amazon.com/blogs/big-data/easily-manage-your-data-lake-at-scale-using-tag-based-access-control-in-aws-lake-formation/)
+
+## Suggestion 3.5.2 – Record lineage of data to track changes in the Data Catalog
+
+Data lineage is a relation among data and the processing
+systems. For example, the data lineage tells where the
+source system of the data has come from, what changes
+occurred to the data, and which downstream systems have
+access to it. Your organization should be able to
+discover, record, and visualize the data lineage from
+source to target systems.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Metadata
+classification, lineage, and discovery using Apache
+Atlas on Amazon EMR](https://aws.amazon.com/blogs/big-data/metadata-classification-lineage-and-discovery-using-apache-atlas-on-amazon-emr/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.5---record-data-classifications-into-the-data-catalog-so-that-analytics-workloads-can-understand..html*
+
+---
+
+# Best practice 3.6 – Implement encryption policies
+
+Data encryption is a way of translating data from plaintext
+(unencrypted) to ciphertext (encrypted). Encryption is a
+critical component of a *defense in
+depth* strategy. Therefore, it is highly
+recommended that your organization implement a well-designed
+encryption and key management system by separating access to
+the decryption key from access to your data to provide data
+security.
+
+## Suggestion 3.6.1 – Implement encryption policies for data at rest and in transit
+
+Each analytics service provides different types of encryption methods.
+Review the viable encryption methods of your solutions and
+implement as necessary.
+
+For more details, refer to the following information:
+
+- [AWS Key Management Service (AWS KMS) encryption best practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/encryption-best-practices/kms.html)
+- AWS Big Data Blog:
+[Best
+Practices for Securing Amazon EMR](https://aws.amazon.com/blogs/big-data/best-practices-for-securing-amazon-emr/)
+- AWS Big Data Blog:
+[Encrypt
+Your Amazon Redshift Loads with Amazon S3 and AWS KMS](https://aws.amazon.com/blogs/big-data/encrypt-your-amazon-redshift-loads-with-amazon-s3-and-aws-kms/)
+- AWS Big Data Blog:
+[Encrypt
+and Decrypt Amazon Kinesis Records Using AWS KMS](https://aws.amazon.com/blogs/big-data/encrypt-and-decrypt-amazon-kinesis-records-using-aws-kms/)
+- AWS Partner Network (APN) Blog:
+[Data
+Tokenization with Amazon Redshift and Protegrity](https://aws.amazon.com/blogs/apn/data-tokenization-with-amazon-redshift-and-protegrity/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.6---implement-encryption-policies.html*
+
+---
+
+# Best practice 3.7 – Implement data retention policies for each class of data in the analytics workload
+
+The business’s data classification policies determine how
+long the analytics workload should retain the data and how
+long backups should be kept. These policies help ensure that
+every system follows the data security rules and compliance
+requirements. The analytics workload should implement data
+retention and backup policies according to these data
+classification policies. For example, if the policy requires
+every system to retain the operational data for five years,
+the analytics systems should implement rules to keep the
+in-scoped data for five years. More information on data
+retention can be found in [Sustainability](./sustainability.html).
+
+## Suggestion 3.7.1 – Create backup requirements and policies based on data classifications
+
+Data backup should be based on business requirements, such
+as recovery point objective (RPO), recovery time objective
+(RTO), data classifications, and the compliance and audit
+requirements.
+
+## Suggestion 3.7.2 – Create data retention requirement policies based on the data classifications
+
+Avoid creating blanket retention policies. Instead,
+policies should be tailored to individual data assets
+based on their retention requirements.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Building
+a cost efficient, petabyte-scale lake house with Amazon S3
+Lifecycle rules](https://aws.amazon.com/blogs/big-data/part-1-building-a-cost-efficient-petabyte-scale-lake-house-with-amazon-s3-lifecycle-rules-and-amazon-redshift-spectrum/)
+[and
+Amazon Redshift Spectrum: Part 1](https://aws.amazon.com/blogs/big-data/part-1-building-a-cost-efficient-petabyte-scale-lake-house-with-amazon-s3-lifecycle-rules-and-amazon-redshift-spectrum/)
+- AWS Big Data Blog:
+[Retaining
+data streams up to one year with Amazon Kinesis Data Streams](https://aws.amazon.com/blogs/big-data/retaining-data-streams-up-to-one-year-with-amazon-kinesis-data-streams/)
+- AWS Big Data Blog:
+[Retain
+more for less with UltraWarm for Amazon OpenSearch Service](https://aws.amazon.com/blogs/big-data/retain-more-for-less-with-ultrawarm-for-amazon-opensearch-service/)
+
+## Suggestion 3.7.3 – Create data version requirements and policies
+
+Implement a process that captures the data version to
+address, based on compliance, security, and operational
+requirements.
+
+For more details, refer to the following information:
+
+- AWS Storage Blog:
+[Reduce
+storage costs with fewer noncurrent versions using
+Amazon S3 Lifecycle](https://aws.amazon.com/blogs/storage/reduce-storage-costs-with-fewer-noncurrent-versions-using-amazon-s3-lifecycle/)
+- AWS Storage Blog:
+[Simplify
+your data lifecycle by using object tags with Amazon S3
+Lifecycle](https://aws.amazon.com/blogs/storage/simplify-your-data-lifecycle-by-using-object-tags-with-amazon-s3-lifecycle/)
+- AWS Database Blog:
+[Implementing
+version control using Amazon DynamoDB](https://aws.amazon.com/blogs/database/implementing-version-control-using-amazon-dynamodb/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.7---implement-data-retention-policies-for-each-class-of-data-in-the-analytics-workload..html*
+
+---
+
+# Best practice 3.8 – Enforce downstream systems to honor the data classifications
+
+Since other data-consuming systems will access the data that
+the analytics workload shares, the workload should require
+the downstream systems to implement the required data
+classification policies. For example, if the analytics
+workload shares the data that is required to be encrypted
+using customer managed private keys in AWS Key Management Service (AWS KMS), then the downstream systems should also
+acknowledge and implement such a data protection policy.
+
+This helps to ensure that the data is protected throughout
+the data pipelines.
+
+## Suggestion 3.8.1 – Have a centralized, shareable catalog with cross-account access to ensure that data owners manage permissions for downstream systems
+
+Downstream systems can run on independent AWS accounts,
+different from the AWS account running the majority of the
+analytics workload. Downstream systems should be able to
+discover the data, acknowledge the required data
+protection policies, and enforce those policies across the
+analytics platform.
+
+To allow the downstream systems to use the data from
+analytics workload, the analytics workload should provide
+cross-account access based on least privileges for each
+dataset.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog: [Cross-account AWS Glue Data Catalog access with Amazon Athena](https://aws.amazon.com/blogs/big-data/cross-account-aws-glue-data-catalog-access-with-amazon-athena/)
+- AWS Big Data Blog:
+[How
+JPMorgan Chase built a data mesh architecture to drive
+significant value to](https://aws.amazon.com/blogs/big-data/how-jpmorgan-chase-built-a-data-mesh-architecture-to-drive-significant-value-to-enhance-their-enterprise-data-platform/)
+[enhance
+their enterprise data platform](https://aws.amazon.com/blogs/big-data/how-jpmorgan-chase-built-a-data-mesh-architecture-to-drive-significant-value-to-enhance-their-enterprise-data-platform/)
+
+## Suggestion 3.8.2 – Monitor the downstream systems’ eligibility to access classified data from the analytics workload
+
+Monitor the downstream systems’ eligibility to handle
+sensitive data. For example, you do not want development
+or test Amazon Redshift clusters to read sensitive data
+from the analytics workload. If your organization runs a
+program that certifies which systems are eligible to
+process various classes of data, periodically verify that
+each downstream system’s data processing eligibility
+levels are correct and the list of data that it accesses
+are appropriate.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-3.8---enforce-downstream-systems-to-honor-the-data-classifications..html*
+
+---
+
+# Best practice 4.1 – Allow data owners to determine which people or systems can access data in analytics and downstream workloads
+
+Data owners are the people that have direct responsibility
+for data protection. For instance, the data owners want to
+determine which data is publicly accessible, or which data
+is restricted access to whom or what systems. The data
+owners should be able to provide data access rules, so that
+the analytics workload can implement the rules.
+
+## Suggestion 4.1.1 – Identify data owners and assign roles
+
+Data ownership is the management and oversight of an
+organization's data assets to help provide business users
+with high-quality data that is easily accessible in a
+consistent manner. Because the analytics workload
+consolidates multiple datasets into a central place, each
+dataset is owned by different teams or people. So, it is
+important for the analytics workload to identify which
+dataset is owned by whom to have the owners control the
+data access permissions.
+
+## Suggestion 4.1.2 – Identify permission using a permission matrix for users and roles based on actions performed on the data by users and downstream systems
+
+To aid in identifying and communicating data-access
+permissions, an Access Control Matrix is a helpful method
+to document which users, roles, or systems have access to
+which datasets, and to describe what actions they can
+perform. Below is a sample matrix for two users, and two
+roles for two schemas with a table in them:
+
+Table 1: Example Access Control Matrix for Users and Roles
+
+**Permissions**
+
+**Read**
+
+**Write**
+
+Schema 1
+
+User1, User2, Role1, Role2
+
+Role1
+
+Schema 1 / Table 1
+
+User1, User2, Role1, Role2
+
+Role2
+
+Schema 2
+
+User1, User2, Role1, Role2
+
+User1, Role1
+
+Schema 2 / Table 2v
+
+User1, User2, Role1, Role2
+
+User2, Role2
+
+The matrix format can help identify the least permissions
+that are required by various resources and to avoid
+overlaps. An Access Control Matrix should be thought of as
+an abstract model of permissions at a given point in time.
+Periodically review the actual access permissions against
+the permission matrix document to ensure accuracy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.1---allow-data-owners-to-determine-which-people-or-systems-can-access-data-in-analytics-and-downstream-workloads..html*
+
+---
+
+# Best practice 4.2 – Build user identity solutions that uniquely identify people and systems
+
+To control data access effectively, the analytics workload
+should be able to uniquely identify the people or systems.
+For example, the workload should be able to tell who
+accessed to the data by looking at the user identifiers (such
+as user names, tags, or IAM role names) with confidence that
+the identifier represents only one person or system.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Amazon Redshift identity federation with multi-factor
+authentication](https://aws.amazon.com/blogs/big-data/amazon-redshift-identity-federation-with-multi-factor-authentication/)
+- AWS Big Data Blog:
+[Federating
+single sign-on access to your Amazon Redshift cluster with
+PingIdentity](https://aws.amazon.com/blogs/big-data/federating-single-sign-on-access-to-your-amazon-redshift-cluster-with-pingidentity/)
+- AWS Database Blog:
+[Get
+started with Amazon OpenSearch Service: Use Amazon Cognito for Kibana](https://aws.amazon.com/blogs/database/get-started-with-amazon-elasticsearch-service-use-amazon-cognito-for-kibana-access-control/)
+[access
+control](https://aws.amazon.com/blogs/database/get-started-with-amazon-elasticsearch-service-use-amazon-cognito-for-kibana-access-control/)
+- AWS Partner Network (APN) Blog:
+[Implementing
+SAML AuthN for Amazon EMR Using Okta and](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+[Column-Level
+AuthZ with AWS Lake Formation](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+- AWS CloudTrail User Guide:
+[How
+AWS CloudTrail works with IAM](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/security_iam_service-with-iam.html)
+
+## Suggestion 4.2.1 – Centralize workforce identities
+
+It’s a best practice to centralize your workforce
+identities, which allows you to federate with AWS Identity and Access Management (IAM) using AWS IAM Identity Center
+or another federation
+provider. In Amazon Redshift, IAM roles can be mapped to
+Amazon Redshift database groups. In Amazon EMR, IAM roles
+can be mapped to an Amazon EMR security configuration or an
+Apache Ranger Microsoft Active Directory group-based
+policy. In AWS Glue, IAM roles can be mapped to AWS AWS Glue Data Catalog resource policies.
+
+AWS analytics services – such as Amazon OpenSearch Service
+and Amazon DynamoDB – allow integration with Amazon Cognito for authentication. Amazon Cognito lets you add
+user sign-up, sign- in, and access control to your web and
+mobile apps. Amazon Cognito scales to millions of users
+and supports sign-in with social identity providers, such
+as Apple, Facebook, Google, and Amazon, and enterprise
+identity providers via SAML 2.0 and OpenID Connect.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Federate
+Database User Authentication Easily with IAM and Amazon Redshift](https://aws.amazon.com/blogs/big-data/federate-database-user-authentication-easily-with-iam-and-amazon-redshift/)
+- WS Big Data Blog:
+[Federating
+single sign-on access to your Amazon Redshift cluster
+with PingIdentity](https://aws.amazon.com/blogs/big-data/federating-single-sign-on-access-to-your-amazon-redshift-cluster-with-pingidentity/)
+- Amazon EMR Management Guide:
+[Allow
+AWS IAM Identity Center for Amazon EMR Studio](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-enable-sso.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.2---build-user-identity-solutions-that-uniquely-identify-people-and-systems..html*
+
+---
+
+# Best practice 4.3 – Implement the required data access authorization models
+
+User authorization determines what actions that a user is
+permitted to take on the data or resource. The data owners
+should be able to use the authorization methods to protect
+their data as needed. For example, if the data owners must
+control which users are allowed to view certain columns of
+data, the analytics workload should provide column-wise data
+access authorization along with user group management for an
+effective control.
+
+## Suggestion 4.3.1 – Implement IAM policy-based data access controls
+
+Limit access to sensitive data stores with IAM policies
+where possible. Provide systems and people with rotating
+short-term credentials via role-based access control
+(RBAC).
+
+For more details, see AWS Big Data Blog: [Restrict access to your AWS Glue Data Catalog with resource-level IAM permissions and resource-based policies](https://aws.amazon.com/blogs/big-data/restrict-access-to-your-aws-glue-data-catalog-with-resource-level-iam-permissions-and-resource-based-policies/)
+
+## Suggestion 4.3.2 – Implement dataset-level data access controls
+
+As dataset owners require independent rules of granting
+data access, you should build the analytics workloads to
+have the dataset owners control the data access per each
+dataset level. For example, if the analytics workload
+hosts a shared Amazon Redshift cluster, the owners of the
+individual table should be able to authorize the table
+read and write independently.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Validate,
+evolve, and control schemas in Amazon MSK and Amazon Kinesis Data](https://aws.amazon.com/blogs/big-data/validate-evolve-and-control-schemas-in-amazon-msk-and-amazon-kinesis-data-streams-with-aws-glue-schema-registry/)
+[Streams
+with AWS Glue Schema Registry](https://aws.amazon.com/blogs/big-data/validate-evolve-and-control-schemas-in-amazon-msk-and-amazon-kinesis-data-streams-with-aws-glue-schema-registry/).
+- Amazon Redshift:
+[Amazon Redshift announces support for Row-Level Security
+(RLS)](https://aws.amazon.com/about-aws/whats-new/2022/07/amazon-redshift-row-level-security/)
+[Streams
+with AWS Glue Schema Registry](https://aws.amazon.com/blogs/big-data/validate-evolve-and-control-schemas-in-amazon-msk-and-amazon-kinesis-data-streams-with-aws-glue-schema-registry/).
+
+## Suggestion 4.3.3 – Implement column-level data access controls
+
+Care should be taken that end users of analytics
+applications are not exposed to sensitive data. Downstream
+consumers of data should only access the limited view of
+data necessary for that analytics purpose. Enforce that
+sensitive data is not exposed using column-level
+restrictions, for example, mask the sensitive columns to
+downstream systems so an accidental exposure is avoided.
+
+For more details, refer to the following information:
+
+- AWS Big Data Blog:
+[Allow
+fine-grained permissions for Quick authors in
+AWS Lake](https://aws.amazon.com/blogs/big-data/enable-fine-grained-permissions-for-amazon-quicksight-authors-in-aws-lake-formation/)
+[Formation](https://aws.amazon.com/blogs/big-data/enable-fine-grained-permissions-for-amazon-quicksight-authors-in-aws-lake-formation/)
+- Amazon Redshift: [Role-based access controls](https://docs.aws.amazon.com/redshift/latest/dg/t_Roles.html)
+- AWS Partner Network (APN) Blog:
+[Implementing
+SAML AuthN for Amazon EMR Using Okta and](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+[Column-Level
+AuthZ with AWS Lake Formation](https://aws.amazon.com/blogs/apn/implementing-saml-authn-for-amazon-emr-using-okta-and-column-level-authz-with-aws-lake-formation/)
+- AWS Big Data Blog:
+[Implementing
+Authorization and Auditing using Apache Ranger on Amazon EMR](https://aws.amazon.com/blogs/big-data/implementing-authorization-and-auditing-using-apache-ranger-on-amazon-emr/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.3---implement-the-required-data-access-authorization-models..html*
+
+---
+
+# Best practice 4.4 – Establish an emergency access process to ensure that admin access is managed and used when required
+
+Emergency access allows expedited access to your workload in
+the unlikely event of an automated process or pipeline
+issue. This will help you rely on least privilege access,
+but still provide users the right level of access when they
+require it.
+
+## Suggestion 4.4.1 – Ensure that risk analysis is performed on your analytics workload by identifying emergency situations and a procedure to allow emergency access
+
+Identify the potential events that can happen from source
+systems, analytics workload, and downstream systems.
+Quantify the risk of each event such as likelihood (low,
+medium, or high) and the size of the business impact
+(small, medium, or large).
+
+For example, after you identified priority risks, discuss
+with the source and downstream system owners on how to
+allow analytics workload access to the source and
+downstream systems to continue the data processing
+business.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.4---establish-an-emergency-access-process-to-ensure-that-admin-access-is-managed-and-used-when-required..html*
+
+---
+
+# Best practice 4.5 – Track data and database changes
+
+Data auditing involves monitoring a database to track the
+actions of a user or process, and to audit the changes that
+have occurred to the data.
+
+## Suggestion 4.5.1 – Database triggering for data auditing
+
+A database trigger is procedural code that is
+automatically run in response to certain events on a
+particular table or view in a database. Database triggers
+can then be used to update an audit table with the changes
+that have occurred. The types of information that should
+be included in the auditing process include: the original
+and updated value of what has been updated, the process or
+stored procedure that made the update, and the time and
+date the update occurred.
+
+## Suggestion 4.5.2 – Enable advanced auditing
+
+If your database engine supports auditing as a native
+feature, you should enable the feature to record and audit
+database events such as connections, disconnections,
+tables queried, or types of queries issued.
+
+## Suggestion 4.5.3 – AWS Lake Formation time travel queries
+
+Apache Iceberg and Apache Hudi provide a high-performance data lake table format that works just like a SQL table. Iceberg and Hudi make it simple to manage your data lake information and support SQL type analytics. Data that is managed by Iceberg or Hudi is version-controlled, therefore there is a complete history of all data updates. A good example is if you need to know the status of an individual at a certain time, then a time travel query allows you to select a date range to return the value that existed at that time, rather than the current value.
+
+For more details, see [Use the AWS Glue connector to read and write Apache Iceberg tables with ACID transactions and perform time travel](https://aws.amazon.com/blogs/big-data/use-aws-glue-to-read-and-write-apache-iceberg-tables-with-acid-transactions-and-perform-time-travel/).
+
+## Suggestion 4.5.4 – Change Data Capture (CDC)
+
+CDC records `INSERT`s, `UPDATE`s, and `DELETE`s
+applied to relational database tables, and makes a log available of which relational
+database objects changed, where, and when. These change tables contain columns that
+reflect the column structure of the source table you have chosen to track, along with the
+metadata required to understand the changes that have been made.
+
+For more details, refer to the following information:
+
+- AWS CloudTrail -
+[Secure
+Standardized Logging](https://aws.amazon.com/cloudtrail/)
+- Amazon RDS Aurora -
+[Advanced
+Auditing with an Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html)
+- Amazon RDS Aurora -
+[Configuring
+an audit log to capture database activities for Amazon RDS](https://aws.amazon.com/blogs/database/configuring-an-audit-log-to-capture-database-activities-for-amazon-rds-for-mysql-and-amazon-aurora-with-mysql-compatibility/)
+- AWS Database Migration Service (AWS DMS)
+[AWS Database Migration Service](https://aws.amazon.com/dms/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-4.5-track-data-and-database-changes..html*
+
+---
+
+# Best practice 5.1 – Prevent unintended access to the infrastructure
+
+Grant least privilege access to infrastructure to help
+prevent inadvertent or unintended access to the
+infrastructure. For example, make sure that anonymous users
+are not allowed to access to the systems, and that the
+systems are deployed into isolated network spaces. Network
+boundaries isolate analytics resources and restrict network
+access. Network access control lists (NACLs) act as a
+firewall for controlling traffic in and out. To reduce the risk
+of inadvertent access, define the network boundaries of the
+analytics systems and only allow intended access.
+
+## Suggestion 5.1.1 – Ensure that resources in the infrastructure have boundaries
+
+Use infrastructure boundaries for services such as
+databases. Place services in their own VPC private subnets
+that are configured to allow connections only to needed
+analytics systems.
+
+Use
+[AWS Identity and Access Management (IAM) Access
+Analyzer](https://aws.amazon.com/iam/features/analyze-access/) for all AWS accounts that are centrally
+managed through
+[AWS Organizations.](https://aws.amazon.com/organizations/) This allows security teams and
+administrators to uncover unintended access to resources
+from outside their AWS organization within minutes.
+
+You can proactively address whether any resource policies
+across any of your accounts violate your security and
+governance practices by allowing unintended access.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.1---prevent-unintended-access-to-the-infrastructure..html*
+
+---
+
+# Best practice 5.2 – Implement least privilege policies for source and downstream systems
+
+The principle of least privilege works by giving only enough
+access for systems to do the job. Set an expiry on temporary
+permissions to ensure that re-authentication occurs
+periodically. The system actions on the data should
+determine the permission and granting permissions to other
+systems should not be permitted.
+
+## Suggestion 5.2.1 – Ensure that permissions are least for the action performed by user/system
+
+Identify the minimum privileges that each user or system
+requires, and only allow the permissions that they need.
+For example, if a downstream system requests to read an
+Amazon Redshift table from an analytics workload, only
+give the read permission for the table using Amazon Redshift user privilege controls.
+
+For more details, refer to the following information:
+
+- AWS Security Blog:
+[Techniques
+for writing least privilege IAM policies](https://aws.amazon.com/blogs/security/techniques-for-writing-least-privilege-iam-policies/)
+- Amazon Redshift Database Developer Guide:
+[Managing
+database security](https://docs.aws.amazon.com/redshift/latest/dg/r_Database_objects.html)
+- AWS Security Blog:
+[IAM
+Access Analyzer makes it easier to implement least
+privilege permissions by](https://aws.amazon.com/blogs/security/iam-access-analyzer-makes-it-easier-to-implement-least-privilege-permissions-by-generating-iam-policies-based-on-access-activity/)
+[generating
+IAM policies based on access activity](https://aws.amazon.com/blogs/security/iam-access-analyzer-makes-it-easier-to-implement-least-privilege-permissions-by-generating-iam-policies-based-on-access-activity/)
+
+## Suggestion 5.2.2 – Implement the two-person rule to prevent accidental or malicious actions
+
+Even if you have implemented the least privilege policies,
+someone must have critical permissions for the business,
+such as the ability to delete datasets from analytics
+workloads.
+
+The two-person rule is a safety mechanism that requires
+the presence of two authorized personnel to perform tasks
+that are considered important. It has its origins in
+military protocol, but the IT security space has also
+widely adopted the practice.
+
+By implementing the two-person rule, you can have
+additional prevention of accidental or malicious actions
+of the people who have critical permissions.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.2---implement-least-privilege-policies-for-source-and-downstream-systems..html*
+
+---
+
+# Best practice 5.3 – Monitor the infrastructure changes and the user activities against the infrastructure
+
+As the infrastructure changes over time, you should monitor
+what has been changed by whom. This is to ensure that such
+changes are deliberate and the infrastructure is still
+protected.
+
+## Suggestion 5.3.1 – Monitor the infrastructure changes
+
+You want to know every infrastructure change and want to
+know that such changes are deliberate. Monitor the
+infrastructure changes using available methods on your
+team. For example, you can implement an operation
+procedure to review the infrastructure configurations every
+quarter of the year. Or, you can use AWS services that
+assist you to monitor the infrastructure changes with less
+effort.
+
+For more details, refer to the following documentation:
+
+- AWS Config Developer Guide:
+[What
+Is AWS Config?](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
+- Amazon Inspector User Guide:
+[What
+is Amazon Inspector?](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_introduction.html)
+- Amazon GuardDuty User Guide:
+[Amazon S3 protection in Amazon GuardDuty](https://docs.aws.amazon.com/guardduty/latest/ug/s3_detection.html)
+
+## Suggestion 5.3.2 – Monitor the user activities against the infrastructure
+
+You want to know who is changing the infrastructure and
+when, so that you can see that any given infrastructure
+change is performed by an authorized person or system. To
+do so, as examples, you can implement an operation
+procedure to review the AWS CloudTrail audit logs every
+quarter of the year. Or you can implement near real time
+trend analysis using AWS services such as Amazon CloudWatch Logs Insights.
+
+For more details, refer to the following information:
+
+- AWS CloudTrail User Guide:
+[Monitoring
+CloudTrail Log Files with Amazon CloudWatch Logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/monitor-cloudtrail-log-files-with-cloudwatch-logs.html)
+- AWS Management and Governance Blog:
+[Analyzing
+AWS CloudTrail in Amazon CloudWatch](https://aws.amazon.com/blogs/mt/analyzing-cloudtrail-in-cloudwatch/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.3---monitor-the-infrastructure-changes-and-the-user-activities-against-the-infrastructure..html*
+
+---
+
+# Best practice 5.4 – Secure the audit logs that record every data or resource access in analytics infrastructure
+
+Logs are an audit trail of events and should be stored in an immutable format for compliance purposes. These logs provide proof of actions
+and help in identifying misuse. The logs provide a baseline
+for analysis or for an audit when initiating an
+investigation. By using a fault-tolerant storage for these
+logs, it is possible to recover them even when there is a
+failure in the auditing systems. Access permissions to these
+logs must be restricted to privileged users. Also log audit
+log access to help in identifying unintended access to audit
+data.
+
+## Suggestion 5.4.1 – Ensure that auditing is active in analytics services and are delivered to fault-tolerant persistent storage
+
+Review the available audit log features of your analytics
+solutions, and configure the solutions to store the audit
+logs to fault-tolerant persistent storage. This helps
+ensure that you have complete audit logs for security and
+compliance purposes.
+
+For more details, refer to the following information:
+
+- AWS Management and Governance Blog:
+[AWS CloudTrail Best Practices](https://aws.amazon.com/blogs/mt/aws-cloudtrail-best-practices/)
+- Amazon Redshift Cluster Management Guide:
+[Database
+audit logging](https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html)
+- Amazon OpenSearch Service (successor to Amazon OpenSearch Service) Developer Guide:
+[Monitoring](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/audit-logs.html)
+[audit
+logs in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/audit-logs.html)
+- AWS Technical Guide – Build a Secure Enterprise Machine
+Learning Platform on AWS:
+[Audit
+trail](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/audit-trail-management.html)
+[management](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/audit-trail-management.html)
+- AWS Big Data Blog:
+[Build,
+secure, and manage data lakes with AWS Lake Formation](https://aws.amazon.com/blogs/big-data/building-securing-and-managing-data-lakes-with-aws-lake-formation/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-5.4---secure-the-audit-logs-that-record-every-data-or-resource-access-in-analytics-infrastructure..html*
+
+---

--- a/skills/wa-review/references/lenses/data-analytics/sustainability.md
+++ b/skills/wa-review/references/lenses/data-analytics/sustainability.md
@@ -1,0 +1,665 @@
+# Sustainability
+
+**Pages**: 7
+
+---
+
+# Best practice 15.1 – Define your organization’s current environmental impact
+
+As an organization, you should track your progress towards your sustainability goals. By determining your current environmental impact, you can track and report improvements as you make changes over time. Without knowing where you are you can’t know how far you’ve come.
+
+**How do you track your analytics
+carbon footprint?**
+
+## Suggestion 15.1.1 – Determine the carbon emissions of your workload using the AWS Customer Carbon Footprint Tool
+
+Determining the current carbon emissions of your analytics workloads at the start of your optimization journey is important as it enables you to track your changes and see what efforts have the biggest impact. If you are an AWS user, your
+organization can use the AWS Customer Carbon Footprint Tool. The AWS Customer Carbon
+Footprint Tool is a data tracking and visualization tool that reports on your AWS accounts carbon usage.
+
+Your organization should maintain an audit trail of the changes that your team
+have made, when they were made, and the impact that the changes had on the carbon
+footprint of each workload.
+
+For more details, refer to the following information:
+
+- [AWS Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/)
+- [AWS Customer Carbon
+Footprint Tool Overview](https://www.youtube.com/watch?v=WqhAnLdg3rg)
+- [Sustainability Pillar Improvement Process](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/improvement-process.html)
+- [Sustainability Pillar Improvement Process](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/improvement-process.html)
+
+## Suggestion 15.1.2 – Define and track your progress using proxy metrics
+
+When something is hard or impractical or very difficult to measure directly, you can instead use a related measurements in its place. This is called a *proxy metric*.
+
+Environmental impact is hard to measure directly, especially when you want fine-grained measurements. However, in the cloud, the environmental impact of a workload is often correlated with efficiency, which is also often correlated with cost. Just like you can apply many of the best practices of the performance efficiency and cost optimization pillars to lower your environmental impact, you can also use performance metrics and cost as proxy metrics to track your progress.
+
+For more details, refer to the following information:
+
+- [Evaluate specific improvements](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/evaluate-specific-improvements.html)
+- [Turning Cost and Usage Reports into Efficiency Reports](https://catalog.workshops.aws/well-architected-sustainability/en-US/5-process-and-culture/cur-reports-as-efficiency-reports)
+- [Best practice 8.3 – Define and measure the computing performance metrics](https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-8.3---define-and-measure-the-computing-performance-metrics..html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.1-define-organization-current-environmental-impact.html*
+
+---
+
+# Best practice 15.2 – Encourage sustainable thinking
+
+Software architects are often encouraged to apply systems thinking to the problems they tackle. To zoom out and look at the bigger picture and how the different components interact and form a whole. To build sustainable cloud workloads also requires sustainability thinking – including environmental impact as a parameter in design and planning.
+
+Organizations should include sustainability requirements when considering new projects, and continuously evaluate the environmental impact of existing workloads. They should find the balance between business needs and sustainable goals – and creative solutions to achieve both.
+
+Encourage questioning business requirements on sustainability grounds. For example, when considering the update frequency of dashboards, include the impact on things like energy usage in the discussions. Sometimes this leads to insights such as that only some of the KPIs need frequent updates, while the majority of the dashboard contents only need updating once per day. This can result in a reduction in energy usage while still delivering the same business value.
+
+## Suggestion 15.2.1 – Review the update frequency of your reports and dashboards
+
+Running reports and refreshing dashboards can be a compute intensive process. Continuously review the business requirements and question how frequently refreshes are needed. Can some reports be run only on demand because they are accessed infrequently? Can reports that today run on demand instead be run on a schedule to have them always available instead of multiple people running them many times per day? Does every KPI need to be refreshed at the same time?
+
+## Suggestion 15.2.2 – Review your reports, dashboards, and metrics and remove what is no longer needed
+
+As organizations evolve, so does business requirements.. Over time, some reports and dashboards become more important and used, and others less. New metrics become important, and reports and dashboards accumulate elements that are no longer necessary.
+
+Continually evaluate business requirements and remove what is no longer needed. Remove metrics from reports when they are not necessary, and remove whole reports and dashboards when they lose their relevance. Eﬃcient reporting has a positive impact on your sustainability goals. Your organization can also identify similar goals across teams or departments to reduce the number of separate reports and thereby reduce duplication and overlap.
+
+## Suggestion 15.2.3– Review the running frequency of your data pipelines
+
+Data pipelines are the backbone of analytics platforms. They process data and produce new data sets. They are compute-intensive processes that can have a big impact on the overall environmental impact of your analytics platform. The more frequently they run, the higher the impact. Work backwards from your business requirements and decide appropriate running frequencies that balance business value and environmental impact.
+
+Consider splitting pipeline jobs when there is an opportunity to run the majority of its calculations on a lower frequency while still maintaining the overall business goals.
+
+## Suggestion 15.2.4– Be flexible in your job schedules
+
+It’s common to run jobs on regular schedules, like hourly or daily, often at the top of the hour. When using managed and serverless technologies, the service often keeps a warm pool of compute resources to be able to meet demand. The pool needs to be managed to meet peaks in demand, and for job-oriented services this often coincides with the top of the hour. By being flexible in when you run your jobs, and for example avoiding the top of the hour, you can help the service smooth out demand.
+
+This is similar to how you can optimize your own resource usage by implementing buffering and throttling, as described in [SUS02-BP06 Implement buffering or throttling to flatten the demand curve](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sus_sus_user_a7.html).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.2-encourage-sustainable-thinking.html*
+
+---
+
+# Best practice 15.3 – Encourage a culture of data minimization
+
+Analytics relies heavily on large volumes of data being stored and processed. Minimizing the amount of data stored and processed can have a positive impact on the environmental impact of your organization’s analytics platform. Encourage architects, data engineers, and other roles that work on the platform to think about ways to minimize the amount of data stored and processed at every point in the system. A just enough data mindset can reduce the overall amount of data processed and therefore reduce the amount of compute power and storage used, and lower the environmental impact.
+
+Look for opportunities to break linear relationships so that datasets don’t need to grow at the same pace as your business. As your user base increases, find ways to avoid datasets growing at the same pace. In many cases it may be unavoidable, but for example, if you store partially aggregated data you can break the linear relationship.
+
+Encouraging a culture of always thinking about ways to minimize data can help ensure your organization does not unintentionally increase its environmental impact again after reductions have been made.
+More information on building and implementing an Improvement
+process can be found in the
+[Sustainability
+Pillar whitepaper](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/improvement-process.html).
+
+**How do you minimize the amount of
+data that is processed?**
+
+## Suggestion 15.3.1– Minimize the amount of data extracted from your source systems that gets stored in your data warehouse
+
+Data warehousing plays an important role in providing meaningful insights to your reporting layers and analytics. Data warehousing is the ingestion and merging of multiple data sources to create a single data model optimized for the business’ needs. Typically it employs techniques such as denormalization and materialized views of aggregates to provide faster query response times. It is encouraged that your organization applies these principles of building a data warehouse.
+
+It is common that all source data is ingested into a data warehouse. Since data warehouses are good at storing massive amounts of data, and because it’s hard to know in advance what is going to be needed, many organizations store everything. This leads to higher environmental impact because of the added compute and storage requirements.
+
+Work backwards from the business needs, reports, and dashboards when designing ingestion processes and data models for data warehouses. This avoids the overhead of extracting, processing, and storing source data that is not strictly needed.
+
+For more details, refer to the following information:
+
+- [Amazon Redshift development guide: Database Developer Guide](https://docs.amazonaws.cn/en_us/redshift/latest/dg/redshift-dg.pdf)
+- [Optimize your modern data architecture for sustainability: Part 1 – data ingestion and data lake](https://aws.amazon.com/blogs/architecture/optimize-your-modern-data-architecture-for-sustainability-part-1-data-ingestion-and-data-lake/)
+
+When designing your source data extraction processes, it is recommended that your organization should only extract data required for the workloads, such as reports and dashboards, that the data warehouse supports. This results in less data being transferred over the network, less data processed, less data being loaded into the data warehouse, less data being stored over time, and less data to remove when applying data retention policies.
+
+When extracting data from your source datastore, your organization should use a date range to extract only data that has been added or updated in the source datastore since the last data extract. This is called delta updates. This approach reduces the environmental impact of reprocessing the same data multiple times.
+
+Designing and building an efficient data model requires
+upfront consideration. Your development team should ensure
+that the optimal row-level granularity (for example
+customer level, address level, or product level) and data
+attributes reduces unnecessary deduplication and
+filtering further downstream.
+
+Most reporting applications support data editing and data
+filtering capabilities. Therefore, your development teams
+can develop a subset of data within the business tool
+minimizing the amount of data required for a report
+refresh.
+
+For more details, refer to the following information:
+
+- [Quick: Creating
+datasets](https://docs.aws.amazon.com/quicksight/latest/user/creating-data-sets.html)
+
+## Suggestion 15.3.2 – Use appropriate data types when developing database tables
+
+Databases and data warehouses can store many different types of data, and have optimized storage mechanisms for each type. Choosing the appropriate type for columns can optimize both the storage size of a dataset and the compute resources needed to process it. For example, storing numbers as integers, floats, and so on, instead of strings can save a lot of storage space, and greatly reduce the processing required when performing calculations. Similarly, dates and timestamps should be stored using matching data types. Consider each column and assign the most specific data type possible.
+
+For more details, refer to the following information:
+
+- [Amazon Redshift best practices for designing tables](https://docs.aws.amazon.com/redshift/latest/dg/c_designing-tables-best-practices.html)
+- [Data
+types in Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/data-types.html)
+- [Amazon Redshift data types](https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html)
+- [Quick: Supported
+data types and values](https://docs.aws.amazon.com/quicksight/latest/user/supported-data-types-and-values.html)
+
+## Suggestion 15.3.3 – Review your APIs to understand whether all data must be shared with your streaming applications
+
+APIs play an important role in connecting and sharing data between
+applications, databases and other systems. Application developers should consider the size
+of an event payload submitted to these systems.
+
+Organizations require the ability to run analytics on
+real-time data. To do so, organizations send data to
+streaming services. Streaming services, such as Amazon Managed Streaming for Apache Kafka (Amazon MSK) and Amazon Kinesis, allow organizations to run analytics on real-time
+streams of information. It is important that the data
+being shared with such streaming services is reviewed
+through the improvement process, because the more data
+provided in the payload will require more resources to
+store and process the data. Reducing the network, storage,
+and compute resources required to process unnecessary data
+can help towards reducing your organization’s analytics
+environmental impact.
+
+Review data that is captured by the application and pushed
+to the streaming platform to identify data attributes that
+can be removed. Also identify opportunities to store
+commonly used transforms to create values that can be
+computed once. Review your Kafka topic and identify if
+it’s duplicated data of whether a single topic is enough
+to deliver to multiple dependencies. Through the
+Improvement process you should consider data volumes and
+the value of your assets, and measure these against your
+organization’s proxy metrics.
+
+If it is not possible to reduce data at the point of data
+capture, as a developer, you can use AWS Lambda to trim
+event payloads of data attributes that are not required
+for downstream processing. However, as an organization,
+you should balance the trade-off of compute cost of
+removing the data versus retaining the original data
+values. This is not a binary option but should be measured
+over time to determine if it would be worthwhile removing
+data.
+
+For more details, refer to the following information:
+
+- AWS Lambda:
+[Using
+AWS Lambda with Amazon Kinesis](https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis-example.html)
+
+Implement a monitor and alert strategy to get a clear
+picture of data growth over time. Take action on any
+significant data growth by understanding what additional
+attributes have been added to the event payload. Alerts
+should be implemented on thresholds, such as 3x data
+growth, or create an internal metric that your
+organization should expect to increase the overall data
+footprint aligned with new customers.
+
+For more details, refer to the following information:
+
+- Amazon Kinesis:
+[Monitoring
+the Amazon Kinesis Data Streams Service with Amazon CloudWatch](https://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html)
+
+## Suggestion 15.3.4 – Reduce the amount of data migrated from one environment to another
+
+Migrating data from one environment to another is a common exercise. Your
+organization should consider data minimization when migrating from one environment to
+another as migration requires additional network, storage, and compute resources for
+migrating unwanted information. Your organization should regularly review all
+information that is in scope of the migration and determine whether it is necessary
+for future workloads, rather than defaulting to a *migrate all*
+approach.
+
+If your organization maintains a data catalog, a review of the data assets by a
+data owner prior to migrating the data should be performed to understand
+whether the data is required by the business.
+
+For more details, refer to the following information:
+
+- AWS Data Migration: [Top 10 Data Migration](https://pages.awscloud.com/rs/112-TZM-766/images/2020_0124-STG_Slide-Deck.pdf)
+- AWS Data Migration (video):
+[Top 10 Data
+Migration Best Practices](https://www.youtube.com/watch?v=i0-pSHQJ7pA)
+
+## Suggestion 15.3.5 – Apply the optimal data model for your data access patterns
+
+Understanding your data access patterns helps you determine which data modeling technique is most suitable. Work backwards from the way you access the data to determine the most suitable data model. There are two broad approaches to data modelling that you can start to consider: normalization and denormalization.
+
+*Normalization* is the method of arranging the data in a data model
+to reduce redundant data and improve query efficiency. This method involves designing the tables and setting up relationships between those tables according to certain rules. Each piece of data is only stored once, and is referenced using its ID. Joins are used to reassemble the full data model. Typically, normalized data models are used in online transaction processing (OLTP) and are supported by relational databases that store the database data in rows. Normalized models minimize the amount of data stored, and compute power needed to make updates.
+
+*Denormalization* is almost the opposite of normalization. Instead of referencing data using IDs, data is copied as many times as needed. Denormalized data models are typically used in online analytical processing (OLAP) where the data is stored in column-oriented massively parallel processing (MPP) databases such as Amazon Redshift. OLAP is designed for multidimensional analysis of data in a data warehouse, which contains both transactional and historical data. In MPP architectures data locality is important, and keeping redundant copies of data and avoiding joins can reduce the compute power needed, as well as network overhead. On the flip side, they may take up more storage, and updates require more compute power.
+
+Whether you should choose normalization or denormalization for your data model depends on your data access patterns. Consider the way you query and update the data set first. In analytics, denormalized data models often perform better. The extra storage requirements from data duplication is often balanced by compression. When storing data in columns instead of rows, data encoding and compression becomes more efficient.
+
+To normalize or denormalize is not an either-or proposition, but a scale. You can denormalize some parts of your data model heavily, while keeping other parts more normalized. For example, if you store personal data and have to be able to update and delete it easily, normalization of that part of the model may lead to the least environmental impact overall. Each query may become slightly less efficient, but you ensure you don’t have to rewrite the whole data set to remove multiple copies of a data point.
+
+For more details, refer to the following information:
+
+- Modern data architecture:
+[Build a modern data architecture on AWS with Amazon AppFlow, AWS Lake Formation, and Amazon Redshift](https://aws.amazon.com/blogs/big-data/build-a-modern-data-architecture-on-aws-with-amazon-appflow-aws-lake-formation-and-amazon-redshift/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.3-encourage-culture-of-data-minimization.html*
+
+---
+
+# Best practice 15.4 – Implement data retention processes to remove unnecessary data from your analytics environment
+
+The retention of data should be informed, relevant, and limited to what is
+necessary for the purposes for which the data is processed. Storing data indefinitely and
+without purpose can cause significant storage and processing overhead that can impact your
+organization’s analytics environmental impact. Ensure that the period for which the data
+should be stored is limited and reviewed on a regular basis.
+
+**How can you remove unnecessary data from an object
+store?**
+
+## Suggestion 15.4.1 – Deﬁne and implement a data lifecycle process for data at rest
+
+Implement a lifecycle management process that will either remove data that is no
+longer required, or archive data into less resource-intensive storage.
+
+When removing data from an object store, your organization should consider the
+following design points:
+
+- The data retention removal process should run on a regular basis
+- The data retention removal process should remove data from all buckets,
+sub-directories and prefixes.
+- The data retention removal process should take an
+audit of what data has been removed, when it was
+removed, and who performed the removal process. This
+audit data should be tracked in an immutable audit log
+for auditing purposes.
+- Production, user acceptance test (UAT), and
+development (DEV) environments must be included and
+adhere to the agreed retention policy across all
+environments.
+- Consider other locations where data might be stored,
+such as SFTP locations.
+- Classify your organization’s data by data temperature,
+such as *hot* for frequently
+accessed, and *cold* for
+infrequently accessed. After data has been classified
+by temperature, your organization should implement a
+strategy to move data into the respective S3 bucket
+storage classes. For example, cold data could be moved
+to Amazon Glacier storage class. For an
+illustration of data temperatures, see
+[Optimizing
+your AWS Infrastructure for Sustainability, Part II:
+Storage](https://aws.amazon.com/blogs/architecture/optimizing-your-aws-infrastructure-for-sustainability-part-ii-storage/).
+
+For more details, refer to the following information:
+
+- Amazon S3 Lifecycle
+Management:
+[Managing
+your storage lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+
+**How can you remove unnecessary
+data from databases?**
+
+## Suggestion 15.4.2 – Remove unnecessary data from databases
+
+To effectively remove information from a database, your
+organization should track when the data was loaded into
+the database and when the last customer interaction
+occurred, such as a purchase or other activity. This
+tracking helps you accurately identify when data should be
+removed.
+
+- The data retention removal process should run
+frequently, but should not be run excessively, as
+excessive deletion can increase compute resources that
+could mitigate the benefit of removing the data from
+your database.
+- The data retention removal process should remove data
+from all databases and tables.
+- The data retention removal process should retain an
+audit of what data has been removed, when it was
+removed, and who performed the removal process. This
+audit data should be tracked in an immutable audit log
+for auditing purposes.
+- If your database enforces referral integrity, you
+should redact only the data and retain the primary and
+foreign keys.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Amazon Redshift Stored Procedures](https://docs.amazonaws.cn/en_us/redshift/latest/dg/stored-procedure-create.html)
+- Amazon Redshift:
+[DELETE
+Statement](https://docs.aws.amazon.com/redshift/latest/dg/r_DELETE.html)
+- Amazon Redshift:
+[Scheduling
+a query on the Amazon Redshift console](https://docs.aws.amazon.com/redshift/latest/mgmt/query-editor-schedule-query.html)
+
+## Suggestion 15.4.3 – Use the shortest possible retention period in streaming applications
+
+The primary use-case of a streaming application is to transfer information from source to target, but they can also retain data for a configured time. This allows replaying the stream to, for example, recover from corruption in a downstream system. At the same time, data stored in a streaming application becomes redundant as soon as it has been stored downstream. Determine the shortest possible retention period that you need to meet your Recovery Point Objective (RPO).
+
+For more details, refer to the following information:
+
+- Amazon Kinesis:
+[Changing
+the Data Retention Period](https://docs.aws.amazon.com/streams/latest/dev/kinesis-extended-retention.html)
+- Amazon Managed Streaming for Apache Kafka:
+[Adjust
+data retention parameters](https://docs.aws.amazon.com/msk/latest/developerguide/bestpractices.html)
+
+## Suggestion 15.4.4 – Design your application to make it possible to efficiently remove or archive outdated data
+
+Designing a data model that supports efficient deletion of data can be surprisingly hard. In the worst case, the deletion of a single piece of data may require rewriting a large portion of the data set in a data lake. This is inefficient and has an unnecessary environmental impact. When designing an application, also design how you remove or archive data from it once that data is outdated, no longer relevant, or upon request.
+
+Consider, and design for things like:
+
+- How to delete all data belonging to a specific user
+- How to delete data older than a specific time
+- How to delete personal data
+
+In data lakes and analytics applications it is often hard to delete individual pieces of data. Consider how to organize data to reduce the amount of data that has to be rewritten to delete a single piece of data – but always balance it against the impact to query performance.
+
+It is often good practice to partition a data set in a data lake by time to make it possible to efficiently delete historical data when it is no longer needed. Similarly, in a data warehouse, keeping data sorted by time yields similar efficiencies.
+
+For more details see:
+
+- [Optimize your modern data architecture for sustainability: Part 1 – data ingestion and data lake](https://aws.amazon.com/blogs/architecture/optimize-your-modern-data-architecture-for-sustainability-part-1-data-ingestion-and-data-lake/)
+- [AWS Well-Architected Framework: SUS04-BP05 Remove unneeded or redundant data](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sus_sus_data_a6.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.4-implement-data-retention-processes-to-remove-redundant-data-from-your-analytics-environment..html*
+
+---
+
+# Best practice 15.5 – Optimize your data modeling and data storage for efficient data retrieval
+
+How your data is organized in a data store, database, or ﬁle system can have an impact on the amount of resources that are required to store, process, and analyze the data. Using encoding, compression, indexes, partitioning, and similar tools we can make this more efficient and reduce the overall environmental impact of our analytics workloads.
+
+**How can your organization reduce the
+resources required to store, process, and analyze your
+organization’s data in a sustainable manner?**
+
+Reducing data that a database system scans to return a result is an eﬃcient way in reducing your organization’s analytics environmental impact. This approach requires less resources to scan the disk to retrieve the information to service the request, and reduces the amount of provisioned storage required to service the workload. There are diﬀerent methods that database engines use to optimize the amount of information scanned, such as partitioning, bucketing, and sorting.
+
+## Suggestion 15.5.1 – Implement an efficient partitioning strategy for your data lake
+
+Partitioning plays a crucial role when optimizing data sets for
+Amazon Athena or Amazon Redshift Spectrum. By partitioning a data set, you can reduce the amount of data scanned by queries dramatically. This reduces the amount of compute power needed, and therefore the environmental impact.
+
+When implementing a partitioning scheme for your data model, work backwards from your queries and identify the properties that would reduce the amount of data scanned the most. For example, it is common to partition data sets by date. Data sets tend to grow over time, and queries tend to look at specific windows of time, such as the last week, or last month.
+
+For more details, refer to the following information:
+
+- Amazon S3 and Amazon Athena:
+[Partitioning and bucketing in Athena](https://docs.aws.amazon.com/athena/latest/ug/ctas-partitioning-and-bucketing.html)
+- Amazon Athena:
+[Partitioning
+data in Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/partitions.html)
+
+## Suggestion 15.5.2 – Configure and sort distribution keys on your Amazon Redshift tables
+
+Amazon Redshift sort keys determine the order in which
+rows in a table are stored on the disk. When you query a data set in Redshift, it can leverage the sort order of the data to avoid reading blocks that are outside of the range of values you are looking for. By reading fewer blocks of data, this approach can result in a reduction of compute resources required.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Choose
+the best sort key](https://docs.aws.amazon.com/redshift/latest/dg/c_best-practices-sort-key.html)
+
+In Amazon Redshift, the distribution key, or distkey, determines how data is distributed between the nodes in a cluster. Choosing the right distribution keys can improve the performance of common analytical operations like joins and aggregations.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Automate
+your Amazon Redshift performance tuning with automatic
+table optimization](https://aws.amazon.com/blogs/big-data/automate-your-amazon-redshift-performance-tuning-with-automatic-table-optimization/)
+- Amazon Redshift:
+[Distribution
+styles](https://docs.aws.amazon.com/redshift/latest/dg/c_choosing_dist_sort.html)
+
+## Suggestion 15.5.3 – Enable results and query plan caching
+
+Computing the same result over and over again is wasteful. Query engines and data warehouses often support result caching, and/or query plan caching. By enabling these you can reduce the overall amount of compute power needed for your analytics workload by eliminating recomputing results and/or query plans when the data set hasn’t changed. This saves on compute resource and reduce the environmental impact.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Performance
+optimization](https://docs.aws.amazon.com/redshift/latest/dg/c_challenges_achieving_high_performance_queries.html)
+- Amazon Athena: [Query result reuse](https://docs.aws.amazon.com/athena/latest/ug/reusing-query-results.html)
+
+## Suggestion 15.5.4 – Enable data compression to reduce storage resources
+
+Your organization should consider compressing data in both
+object stores, such as Amazon S3, and if supported, in
+your organization’s database systems. By compressing data,
+your organization is reducing the amount of storage and
+networking resources required for the workload. Database
+systems can decompress the data at a rate that is almost
+unnoticeable to the end user or application. As the data
+is compressed and then decompressed, this will also reduce
+the retrieval time of the database engine to fetch all the
+data from the storage array leading to a potential
+reduction in compute resources.
+
+For more details, refer to the following information:
+
+- **Amazon Redshift compression
+and encoding:**
+[Amazon Redshift Engineering’s Advanced Table Design Playbook:
+Compression Encodings](https://aws.amazon.com/blogs/big-data/amazon-redshift-engineerings-advanced-table-design-playbook-compression-encodings/)
+- **Amazon Redshift file
+compression parameter:**
+[File
+compression parameters](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-file-compression.html)
+- Amazon Redshift
+Compression:
+[Compression
+encodings](https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html)
+- Amazon DynamoDB
+Compression:
+[Using
+data compression](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EMRforDynamoDB.CopyingData.Compression.html)
+- Amazon Athena Compression
+Support:
+[Amazon Athena compression support](https://docs.aws.amazon.com/athena/latest/ug/compression-formats.html)
+
+## Suggestion 15.5.5– Use file formats that optimize storage and compute needs
+
+There are many diﬀerent file formats that can be used to store data from the ubiquitous CSV format, through structured formats like JSON, and data lake-optimized formats like Parquet – each is designed to overcome speciﬁc technical challenges. There is no file format that meets all needs, and different formats have different uses.
+
+For analytical workloads, columnar file formats like Parquet and ORC often perform better overall. They achieve higher compression rates, and help query engines scan less data. Through reduced storage and compute needs they can help reduce the environmental impact of your workload.
+
+More information on how to choose the right format can be found in [Choose the best-performing file format and partitioning](https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/design-principle-10.html).
+
+## Suggestion 15.5.6– Avoid using unnecessary operations in queries, use approximations where possible, and pre-compute commonly used aggregates and joins
+
+Consider the computational requirements of the operations you use when writing queries. For example, think about how the result gets consumed. For example, avoid adding an ORDER BY clause unless the result strictly needs to be ordered.
+
+Many compute-intensive operations can be replaced by approximations. Modern query engines and data warehouses, like Amazon Athena and Amazon Redshift, have functions that can calculate approximate distinct counts, approximate percentiles, and similar analytical functions. These often require much less compute power to run, which can lower the environmental impact of your analytical workload.
+
+Consider pre-computing operations. When you notice that the complexity of your queries increase, or that many queries include the same joins, aggregates, or other compute intensive operations, this can be a sign that you should pre-compute these. Depending on your platform this can be in the form of adding steps to your data transformation pipeline, or by introducing a materialized view.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.5-optimize-your-data-modeling-and-data-storage-for-efficient-data-retrieval..html*
+
+---
+
+# Best practice 15.6 – Prevent unnecessary data movement between systems and applications
+
+Moving data around your organization can be very costly as
+it requires compute, networking, and storage resources. This
+can be particularly costly for analytics workloads as they
+generally require large quantities of information. When
+businesses move data around their organization, they
+increase the risk of creating duplicate data, which can
+impact your storage resource.
+
+At the same time, making multiple copies of data can also reduce the overall amount of data transferred from each access to the data. When designing your data platform, consider the overall environmental impact and make informed choices about when and when not to duplicate data.
+
+**How does your organization mitigate
+the unnecessary data movement from one part of your
+organization to another?**
+
+## Suggestion 15.6.1 – Implement data virtualization techniques to query information where the data resides
+
+In data virtualization, only the data that is required to service the request is copied from the source location into the data virtualization layer and temporarily cached in memory. This data is then used to service the user’s request. By copying the most frequently used parts of the data set closer to the compute instances, overhead associated with data movement is reduced, and the query processing has more efficient access to the data.
+
+For more details, refer to the following information:
+
+- Use Amazon Athena for data
+virtualization:
+[Amazon Athena](https://aws.amazon.com/athena/?whats-new-cards.sort-by=item.additionalFields.postDateTime&whats-new-cards.sort-order=desc)
+- Running Presto and Trino on Amazon EMR:
+[Presto
+and Trino](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-presto.html)
+
+## Suggestion 15.6.2 – Reduce the ﬂow of data between application and database by implementing predicates pushdown
+
+Filtering data by pushing down predicates as close to the storage as possible reduces the amount of data that upstream systems need to process. Query engines like Amazon Athena have query planners that leverage predicate pushdown where possible. For example, when using columnar file formats like Parquet and ORC, Athena can use metadata stored in the files to determine which sections of the files to read, effectively pushing down some predicates to the storage layer. Similarly, when querying a federated data source, Athena can push down some, but not all, predicates into the source systems. This reduces the amount of data that needs to be transferred from the source system into the query engine itself. Research the query engine you use to determine under which circumstances it is able to perform predicate pushdown, and leverage this in your application.
+
+For more details, refer to the following information:
+
+- Use pushdown predicated with Amazon Athena:
+[Top
+10 Performance Tuning Tips for Amazon Athena](https://aws.amazon.com/blogs/big-data/top-10-performance-tuning-tips-for-amazon-athena/)
+- Optimizing EMR Spark with leveraging pushdown
+predicates:
+[Optimize
+Spark performance](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-performance.html)
+
+## Suggestion 15.6.3 – Prevent data movement by leveraging pre-calculated materialized views
+
+A materialized view can reduce the amount of data shared
+between your data warehouse and reporting layers by
+pre-computing the results of a pre-defined query.
+Materialized views are especially useful for speeding up
+queries that are predictable and repeated. Instead of
+performing resource-intensive queries against large tables
+(such as aggregates or multiple joins), applications can
+query a materialized view and retrieve a precomputed
+result set, therefore, saving on compute resource and
+reducing an organization’s analytics environmental impact.
+
+Where materialized views are not available, you can use operations such as CREATE TABLE AS (CTAS) to create pre-computed versions of queries.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Creating
+materialized views in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html)
+- Amazon Athena: [Creating a table from query results (CTAS)](https://docs.aws.amazon.com/athena/latest/ug/ctas.html)
+
+## Suggestion 15.6.4 – Reduce the flow of data between an operational database and a data warehouse by using federated querying
+
+A federated query allows you to directly
+query data stored in external databases without data movement. This allows data
+analysts, engineers, and data scientists to perform SQL
+queries across data stored in relational, non-relational,
+object, and custom data sources.  With federated querying,
+you can submit a single SQL query and analyze data from
+multiple sources running on premises or hosted in the
+cloud, which reduces data latency in reporting. Federated
+querying can reduce the amount of information shared
+between data stores, however, the sustainability trade-off
+is that your organization could transfer the same
+information multiple times rather than a once-off single
+bulk copy of all information on a daily basis. Your
+organization should frequently review your federated
+querying patterns to identify whether it’s more
+sustainable to use federated query or single bulk copies.
+To do this, your organization could review the amount of
+data that has been queried in a week, versus calculating
+the size of a full extract, and implement the approach
+that processes the least amount of data.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Querying
+data with federated queries in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/federated-overview.html)
+- Amazon Athena:
+[Using
+Amazon Athena Federated Query](https://docs.aws.amazon.com/athena/latest/ug/connect-to-a-data-source.html)
+
+## Suggestion 15.6.5 – Decrease the amount of data duplication between Amazon Redshift clusters by using data sharing
+
+Data sharing allows an administrator to share databases, tables, and views from one Amazon Redshift cluster to another cluster without copying the underlying data. The consumer cluster can query live data, meaning changes made on the producer cluster reflect immediately on the consumer cluster. This removes the need to create, store, and keep copies of data sets up-to-date.
+
+For more details, refer to the following information:
+
+- Amazon Redshift:
+[Amazon Redshift Data Sharing](https://aws.amazon.com/redshift/features/data-sharing/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.6-prevent-unnecessary-data-movement-between-systems-and-applications..html*
+
+---
+
+# Best practice 15.7 – Efficiently manage your analytics infrastructure to reduce underutilized resources
+
+Ensuring your organization has the correct amount of resource provisioned for your workload is a diﬃcult and challenging task. The common approach for ensuring your organization has the suﬃcient number of resources available for unpredicted peaks is to overprovision your resources. However, this approach generally leads to underutilization, and energy waste.
+
+When designing your analytics workloads, consider using managed and serverless services. Managed services shift responsibility for maintaining high average utilization, and sustainability optimization of the deployed hardware, to AWS. Use managed services to distribute the sustainability impact of the service across all tenants of the service, reducing your individual contribution.
+
+For a wider understanding of optimizing infrastructure for sustainability, refer to the
+following information:
+
+- Well-Architected Sustainability: [Optimizing your AWS Infrastructure for Sustainability, Part I: Compute](https://aws.amazon.com/blogs/architecture/optimizing-your-aws-infrastructure-for-sustainability-part-i-compute/)
+- Well-Architected Sustainability: [Optimizing your AWS Infrastructure for Sustainability, Part II: Storage](https://aws.amazon.com/blogs/architecture/optimizing-your-aws-infrastructure-for-sustainability-part-ii-storage/)
+
+**How does your organization ensure efficient infrastructure
+usage?**
+
+## Suggestion 15.7.1– Use managed and serverless services
+
+Serverless is ideal when it is diﬃcult to predict compute needs, such as with variable workloads, periodic workloads with idle time, and steady-state workloads with spikes. These kinds of workloads are common in analytics applications. Data processing pipelines, running reports, and as-necessary queries are some examples.
+
+Use serverless services AWS Glue ETL and Amazon EMR Serverless to run your data processing jobs and let AWS manage and optimize the underlying resources efficiently. Similarly, using Amazon Athena and Amazon Redshift Serverless for data lakes and data warehousing ensures that you only use compute resources when needed, and allow these services to optimize resource utilization behind the scenes.
+
+For more details, refer to the following information:
+
+- [Amazon Athena](https://aws.amazon.com/athena/)
+- [AWS Glue](https://aws.amazon.com/glue/engines/)
+- [Amazon Redshift Serverless](https://aws.amazon.com/redshift/redshift-serverless/)
+- [Amazon EMR Serverless](https://aws.amazon.com/emr/serverless/)
+
+## Suggestion 15.7.2– Pause your data warehouse and compute clusters when not in use
+
+Compute resources should only be allocated when needed. If your workload cannot leverage serverless technologies, you should implement a process of stopping your compute clusters if there are periods when they will not be used (for example, during nights and weekends).
+
+If your data warehouse uses Amazon Redshift, you can use the pause and resume feature. This retains the underlying data structures so that you can resume the cluster when needed. You can pause and resume clusters using the console, or the API, or even create a schedule that automatically pauses and resumes the cluster at set times.
+
+Pausing data warehouse and compute clusters when not in use ensures there are fewer underutilized resources and reduces the environmental impact of your analytics workload.
+
+For more details, refer to the following information:
+
+- [Amazon Redshift pause and resume: Lower your costs with the new pause and resume actions on Amazon Redshift](https://aws.amazon.com/blogs/big-data/lower-your-costs-with-the-new-pause-and-resume-actions-on-amazon-redshift/)
+- [Amazon Redshift pause and resume: Pausing and resuming clusters](https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html#rs-mgmt-pause-resume-cluster)
+- [AWS Well-Architected Framework Data Analytics: Decouple storage from compute](https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-11.1---decouple-storage-from-compute..html)
+
+## Suggestion 15.7.3 – Scale your data warehouses and compute clusters to match demand
+
+Only the necessary amount of compute resources should be allocated at any time. Scaling your data warehouse and compute clusters to match demand helps you maximize resource utilization, and reduce the environmental impact of your analytics workload.
+
+For more details, refer to the following information:
+
+- [AWS Well-Architected Framework: SUS05-BP01 Use the minimum amount of hardware to meet your needs](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sus_sus_hardware_a2.html)
+- AWS Well-Architected Framework Data Analytics: Best practice 11.4 – Use auto scaling where appropriate
+- [Scale Amazon Redshift to meet high throughput query requirements](https://aws.amazon.com/blogs/big-data/scale-amazon-redshift-to-meet-high-throughput-query-requirements/)
+- [Amazon Redshift: Elastic resize](https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html#elastic-resize)
+- [Amazon Redshift: Working with concurrency scaling](https://docs.aws.amazon.com/redshift/latest/dg/concurrency-scaling.html)
+
+## Suggestion 15.7.4 – Run your analytics workloads on spare capacity in your Amazon EKS environment for optimal application infrastructure usage
+
+If you use Amazon EKS to run your applications, you can use Amazon EMR on Amazon EKS to also run your analytics workloads, such as Apache Spark jobs, on the same infrastructure. This can make it possible to increase the utilization of your existing compute resources.
+
+For more details, refer to the following information:
+
+- [Amazon EMR on Amazon EKS](https://aws.amazon.com/emr/features/eks/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/analytics-lens/best-practice-15.7-efficiently-manage-your-analytics-infrastructure-to-reduce-underutilized-resources.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLCOST01.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLCOST01.md
@@ -1,0 +1,342 @@
+# MLCOST01
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLCOST01-BP01 Define overall return on investment (ROI) and opportunity cost
+
+Machine learning projects require careful evaluation of their
+business value and resource requirements. By analyzing the ROI and
+opportunity costs of ML implementations, you can make informed
+decisions that optimize resource allocation while delivering maximum
+business impact.
+
+**Desired outcome:** When you
+implement this practice, you have a clear understanding of the
+financial and business implications of your ML projects. You can
+differentiate between research-oriented and development-oriented ML
+initiatives, track costs effectively through tagging mechanisms, and
+make data-driven decisions about resource allocation. You have
+established processes to continuously evaluate the cost-benefit
+ratio of ML initiatives as business conditions evolve, and your
+investments deliver measurable value while managing risks
+appropriately.
+
+**Common anti-patterns:**
+
+- Initiating ML projects without defining clear business
+objectives or expected outcomes.
+- Failing to distinguish between research projects (long-term
+returns) and development projects (near-term returns).
+- Not implementing cost tracking mechanisms for ML projects.
+- Overlooking the ongoing operational costs of maintaining ML
+models in production.
+- Failing to reassess the cost-benefit model when business
+conditions change.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved allocation of limited resources to ML initiatives with
+highest potential returns.
+- Clear visibility into project costs and benefits for better
+budgeting and planning.
+- Reduced risk of project failure through upfront analysis and
+ongoing monitoring.
+- Enhanced ability to communicate ML value to stakeholders.
+- Accelerated time-to-value through focus on high-impact use
+cases.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Understanding the financial implications of machine learning
+initiatives is crucial for making strategic technology
+investments. Machine learning projects can vary significantly in
+terms of resource requirements, timeline to value, and overall
+business impact. By carefully evaluating the ROI and opportunity
+costs, you can prioritize initiatives that deliver the most
+significant business value while managing costs effectively.
+
+Start by working with both technical and business teams to clearly
+define whether an ML project is research-oriented (focused on
+exploring potential future value) or development-oriented
+(applying established methods to deliver immediate business
+value). This distinction assists to set appropriate expectations
+around timelines, resources, and outcomes. Implement comprehensive
+cost tracking through tagging mechanisms to maintain visibility
+into project expenses across data engineering, model development,
+and production deployment phases.
+
+When assessing ML project costs, consider both direct expenses
+(infrastructure, tools, services) and indirect costs (staff time,
+training requirements, maintenance). Factor in potential costs
+associated with data preparation, model accuracy, and production
+errors. Develop a comprehensive cost-benefit model that accounts
+for these elements while considering business-specific factors
+like competitive advantage and strategic positioning.
+
+### Implementation steps
+
+- **Specify the objectives of the ML
+project as research or development**. Work with
+both business stakeholders and data science teams to
+determine if your ML initiative is exploratory research with
+long-term returns or development applying established
+methods for faster ROI. Align between technical teams and
+business leaders on project classification, timelines, and
+expected outcomes.
+- **Use tagging to track costs by
+project and business unit**. Implement
+comprehensive tagging in your AWS environment using
+[AWS Cost Categories](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-categories.html) and
+[AWS Tagging](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html) strategies to allocate ML-related expenses to
+specific projects and business functions. Monitor these
+costs through
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) to maintain clear visibility of ROI by
+project.
+- **Evaluate and assess the data
+pipeline, the ML model, and the expected quality of
+production inferences**. Analyze the infrastructure
+requirements, operational costs, and potential business
+impact of errors in your ML system. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) to assess model quality and
+identify potential bias that could impact business outcomes
+and add remediation costs.
+- **Develop a cost-benefit
+model**. Create a comprehensive financial model
+that accounts for initial development costs, ongoing
+operational expenses, and expected business benefits.
+Regularly reassess this model as business conditions change
+or when considering new data sources. Use
+[Quick](https://aws.amazon.com/quicksight/) to build dashboards tracking ML costs
+against business KPIs.
+- **Understand, evaluate, and monitor
+project risks**. Identify technical, operational,
+and business risks associated with your ML project.
+Establish monitoring systems to track these risks through
+development and production phases. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor technical metrics and
+[AWS Budgets](https://aws.amazon.com/aws-cost-management/aws-budgets/) to track spending against forecasts.
+- **Estimate the cost of resources
+needed for production maintenance**. Calculate the
+ongoing expenses required to maintain your ML model in
+production, including data engineers, data scientists,
+infrastructure costs, and monitoring systems. Consider using
+[AWS Application Cost Profiler](https://aws.amazon.com/aws-cost-management/aws-application-cost-profiler/) to attribute costs
+accurately across your ML applications.
+- **Leverage enhanced cost tracking and
+optimization tools**. Use
+[AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html) to automatically identify
+unusual spending patterns in your ML workloads and receive
+alerts for unexpected cost increases.
+- **Consider model selection trade-offs
+for generative AI projects**. When implementing
+generative AI solutions, carefully evaluate the balance
+between model size, performance, and cost. Smaller,
+domain-specific models may be more cost-effective than large
+foundation models for certain use cases. Consider using
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for access to multiple foundation models
+through a single API, allowing for streamlined model
+selection and optimization.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Pricing Calculator](https://calculator.aws/#/createCalculator)
+- [What
+is AWS Billing and Cost Management and Cost Management?](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-categories.html)
+- [Optimizing
+cost for building AI models with Amazon EC2 and SageMaker AI](https://aws.amazon.com/blogs/aws-cloud-financial-management/optimizing-cost-for-developing-custom-ai-models-with-amazon-ec2-and-sagemaker-ai/)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 4: Training jobs](https://aws.amazon.com/blogs/machine-learning/part-4-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-4-training-jobs/)
+- [AWS Application Cost Profiler](https://aws.amazon.com/aws-cost-management/aws-application-cost-profiler/)
+- [Getting
+started with AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html)
+- [Managing
+costs with AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [AWS Cost and Usage Report](https://aws.amazon.com/aws-cost-management/aws-cost-and-usage-reporting/)
+- [Generative
+AI Cost Optimization Strategies](https://aws.amazon.com/blogs/enterprise-strategy/generative-ai-cost-optimization-strategies/)
+
+**Related videos:**
+
+- [Maximizing
+ML ROI: Amazon SageMaker AI's High-Performance Inference and Cost
+Optimization Strategies](https://aws.amazon.com/awstv/watch/3cf59d4c5e5/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost01-bp01.html*
+
+---
+
+# MLCOST01-BP02 Use managed services to reduce total cost of ownership (TCO)
+
+Using managed machine learning services enables organizations to
+operate more efficiently with reduced resources and costs compared
+to self-managed options. This approach reduces undifferentiated
+heavy lifting, reduces operational burden, and allows teams to focus
+on delivering business value.
+
+**Desired outcome:** By adopting
+managed services and pay-per-usage models, you significantly reduce
+your total cost of ownership while gaining access to a comprehensive
+suite of AI/ML tools. You can use pre-built capabilities instead of
+developing custom solutions, automatically scale resources based on
+demand, and benefit from AWS's continuous innovations without
+additional investment. Your teams can focus on creating business
+value rather than managing infrastructure.
+
+**Common anti-patterns:**
+
+- Building and maintaining custom ML infrastructure on EC2 or
+Kubernetes.
+- Overprovisioning resources for peak ML workloads.
+- Failing to use commitment discounts for persistent workloads.
+- Developing proprietary AI services when managed services would
+suffice.
+- Not analyzing workload patterns to optimize instance selection.
+
+**Benefits of establishing this best
+practice:**
+
+- Significantly lower total cost of ownership compared to
+self-managed options.
+- Reduced operational overhead and simplified management.
+- Increased team productivity with focus on core business
+problems.
+- Access to continuously updated and improved AI/ML capabilities.
+- Flexibility to scale resources based on actual demand.
+- Ability to use commitment-based pricing for additional savings.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Managed services remove the operational burden of maintaining
+infrastructure, allowing you to concentrate on developing ML
+models and applications that drive business value. Using AWS's
+managed ML services provides a comprehensive environment for
+building, training, and deploying models with significantly lower
+costs than self-managed options.
+
+When evaluating your ML strategy, consider the total cost of
+ownership including infrastructure, operational personnel,
+maintenance, scaling, and upgrades. Amazon SageMaker AI provides a
+fully managed service that avoids many of these costs while
+offering advanced ML capabilities. Similarly, AWS's pre-trained AI
+services can address common use cases without requiring ML
+expertise, further reducing implementation time and costs.
+
+To maximize cost efficiency, analyze your workload patterns and
+determine which components would benefit from commitment
+discounts. By using Savings Plans, you can significantly reduce
+your AWS usage costs while maintaining flexibility across instance
+families, sizes, regions, and components.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI as your
+fully managed ML solution.**
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) enables building, training, and
+deploying models at scale with significantly lower costs.
+The total cost of ownership (TCO) of SageMaker AI over a
+three-year period is much lower than other self-managed
+cloud-based ML options, such as
+[Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html) (Amazon EC2) and
+[Amazon Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) (Amazon EKS). SageMaker AI
+includes technologies such as
+[Autopilot](https://aws.amazon.com/sagemaker/autopilot/),
+[Feature
+Store](https://aws.amazon.com/sagemaker/feature-store/),
+[Clarify](https://aws.amazon.com/sagemaker/clarify/),
+[Debugger](https://aws.amazon.com/sagemaker/debugger/),
+[Studio](https://aws.amazon.com/sagemaker/studio/),
+[Training](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html),
+Model deployment,
+[Monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html),
+and
+[Pipelines](https://aws.amazon.com/sagemaker/pipelines/).
+- **Use Amazon managed AI services for
+common use cases.** AWS pre-trained AI services
+provide ready-made intelligence for your applications and
+workflows. These services address common use cases such as
+personalized recommendations, contact center modernization,
+safety and security improvement, and customer engagement
+enhancement. They don't require machine learning expertise,
+are fully managed, and offer pay-as-you-go pricing with no
+upfront commitment.
+- **Perform pricing model analysis for
+cost optimization.** Analyze each component of your
+ML workload to determine if it will run for extended
+periods, making it eligible for commitment discounts such as
+[AWS Savings Plans](https://docs.aws.amazon.com/savingsplans/latest/userguide/what-is-savings-plans.html). You can use Savings Plans to reduce
+AWS usage costs by committing to a consistent amount of
+usage.
+[Amazon SageMaker AI Savings Plans](https://aws.amazon.com/savingsplans/ml-pricing/) offer flexible attributes
+such as instance family, instance size, AWS Region, and
+component for your SageMaker AI instance usage.
+- **Implement right-sizing strategies
+for ML resources.** Evaluate your actual ML
+workload resource requirements and adjust instance types and
+sizes accordingly. This blocks overprovisioning and assists
+to control costs while maintaining performance. Use
+SageMaker AI's automatic scaling capabilities to match
+resources with demand.
+- **Use serverless options when
+appropriate.** For intermittent workloads or those
+with variable demand, consider serverless options like
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) to avoid paying for
+idle resources.
+- **Use Amazon Bedrock for foundation
+model access.**
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) provides a unified API for accessing various
+foundation models, making it simple to experiment with and
+integrate generative AI capabilities without investing in
+model training infrastructure. This fully managed service
+assists to reduce costs while allowing flexibility to choose
+the right model for your use case.
+- **Use Foundation Model Hub for
+centralized model access**. Use the Foundation
+Model Hub to access a centralized catalog of popular
+foundation models with simplified deployment and performance
+benchmarking tools, reducing the time and cost of model
+selection and deployment.
+- **Use AI-powered code generation
+tools.** Use
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and AI-powered IDEs like Kiro to
+accelerate ML development through AI-assisted coding,
+automated code generation, and intelligent troubleshooting,
+significantly reducing developer time and associated costs.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon
+managed AI services](https://aws.amazon.com/machine-learning/ai-services/)
+- [AWS AI Services overview](https://aws.amazon.com/machine-learning/)
+- [ML
+Savings Plans](https://aws.amazon.com/savingsplans/ml-pricing/)
+- [AWS Pricing Calculator for SageMaker AI](https://calculator.aws/#/createCalculator/SageMaker AI)
+- [Viewing
+resource recommendations](https://docs.aws.amazon.com/compute-optimizer/latest/ug/viewing-recommendations.html)
+- [What
+is Amazon Bedrock?](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
+- [What
+is AWS Migration Hub?](https://docs.aws.amazon.com/migrationhub/latest/ug/whatishub.html)
+- [What
+are AWS Cost and Usage Reports?](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost01-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLCOST02.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLCOST02.md
@@ -1,0 +1,338 @@
+# MLCOST02
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLCOST02-BP01 Identify if machine learning is the right solution
+
+Evaluating whether machine learning is the appropriate solution for
+your business problem is crucial for cost optimization. Not every
+problem requires ML solutions, and sometimes simpler approaches may
+be more effective and less costly. By thoroughly evaluating
+alternatives against ML approaches, you can make informed decisions
+that optimize both your technical resources and business outcomes.
+
+**Desired outcome:** You identify
+whether machine learning is truly the optimal solution for your
+business problem by comparing it against simpler alternatives. You
+make informed decisions about resource allocation, understanding the
+cost implications of ML adoption including data preparation,
+storage, training, hosting, and maintenance. You validate your
+approach using tools like Amazon SageMaker AI Autopilot and Amazon SageMaker AI Clarify to verify that ML provides measurable benefits
+over alternative solutions.
+
+**Common anti-patterns:**
+
+- Jumping directly to ML solutions without evaluating simpler
+alternatives.
+- Underestimating the total cost of implementing ML, including
+data preparation and maintenance.
+- Failing to establish a baseline for comparison with existing or
+rules-based approaches.
+- Overlooking specialized resource constraints such as data
+scientist availability or model time-to-market.
+
+**Benefits of establishing this best
+practice:**
+
+- Avoids unnecessary complexity and cost in solution design.
+- Optimizes resource allocation based on actual business value.
+- Reduces risk of project failure due to inappropriate technology
+selection.
+- Provides quantifiable metrics for evaluating ML solution
+effectiveness.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When considering machine learning for a business problem, start by
+thoroughly evaluating whether ML is truly necessary. Many problems
+can be effectively solved with simpler rule-based approaches that
+may be less expensive to develop and maintain. Machine learning
+requires significant investment in data preparation, specialized
+hardware, and ongoing maintenance that must be justified by the
+business value it delivers.
+
+Begin by clearly articulating your problem and determining if it
+requires the adaptive learning capabilities that ML provides.
+Consider if the problem involves complex patterns that rules can't
+simply capture, or if it requires continuous adaptation to
+changing conditions. For example, fraud detection in financial
+transactions might benefit from ML due to constantly evolving
+fraudulent behaviors, while simple inventory management might be
+better served by a rules-based system.
+
+Evaluate costs associated with an ML solution, including data
+preparation, storage, compute resources for training, potential
+data labeling, model hosting, and ongoing maintenance. Compare
+these costs against the business value gained from using ML versus
+alternative approaches. Remember that specialized resources like
+data scientists might be your most constrained resource, making
+their time allocation a critical consideration.
+
+### Implementation steps
+
+- **Articulate your problem
+clearly**. Define the business problem you're
+trying to solve, the desired outcomes, and how success will
+be measured. Be specific about what decisions need to be
+made and what data is available to support those decisions.
+- **Identify your data
+sources**. Evaluate what data you already have,
+what data you need to collect, and whether the quality and
+quantity are sufficient for ML applications. Consider
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) to catalog and manage your data assets.
+- **Calculate comprehensive cost
+implications**. Consider the aspects of
+implementing an ML solution:
+
+Data preparation and engineering costs
+- Data storage requirements and associated costs using
+[Amazon S3](https://aws.amazon.com/s3/) or other storage services
+- Model training expenses on various hardware options in
+[Amazon SageMaker AI Model Training](https://aws.amazon.com/sagemaker/ai/train/)
+- Data labeling costs if supervised learning is required
+- Potential retraining costs due to model drift or bias
+- Model hosting and inference costs
+- Ongoing maintenance and monitoring expenses
+
+- **Establish a baseline
+solution**. Evaluate how the problem is currently
+being solved or how it could be solved with a simpler
+approach. If a rules-based solution exists, use it as a
+baseline for comparison. For basic ML approaches, consider
+pre-built solutions from
+[AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning) or
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/).
+- **Build and evaluate an ML
+prototype**. Use
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) or
+[Amazon SageMaker AI Autopilot](https://docs.aws.amazon.com/sagemaker/latest/dg/autopilot-automate-model-development.html) to quickly develop an ML model.
+Compare the performance metrics of this solution against
+your baseline approach, including accuracy, inference time,
+and total cost of operation.
+- **Analyze model
+explainability**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-fairness-and-explainability.html) to understand how your ML model
+makes decisions and evaluate if these explanations align
+with business expectations and requirements.
+- **Make a data-driven
+decision**. Based on your comparative analysis,
+determine if the ML approach demonstrates sufficient
+improvement over simpler solutions to justify the
+investment. Consider both quantitative metrics and
+qualitative factors like flexibility and scalability.
+- **Use no-code ML for rapid
+validation**. Use
+[SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html) with natural language support to quickly
+validate whether ML approaches provide value over simpler
+solutions, reducing the time and cost of initial feasibility
+assessment. Export Canvas-generated models and code to
+notebooks for further customization and integration into
+production workflows.
+- **Use AI-powered code generation for
+rapid prototyping**. Use AI-powered development
+tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to quickly
+generate ML prototype code, automate data preprocessing
+scripts, and accelerate the validation process for
+determining if ML is the right solution.
+- **Assess hybrid approaches**.
+Consider whether combining rules-based systems with ML or
+generative AI could provide the optimal balance of cost,
+performance, and explainability for your specific use case.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [SageMaker AI
+autopilot](https://docs.aws.amazon.com/sagemaker/latest/dg/autopilot-automate-model-development.html)
+- [Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/)
+- [Machine
+Learning solutions in AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning)
+- [Cost
+Optimization Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [What
+is Amazon Bedrock?](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost02-bp01.html*
+
+---
+
+# MLCOST02-BP02 Perform a tradeoff analysis between custom and pre-trained models
+
+Optimize machine learning costs by carefully analyzing the tradeoffs
+between developing custom models and using pre-trained models. This
+analysis should maintain security and performance efficiency within
+acceptable thresholds while minimizing unnecessary expenses.
+
+**Desired outcome:** You achieve
+optimal cost efficiency in your machine learning initiatives by
+making informed decisions about when to use pre-trained models
+versus developing custom solutions. You balance development costs,
+time-to-market, model performance, and specific business
+requirements while maintaining appropriate security standards. This
+strategic approach allows you to accelerate ML development while
+optimizing your investment in AI/ML resources.
+
+**Common anti-patterns:**
+
+- Building custom models for every use case without considering
+available pre-trained alternatives.
+- Using pre-trained models without evaluating if they meet your
+specific business requirements.
+- Ignoring the total cost of ownership including data scientist
+time, infrastructure, and ongoing maintenance.
+- Overlooking security and compliance requirements when selecting
+pre-trained models.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time-to-market for ML solutions.
+- Lower development and operational costs.
+- Ability to use state-of-the-art models without needing extensive
+expertise.
+- More efficient use of data scientist and ML engineer resources.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When implementing machine learning solutions, the decision between
+building custom models and using pre-trained ones significantly
+impacts costs, time-to-market, and solution effectiveness. Custom
+models offer greater flexibility and potential performance
+advantages for specialized tasks but require substantial
+investment in data collection, training infrastructure, and
+expertise. Pre-trained models provide rapid deployment and reduced
+initial costs but may not perfectly align with specific business
+needs.
+
+Your analysis should consider factors including data availability,
+task specificity, performance requirements, available expertise,
+and long-term maintenance costs. For many common use cases like
+sentiment analysis, image classification, or document processing,
+pre-trained models can deliver excellent results without the
+overhead of custom development. For highly specialized domains or
+when competitive advantage depends on model performance, custom
+development may justify the additional investment.
+
+### Implementation steps
+
+- **Assess your machine learning
+needs**. Begin by clearly defining your business
+use case, required model accuracy, latency requirements, and
+available data. Understand whether your use case is standard
+(for example, image classification or sentiment analysis) or
+highly specialized to guide your decision-making process.
+- **Use Amazon SageMaker AI built-in
+algorithms and AWS Marketplace**.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/ai/?nc=sn&loc=1) provides a suite of built-in algorithms
+for data scientists and machine learning practitioners to
+get started on training and deploying machine learning
+models. Pre-trained ML models are ready-to-use models that
+can be quickly deployed on Amazon SageMaker AI. By pre-training
+the ML models for you, solutions in the
+[AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning/pre-trained-models) take care of the heavy lifting so that
+you can deliver AI- and ML-powered features faster and at a
+lower cost. Evaluate the cost of your data scientists' time
+and other resource requirements to develop your own custom
+model vs. bringing a pre-trained model and deploying it on
+SageMaker AI for inferencing. The advantage of a custom model
+is the flexibility to fine-tune it to match the needs of
+your business use case. A pre-trained model can be difficult
+to modify and you might have to use it as is.
+- **Use Amazon SageMaker AI
+JumpStart**. Use
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) to access pre-trained models and
+accelerate the ML development process. SageMaker AI JumpStart
+provides a set of solutions for the most common use cases
+that can be deployed readily with just a few clicks. The
+solutions are fully customizable and showcase the use of AWS CloudFormation templates and reference architectures so you
+can accelerate your ML journey. Amazon SageMaker AI JumpStart
+also supports one-click deployment and fine-tuning of more
+than 150 popular open-source models such as natural language
+processing, object detection, and image classification
+models.
+- **Conduct a cost-benefit
+analysis**. Calculate the total cost of ownership
+for both custom and pre-trained approaches, including
+development time, infrastructure costs, and ongoing
+maintenance. Consider factors such as data preparation,
+training resources, and the expertise required. Compare
+these costs against expected business value and performance
+requirements to determine the most cost-effective approach.
+- **Implement cost monitoring and
+optimization**. Use
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and
+[AWS Budgets](https://aws.amazon.com/aws-cost-management/aws-budgets/) to monitor and manage your ML workload costs.
+Implement automatic shutdown of idle resources to reduce
+unnecessary expenses. Consider using
+[AWS Compute Optimizer](https://aws.amazon.com/compute-optimizer/) to get cost optimization
+recommendations for your ML infrastructure.
+- **Explore model customization
+options**. When pre-trained models don't fully meet
+your requirements, explore customization options like
+fine-tuning or transfer learning before committing to full
+custom development. This approach can provide a middle
+ground between cost and performance and access to existing
+models while adapting them to your specific needs.
+- **Implement a multi-model
+approach**. For complex use cases, consider using
+different models for different components of your solution
+based on their requirements. This allows you to optimize
+costs by using simpler, more economical models where
+appropriate while reserving more powerful models for tasks
+that require them.
+- **Evaluate foundation models in Amazon
+Bedrock**.
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) provides a fully managed service that offers
+foundation models from leading AI companies through a single
+API. Consider using these models for text, image, and
+multimodal generative AI applications instead of building
+custom models. You can customize these models to your
+specific needs using retrieval-augmented generation (RAG) or
+fine-tuning while maintaining cost efficiency.
+- **Use expanded pre-trained model
+libraries**. Use the expanded
+[SageMaker AI
+JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) catalog which now includes broader
+selection of pre-trained models and industry-specific
+solutions, reducing the need for custom model development
+and associated costs.
+- **For generative AI workloads,
+consider retrieval-augmented generation (RAG)**.
+For many generative AI applications, implementing RAG can
+enhance the performance of foundation models by providing
+them with relevant context from your organization's data.
+This approach can be more cost-effective than fine-tuning
+and still provide customized outputs tailored to your
+business domain.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/)
+- [Pre-trained
+machine learning models available in AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning/pre-trained-models)
+- [Amazon SageMaker AI pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [Cloud
+Financial Management with AWS](https://aws.amazon.com/aws-cost-management/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost02-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLCOST03.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLCOST03.md
@@ -1,0 +1,679 @@
+# MLCOST03
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLCOST03-BP01 Use managed data labeling
+
+Use managed labeling tools that provide automation and access to
+cost-effective teams of human data labelers. These tools should
+offer flexibility to choose a variable number of labelers for each
+input, include a user-friendly interface, and incorporate learning
+capabilities to improve labeling efficiency over time.
+
+**Desired outcome:** You have access
+to high-quality labeled datasets for your machine learning models
+without building and managing your own labeling infrastructure. Your
+data labeling process is streamlined, cost-efficient, and scales
+according to your needs, allowing you to focus on model development
+rather than data preparation logistics.
+
+**Common anti-patterns:**
+
+- Building custom data labeling infrastructure from scratch.
+- Relying solely on in-house teams for labeling tasks regardless
+of scale.
+- Using labeling solutions that don't improve through machine
+learning.
+- Managing inconsistent labeling quality without proper oversight
+tools.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduce time-to-market for ML models by accelerating the data
+labeling process.
+- Lower total labeling costs through efficient automation and
+on-demand workforce.
+- Improve labeling quality and consistency through specialized
+tools and workflows.
+- Scale labeling operations up or down based on project
+requirements.
+- Focus your team's effort on model development rather than
+labeling infrastructure.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+To build effective machine learning models, you need large,
+high-quality labeled datasets. Creating these datasets manually is
+time-consuming, expensive, and difficult to scale. By using
+managed data labeling services, you can accelerate this critical
+step in the ML development process while controlling costs and
+maintaining quality.
+
+Managed data labeling combines human intelligence with machine
+learning to improve efficiency over time. As your models process
+more data, they can begin to automate parts of the labeling
+process, reducing costs and time required. These services also
+provide quality control mechanisms through consensus models, where
+multiple labelers evaluate the same data to check accuracy.
+
+When selecting a managed data labeling solution, consider factors
+like the types of data you need to label (like images, text, and
+video), the complexity of your labeling tasks, integration with
+your existing ML workflow, and cost structure. The right solution
+will scale with your needs and provide consistent, high-quality
+labeled data.
+
+### Implementation steps
+
+- **Assess your data labeling
+requirements**. Define what types of data you need
+labeled (images, text, audio, or video), the complexity of
+annotations required, expected volume, and quality
+standards. Determine whether you need specialized domain
+expertise for your labeling tasks.
+- **Use Amazon SageMaker Ground Truth**. To train a machine learning model, you
+need a large, high-quality, labeled dataset.
+[Amazon SageMaker Ground Truth](https://docs.aws.amazon.com/sagemaker/latest/dg/sms.html) assists you to build
+high-quality training datasets for your ML models. With
+Ground Truth, you can use ML along with workers from a
+vendor company that you choose, or an internal, private
+workforce to create a labeled dataset. You can use the
+labeled dataset output from Ground Truth to train your own
+models. You can also use the output as a training data set
+for an Amazon SageMaker AI model.
+- **Use Amazon SageMaker Ground Truth
+Plus**. Ground Truth Plus is a turn-key service
+that uses an expert workforce to deliver high-quality
+training datasets fast, and reduces costs by up to 40
+percent.
+[Amazon SageMaker Ground Truth Plus](https://docs.aws.amazon.com/sagemaker/latest/dg/gtp.html) enables you to create
+high-quality training datasets without having to build
+labeling applications and manage the labeling workforce on
+your own. By using this approach, you don't need to have
+deep ML expertise or extensive knowledge of workflow design
+and quality management. You simply provide data along with
+labeling requirements and Ground Truth Plus sets up the data
+labeling workflows and manages them on your behalf in
+accordance with your requirements.
+- **Configure active learning
+workflows**. Set up your labeling projects to use
+active learning, where the system learns from human
+annotations and begins to automate labeling for similar
+items. This reduces the number of items requiring manual
+labeling over time, improving efficiency and reducing costs.
+Amazon SageMaker Ground Truth provides built-in support for
+active learning.
+- **Implement quality control
+mechanisms**. Configure your labeling jobs to use
+multiple workers per data item and determine consensus
+approaches based on your quality requirements. Monitor
+labeling performance and adjust your quality control
+parameters as needed.
+- **Set up real-time data labeling
+pipelines**. For ongoing ML projects, establish
+continuous data labeling pipelines that can process new data
+as it becomes available. This way, your models can be
+regularly retrained with fresh data.
+- **Create custom labeling interfaces
+when needed**. For specialized labeling tasks, use
+Ground Truth's custom template capabilities to create
+tailored labeling interfaces that make the process more
+efficient for your specific use case.
+- **Use enhanced Ground Truth
+capabilities**. Use improved Ground Truth Plus
+features that provide up to 40% cost reduction through
+expert workforce management and automated quality control
+mechanisms.
+- **Use foundation models for
+pre-labeling**. Use generative AI models through
+Amazon Bedrock to assist with initial data labeling, which
+can then be verified by human labelers. This hybrid approach
+can significantly accelerate the labeling process while
+maintaining quality control.
+
+## Resources
+
+**Related documents:**
+
+- [Training
+data labeling using humans with Amazon SageMaker Ground Truth](https://docs.aws.amazon.com/sagemaker/latest/dg/sms.html)
+- [Use
+Amazon SageMaker Ground Truth Plus to Label Data](https://docs.aws.amazon.com/sagemaker/latest/dg/gtp.html)
+- [Using
+the Amazon Mechanical Turk Workforce](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-workforce-management-public.html)
+- [Automate
+data labeling](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-automated-labeling.html)
+- [Custom
+labeling workflows](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-custom-templates.html)
+- [Annotation
+consolidation](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-annotation-consolidation.html)
+- [Ground
+Truth streaming labeling jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/sms-streaming-labeling-job.html)
+- [Implementing
+a custom labeling GUI with built-in processing logic with
+Amazon SageMaker Ground Truth](https://aws.amazon.com/blogs/machine-learning/implementing-a-custom-labeling-gui-with-built-in-processing-logic-with-amazon-sagemaker-ground-truth/)
+
+**Related examples:**
+
+- [Bring
+your own model for SageMaker AI labeling workflows with active
+learning](https://github.com/aws/amazon-sagemaker-examples/blob/master/ground_truth_labeling_jobs/bring_your_own_model_for_sagemaker_labeling_workflows_with_active_learning/bring_your_own_model_for_sagemaker_labeling_workflows_with_active_learning.ipynb)
+- [SageMaker AI
+Ground Truth recipe](https://github.com/aws-samples/aws-sagemaker-ground-truth-recipe)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp01.html*
+
+---
+
+# MLCOST03-BP02 Use no-code or low-code and code generation tools for interactive analysis
+
+Prepare data through data wrangler tools for interactive data
+analysis and model building. The no-code/low-code, automation, and
+visual capabilities improve productivity and reduce the cost for
+interactive analysis. Integrate with generative AI code generation
+tools.
+
+**Desired outcome:** You will be able
+to streamline your data preparation workflow using visual interfaces
+with minimal coding required. By implementing no-code or low-code
+tools like Amazon SageMaker AI Canvas and Data Wrangler, you reduce
+time spent on data preprocessing tasks and gain improved insights
+through interactive visualizations. Amazon Q integration provides
+intelligent assistance for data preparation and code generation,
+enabling faster iteration cycles on model development while
+maintaining data quality and consistency across your machine
+learning projects.
+
+**Common anti-patterns:**
+
+- Writing custom data preparation scripts for every analysis task.
+- Using disjointed tools for data import, transformation, and
+visualization.
+- Manually performing repetitive data cleaning operations.
+- Creating non-reproducible data preparation workflows.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time and cost for data preparation and feature
+engineering.
+- Improved productivity through visual interfaces and automation.
+- Streamlined workflow from data import to model deployment.
+- Support for code and no-code approaches to accommodate different
+skill levels.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Data preparation is often cited as the most time-consuming aspect
+of machine learning projects, typically consuming 60-80% of data
+scientists' time. Data wrangler tools provide visual interfaces to
+simplify and accelerate this process through automation and
+low-code solutions.
+
+Amazon SageMaker AI Data Wrangler offers an end-to-end solution for
+data preparation that integrates directly with your machine
+learning workflow. By using a visual interface, you can import
+data from various sources, identify and fix data quality issues,
+transform features, and generate insights—all with minimal coding
+required. The tool provides transparency by generating code for
+your transformations, fostering reproducibility and allowing
+customization when needed.
+
+Data wrangler tools are particularly valuable for exploratory data
+analysis, where quick iteration and visualization are essential.
+They allow you to rapidly identify patterns, outliers, and
+relationships in your data, accelerating the feature engineering
+process. With built-in data quality and insights features, you can
+understand your data characteristics and address issues before
+model training begins.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Canvas or
+Studio environment**. Access SageMaker AI Canvas for a
+no-code experience or SageMaker AI Studio for more advanced
+capabilities through the AWS Management Console. Canvas
+provides a visual, drag-and-drop interface for business
+analysts and citizen data scientists, while Studio offers
+Data Wrangler for more technical users. Both environments
+support the complete machine learning workflow with varying
+levels of coding requirements.
+- **Import data from various
+sources**. Use SageMaker AI Canvas or Data Wrangler to
+connect to multiple data sources including Amazon S3, Amazon Athena, Amazon Redshift, Snowflake, and various databases.
+Canvas provides a simplified point-and-click interface for
+business users, while Data Wrangler offers more advanced
+data source connectivity options. Both tools avoid the need
+for custom connector code.
+- **Explore and visualize your
+data**. USe Data Wrangler's built-in data
+visualizations to understand distributions, correlations,
+and outliers. These visualizations assist to identify
+potential issues early and inform feature engineering
+decisions without writing complex plotting code.
+- **Use Amazon Q for generative
+AI-powered data preparation and code generation**.
+Use Amazon Q integrated within SageMaker AI Canvas and Data
+Wrangler to get natural language assistance for data
+preparation tasks, automated code generation, and
+intelligent suggestions for data transformations. Amazon Q
+can explain data patterns, suggest optimal preprocessing
+steps, and generate code snippets for custom
+transformations, significantly reducing the time needed for
+data preparation tasks. Additionally, use AI-powered
+development tools like Kiro for intelligent code generation
+and optimization of your data processing workflows.
+- **Apply transformations to prepare
+your data**. Use the visual transformation
+interface to clean and prepare data through operations like
+handling missing values, encoding categorical features,
+scaling numerical values, and feature extraction. Data
+Wrangler provides over 300 built-in transformations while
+allowing custom Python transformations when needed.
+- **Analyze data quality and generate
+insights**. Use the built-in data quality and
+insights features to detect anomalies, check for imbalanced
+data, and understand feature importance. These automated
+analyses identify potential issues before model training
+begins.
+- **Balance your datasets**.
+Address imbalanced datasets using built-in techniques like
+random oversampling, random undersampling, and synthetic
+minority oversampling (SMOTE). Data Wrangler provides visual
+controls to implement these techniques without specialized
+knowledge.
+- **Scale to larger datasets**.
+Process larger datasets by configuring instance types and
+using distributed processing capabilities. Data Wrangler
+supports processing wide datasets with thousands of columns
+and large datasets with billions of rows through appropriate
+resource allocation.
+- **Prepare time series data**.
+Use specialized time series transformations to handle
+temporal data, including resampling, lagged feature
+creation, and time-based aggregations. These operations
+simplify working with sequential data patterns.
+- **Export your data flow for
+production**. Deploy your data preparation workflow
+by exporting to various destinations including Amazon S3,
+SageMaker AI Feature Store, or directly to model building
+workflows. Data Wrangler generates Python code that can be
+integrated into production pipelines. Canvas workflows can
+also be exported to SageMaker AI notebooks for further
+customization and integration into production pipelines.
+- **Use enhanced Canvas
+capabilities**. Use SageMaker AI Canvas's improved
+natural language support and Q integration for
+conversational data analysis, enabling business users to
+perform complex data preparation tasks without technical
+expertise.
+- **Integrate with the broader machine
+learning workflow**. Connect your prepared data
+directly to SageMaker AI's model building capabilities like
+SageMaker AI Autopilot for automated model development or
+custom model training. This integration creates a seamless
+path from data to deployed models.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Get
+Started with Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-getting-started.html)
+- [Prepare
+ML Data with Amazon SageMaker AI Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler.html)
+- [What
+is Amazon Q Developer?](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/what-is.html)
+- [What
+is AWS Glue DataBrew?](https://docs.aws.amazon.com/databrew/latest/dg/what-is.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Accelerate
+data preparation with data quality and insights in Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/blogs/machine-learning/accelerate-data-preparation-with-data-quality-and-insights-in-amazon-sagemaker-data-wrangler/)
+- [Process
+larger and wider datasets with Amazon SageMaker AI Data
+Wrangler](https://aws.amazon.com/blogs/machine-learning/process-larger-and-wider-datasets-with-amazon-sagemaker-data-wrangler/)
+- [Fuel
+Your Data with Generative AI](https://aws.amazon.com/blogs/enterprise-strategy/fuel-your-data-with-generative-ai/)
+
+**Related examples:**
+
+- [Prepare
+ML Data with Amazon SageMaker AI Data Wrangler](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/data-wrangler.md)
+- [SageMaker AI
+Data Wrangler Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-datawrangler)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp02.html*
+
+---
+
+# MLCOST03-BP03 Use managed data processing capabilities
+
+With managed data processing, you can use a simplified, managed
+experience to run your data processing workloads, such as feature
+engineering, data validation, model evaluation, and model
+interpretation.
+
+**Desired outcome:** By implementing
+managed data processing capabilities, you can streamline your
+machine learning workflow with fully managed infrastructure for data
+preprocessing and postprocessing tasks. You gain the ability to run
+processing jobs that integrate with popular frameworks while
+maintaining operational efficiency, allowing your team to focus on
+creating valuable ML models rather than managing infrastructure.
+
+**Common anti-patterns:**
+
+- Building and maintaining custom data processing infrastructure.
+- Managing your own compute clusters for data processing tasks.
+- Manually handling scaling, deployment, and cleanup of processing
+resources.
+- Using inconsistent processing environments across development
+and production.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced operational overhead with fully managed infrastructure.
+- Simplified integration with popular ML frameworks and AWS
+services.
+- Enhanced productivity by focusing on ML development rather than
+infrastructure management.
+- Seamless integration with other SageMaker AI capabilities.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Amazon SageMaker AI Processing provides a managed solution for
+running these data processing workloads. Instead of provisioning
+and managing your own infrastructure, SageMaker AI handles the
+provisioning, scaling, and cleanup of resources. Processing jobs
+accept data from Amazon S3 as input and store processed results
+back to S3 as output. You can use AWS-provided container images
+that come pre-configured with popular data science frameworks, or
+you can bring your own custom containers for specialized
+processing needs.
+
+By using SageMaker AI Processing, you can integrate data processing
+steps seamlessly into your ML pipelines and create consistency
+between development and production environments while reducing
+operational overhead. This allows your data scientists and ML
+engineers to focus on extracting insights from data rather than
+managing infrastructure.
+
+### Implementation steps
+
+- **Set up your processing job
+environment**. Create an Amazon SageMaker AI notebook
+instance or Studio environment from which you'll configure
+and launch your processing jobs. This provides an
+interactive environment for development and testing of your
+data processing scripts before scaling to larger datasets.
+- **Select or create a processing
+container**. Choose from SageMaker AI's built-in
+processing containers for frameworks like scikit-learn,
+PyTorch, TensorFlow, or Apache Spark. Alternatively, create
+a custom Docker container if you have specialized framework
+requirements. The container will include the runtime
+environment and dependencies needed for your processing
+tasks.
+- **Prepare your processing
+script**. Develop a script that runs within the
+processing container to perform your data transformation,
+feature engineering, model evaluation, or other processing
+tasks. This script should read input data, process it
+according to your requirements, and write output to the
+designated locations.
+- **Configure storage
+locations**. Set up Amazon S3 buckets to store your
+input data, processing scripts, and output results.
+SageMaker AI Processing jobs use S3 as the primary storage
+mechanism for exchanging data between steps in your ML
+workflow.
+- **Launch a processing job**.
+Use the SageMaker AI Python SDK or AWS console to configure and
+start your processing job. Specify parameters such as
+instance type, instance count, environment variables, and
+input and output configurations. SageMaker AI will provision
+the requested resources, run your processing script, and
+then automatically clean up the resources when the job
+completes.
+- **Monitor job progress and analyze
+results**. Track your processing job through the
+SageMaker AI console or API. Review logs to debug issues. Once
+completed, access the processed data in the specified S3
+output locations for use in subsequent ML workflow steps.
+- **Integrate with ML
+pipelines**. Incorporate your processing jobs into
+[SageMaker AI
+Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to create automated end-to-end ML
+workflows. This enables you to orchestrate data
+preprocessing, model training, evaluation, and deployment
+steps in a repeatable manner.
+- **Optimize resource utilization and
+costs**. Review processing job metrics to identify
+opportunities for optimizing instance selection and
+parallelization strategies. Consider using Spot instances
+for cost savings on non-time-sensitive processing jobs.
+- **Use enhanced processing
+capabilities**. Use SageMaker AI Processing with
+better integration to popular ML frameworks and enhanced
+monitoring capabilities for more efficient data processing
+workflows.
+- **Use AI-powered code generation for
+data processing**. Use AI-powered development tools
+like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+data processing scripts, automate pipeline creation, and
+accelerate the development of custom data transformation
+workflows.
+- **Implement data validation and
+quality checks**. Incorporate data validation steps
+in your processing jobs to check data quality before model
+training. Use SageMaker AI Clarify within processing jobs to
+detect bias in your datasets and implement model
+explainability.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [CreateProcessingJob](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateProcessingJob.html)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Processing jobs](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_processing/scikit_learn_data_processing_and_model_evaluation/scikit_learn_data_processing_and_model_evaluation.html)
+- [SageMaker AI
+Processing with Spark](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_processing/spark_distributed_data_processing)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp03.html*
+
+---
+
+# MLCOST03-BP04 Enable feature reusability
+
+Reduce duplication and the rerunning of feature engineering code
+across teams and projects by using feature storage. The store should
+have online and offline storage, and data encryption capabilities.
+An online store with low-latency retrieval capabilities is ideal for
+real-time inference. An offline store maintains a history of feature
+values and is suited for training and batch scoring.
+
+**Desired outcome:** You gain a
+centralized repository for storing, sharing, and managing machine
+learning features that reduces redundant work across teams and
+projects. You access features with low latency for real-time
+applications while maintaining a historical record for training
+purposes. Your feature store integrates seamlessly with your ML
+workflows, enhancing collaboration and accelerating model
+development while maintaining data security through robust
+encryption.
+
+**Common anti-patterns:**
+
+- Recreating the same features repeatedly across different teams
+and projects.
+- Storing features in isolated data silos that avoid reuse.
+- Lacking version control for features, leading to inconsistencies
+between training and inference.
+- Using separate systems for real-time and batch feature access.
+- Implementing homegrown feature storage solutions that lack
+scalability and proper governance.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces redundant work and computational costs.
+- Creates consistency between training and inference environments.
+- Enables collaboration and knowledge sharing across teams.
+- Provides feature governance, lineage, and traceability.
+- Reduces time to production for ML models.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Feature engineering is often one of the most time-consuming
+aspects of machine learning development. When teams work in silos,
+they frequently recreate the same features, wasting valuable time
+and resources. By implementing a centralized feature store, you
+create a single source of truth for ML features that promotes
+reusability across your organization.
+
+A well-designed feature store addresses the dual requirements of
+offline storage for training and batch inference and online
+storage for low-latency real-time inference. This dual-storage
+paradigm creates consistency between training and serving
+environments while optimizing for different access patterns. The
+feature store should also provide capabilities for feature
+versioning, access control, and monitoring to maintain data
+quality and governance.
+
+Amazon SageMaker AI Feature Store offers these capabilities as a
+fully managed service, which reduces the need to build and
+maintain complex infrastructure. It seamlessly integrates with
+your ML pipelines and supports both batch and real-time inference
+workflows, making it an ideal solution for feature reusability.
+
+### Implementation steps
+
+- **Identify common features across
+projects**. Begin by analyzing your existing ML
+workflows to identify frequently used features that would
+benefit from centralization. Look for redundancies in
+feature engineering code across different teams and
+prioritize these for migration to the feature store.
+- **Set up Amazon SageMaker AI Feature
+Store**. Create feature groups in
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to organize related
+features. Define the schema for each feature group,
+including feature names, data types, and primary keys.
+Consider the access patterns for both training and inference
+when designing your feature groups.
+- **Configure storage options based on
+requirements**. Determine whether each feature
+group needs online storage, offline storage, or both.
+Configure the appropriate storage options:
+
+**Online store:** Set up
+for low-latency access (milliseconds) needed for
+real-time inference
+- **Offline store:**
+Configure Amazon S3 storage for training and batch
+inference workloads
+- **Online and offline:**
+Implement both for maximum flexibility
+
+- **Implement data ingestion
+pipelines**. Develop automated pipelines to ingest
+data into your feature store. You can use
+[Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/) for data preparation and
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) for orchestration.
+- **Establish feature access
+patterns**. Create standardized methods for
+retrieving features for both training and inference. For
+training, use the offline store with Amazon Athena queries
+to efficiently access historical data. For real-time
+inference, implement API calls to the online store for
+low-latency feature retrieval.
+- **Enable cross-account and cross-team
+sharing**. Configure resource policies to enable
+feature sharing across different teams and AWS accounts.
+This promotes collaboration and maximizes feature reuse
+across your organization while maintaining appropriate
+access controls.
+- **Implement feature versioning and
+lineage tracking**. Track changes to features over
+time using versioning capabilities. Link features to models
+through
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to maintain full lineage
+tracking from data source to deployed model.
+- **Monitor feature usage and
+drift**. Implement monitoring for your feature
+store to detect data drift and track feature usage patterns.
+Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect changes in feature
+distributions that might impact model performance.
+- **Create documentation and discovery
+mechanisms**. Document features and their intended
+use cases to facilitate discovery and reuse. Implement
+tagging and search capabilities so that data scientists can
+find relevant features for their projects.
+- **Use enhanced Feature Store
+capabilities**. Use improved SageMaker AI Feature
+Store with better performance, enhanced monitoring
+capabilities, and improved integration with other SageMaker AI
+services for more efficient feature management.
+- **Use generative AI for feature
+discovery and documentation**. Use large language
+models through
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to automatically generate feature
+descriptions, identify potential feature relationships, and
+improve feature discoverability through natural language
+search capabilities.
+
+## Resources
+
+**Related documents:**
+
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Amazon SageMaker AI Feature Store resources](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-notebooks.html)
+- [Understanding
+the key capabilities of Amazon SageMaker AI Feature
+Store](https://aws.amazon.com/blogs/machine-learning/understanding-the-key-capabilities-of-amazon-sagemaker-feature-store/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Feature Store Notebook Examples](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-notebooks.html)
+
+**Related videos:**
+
+- [Training
+and Tuning State-of-the-Art Models with Amazon SageMaker AI](https://aws.amazon.com/awstv/watch/90cac7f03b4/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost03-bp04.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLCOST04.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLCOST04.md
@@ -1,0 +1,2150 @@
+# MLCOST04
+
+**Pillar**: Unknown  
+**Best Practices**: 14
+
+---
+
+# MLCOST04-BP01 Select optimal computing instance size
+
+Right size your machine learning training instances according to the
+algorithm and workload requirements to maximize efficiency and
+reduce costs. By selecting the most appropriate computing resources,
+you can improve performance while minimizing unnecessary expenses.
+
+**Desired outcome:** You can identify
+and select the optimal computing instance types for your machine
+learning workloads based on actual resource utilization metrics. You
+can systematically evaluate different instance options, understand
+their cost implications, and optimize your machine learning
+infrastructure spending while maintaining or improving performance.
+
+**Common anti-patterns:**
+
+- Using oversized instances for training jobs regardless of model
+complexity.
+- Ignoring resource utilization metrics during training.
+- Failing to experiment with different instance types to find the
+optimal cost-performance balance.
+- Not considering the communication overhead in distributed
+training scenarios.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced infrastructure costs for machine learning workloads.
+- Improved resource utilization and efficiency.
+- Better understanding of ML workload performance characteristics.
+- Optimization of price-performance ratio for different model
+types.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning training workloads vary significantly in their
+resource requirements based on model complexity, dataset size, and
+algorithm characteristics. Simple models might not train faster on
+larger instances because they cannot effectively utilize
+additional compute resources, and might even train slower due to
+high GPU communication overhead. By evaluating your workload's
+resource needs, you can identify the most cost-effective instance
+configuration.
+
+The key to optimizing instance selection is understanding the
+actual resource utilization patterns of your machine learning
+workloads. Start with smaller instances and scale up only when
+necessary based on performance data. Amazon SageMaker AI provides
+tools like Debugger to monitor resource utilization and
+Experiments to compare training performance across different
+instance configurations. This data-driven approach assists you to
+avoid paying for unused resources while maintaining optimal
+training performance.
+
+### Implementation steps
+
+- **Understand your algorithm's resource
+requirements**. Begin by analyzing whether your
+machine learning algorithm is compute-bound, memory-bound,
+or I/O-bound. Different algorithms have different scaling
+characteristics and resource needs. For deep learning
+workloads, consider whether GPU acceleration would provide
+significant benefits or if CPU instances would be more
+cost-effective for your specific model.
+- **Use Amazon SageMaker AI
+Experiments**.
+[Amazon EC2](https://aws.amazon.com/ec2/instance-types/) provides a wide selection of instance types
+optimized to fit different use cases. Machine learning
+workloads can use either a CPU or a GPU instance. Select an
+instance type from
+[the
+available EC2 instance types](https://aws.amazon.com/ec2/instance-types/) depending on the needs
+of your ML algorithm. Experiment with both CPU and GPU
+instances to learn which one gives you the best cost
+configuration. Amazon SageMaker AI lets you use a single
+instance or a distributed cluster of GPU instances. Use
+[Amazon SageMaker AI Experiments](https://aws.amazon.com/sagemaker/ai/experiments/) to evaluate alternative
+options, and identify the size resulting in optimal outcome.
+With the pricing broken down by time and resources, you can
+optimize the cost of Amazon SageMaker AI and only pay for
+what is needed.
+- **Use Amazon SageMaker AI
+Debugger**.
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) automatically monitors the
+utilization of system resources, such as GPUs, CPUs,
+network, and memory, and profiles your training jobs to
+collect detailed ML framework metrics. You can inspect
+resource metrics visually through SageMaker AI Studio and
+take corrective actions if the resource is under-utilized to
+optimize cost.
+- **Start small and scale
+gradually**. Begin with smaller instance sizes for
+new models and monitor performance. Only increase instance
+size when you have data showing that your workload can
+benefit from additional resources. This approach assists you
+to avoid overprovisioning and unnecessary costs.
+- **Consider the communication
+overhead**. For distributed training across
+multiple GPUs or instances, evaluate the communication
+overhead between nodes. In some cases, adding more compute
+resources might actually slow down training due to increased
+coordination requirements.
+- **Monitor and analyze training
+metrics**. Track key metrics like CPU/GPU
+utilization, memory usage, I/O patterns, and training
+throughput across different instance types to identify
+bottlenecks and optimization opportunities.
+- **Use Spot Instances for cost
+savings**. For non-critical training jobs, consider
+using
+[Amazon EC2 Spot Instances](https://aws.amazon.com/ec2/spot/) through SageMaker AI to reduce costs
+by up to 90%. Configure your training jobs to checkpoint
+regularly to minimize the impact of potential interruptions.
+- **Use SageMaker AI Inference Recommender
+for optimal instance selection**. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) with enhanced algorithms and
+support for multi-model endpoints to get sophisticated cost
+optimization recommendations for your specific workloads.
+- **For generative AI workloads, use
+foundation model optimization techniques**. For
+generative AI workloads, consider techniques like
+quantization, distillation, and efficient fine-tuning
+methods to reduce the computational resources needed while
+maintaining model quality.
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) provides optimized foundation
+models that can significantly reduce training time and
+resource requirements.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html)
+- [Accelerate
+generative AI development with Amazon SageMaker AI and
+MLflow](https://aws.amazon.com/sagemaker/ai/experiments/)
+- [Amazon EC2 instance types](https://aws.amazon.com/ec2/instance-types/)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Amazon SageMaker AI Training Compiler](https://docs.aws.amazon.com/sagemaker/latest/dg/training-compiler.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp01.html*
+
+---
+
+# MLCOST04-BP02 Use managed build environments
+
+Using managed build environments for machine learning development
+instead of local setups provides significant cost, time, and
+resource advantages. Managed notebooks come pre-configured with
+security, networking, storage, and compute capabilities that would
+otherwise require extensive development and maintenance effort.
+These environments also offer flexible machine selection, including
+access to powerful GPUs and high-memory instances that may be
+impractical in local setups.
+
+**Desired outcome:** You can quickly
+start machine learning development work without spending time
+setting up infrastructure, managing dependencies, or configuring
+development environments. You gain access to scalable compute
+resources, including specialized hardware like GPUs, and benefit
+from built-in security and collaboration features, allowing you to
+focus on building ML models rather than managing infrastructure.
+
+**Common anti-patterns:**
+
+- Spending excessive time configuring local development
+environments for each project.
+- Encountering hardware limitations when training complex models
+locally.
+- Struggling with inconsistent development environments across
+team members.
+- Managing security and networking configurations manually.
+- Inability to scale resources up or down based on workload
+requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time to start development with pre-configured
+environments.
+- Access to powerful compute resources on demand.
+- Consistent development environments for team members.
+- Built-in security, networking, and storage capabilities.
+- Simplified collaboration and sharing of notebooks and models.
+- Cost optimization through pay-for-what-you-use model.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When implementing machine learning projects, your development
+environment plays a critical role in productivity and efficiency.
+Local development environments often lead to inconsistencies
+between team members, dependency conflicts, and hardware
+limitations. Managed build environments address these challenges
+by providing standardized, scalable, and secure solutions for ML
+development.
+
+Amazon SageMaker AI offers several managed environment options
+tailored to different user needs and expertise levels. These
+include SageMaker AI Notebook Instances for individual developers,
+SageMaker AI Studio for comprehensive ML development, and SageMaker AI
+Canvas for no-code ML solutions. These environments come
+pre-configured with the necessary tools and libraries, saving
+setup time and fostering consistency.
+
+These managed environments integrate seamlessly with other AWS
+services, making it simple to access data stored in Amazon S3, use
+specialized hardware like GPUs, and deploy models to production
+endpoints. They also provide built-in security features, version
+control, and collaboration capabilities that would be difficult to
+implement in a local setup.
+
+### Implementation steps
+
+- **Evaluate your ML development
+needs**. Begin by assessing your team's
+requirements, including technical expertise, project
+complexity, and compute resource needs. Identify which
+SageMaker AI offering best matches these requirements.
+- **Use Amazon SageMaker AI Notebook
+Instances**. Set up SageMaker AI Notebook Instances
+which provide a fully managed Jupyter notebook environment.
+These instances come pre-loaded with popular ML frameworks
+and libraries, allowing you to start working immediately.
+- **Implement Amazon SageMaker AI
+Studio**. Deploy SageMaker AI Studio as your
+comprehensive ML development environment. SageMaker AI Studio
+provides a web-based visual interface where your team can
+perform ML development steps from data preparation to model
+deployment. Access Studio by creating a SageMaker AI domain
+through the SageMaker AI console, which enables team management
+and resource sharing capabilities.
+- **Deploy SageMaker AI Canvas for business
+users**. Implement SageMaker AI Canvas for business
+analysts and non-technical team members who need to create
+ML models without coding. Canvas provides an intuitive
+visual interface for importing data, creating models, and
+generating predictions.
+- **Set up proper IAM roles and
+permissions**. Configure appropriate IAM roles for
+your SageMaker AI environments to provide secure access to AWS
+resources. Create specific roles that follow the principle
+of least privilege, granting only the permissions necessary
+for your ML workflows.
+- **Configure data access and
+storage**. Set up connections between your
+SageMaker AI environments and data sources such as Amazon S3,
+Amazon Redshift, or Amazon RDS. Configure appropriate
+permissions to access these data sources securely.
+- **Implement version control and
+collaboration**. Integrate your managed
+environments with version control systems like Git to track
+changes to notebooks and code. Use SageMaker AI Studio's
+built-in collaboration features to share work among team
+members.
+- **Optimize for cost
+efficiency**. Configure auto-shutdown policies for
+notebook instances when they're idle to reduce costs.
+Monitor resource usage and adjust instance types as needed
+to balance performance and cost.
+- **Use SageMaker AI HyperPod for
+large-scale training**. For distributed training of
+large models, use
+[SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) which provides purpose-built infrastructure
+with automatic checkpoint storage and recovery, optimizing
+resource utilization for long-running training jobs.
+- **Enable SageMaker AI JupyterLab 3
+features**. Take advantage of the productivity
+improvements in JupyterLab 3, which is available in both
+SageMaker AI Studio and Notebook Instances, providing better
+performance and enhanced features for developers.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio.html)
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Amazon SageMaker AI Pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [Amazon SageMaker AI notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp02.html*
+
+---
+
+# MLCOST04-BP03 Select local training for small scale experiments
+
+When developing machine learning models, choosing the right training
+environment is crucial for both cost efficiency and rapid
+experimentation. By evaluating whether to train your ML model
+locally or in the cloud, you can optimize your development workflow
+and appropriately match resources to the scale of your experiment.
+
+**Desired outcome:** You can rapidly
+iterate on machine learning experiments with small datasets by
+training models locally, while having a clear path to scale up to
+cloud-based training when working with larger datasets. This
+approach enables faster development cycles during the
+experimentation phase and cost-effective scaling when required for
+production workloads.
+
+**Common anti-patterns:**
+
+- Deploying cloud-based training clusters regardless of dataset
+size.
+- Using oversized compute instances for small-scale
+experimentation.
+- Not considering the time and cost implications of repeatedly
+launching training clusters during the experimentation phase.
+- Failing to right-size compute resources based on specific
+workload requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced development costs during experimentation phases.
+- Faster iteration cycles when testing various algorithms and
+configurations.
+- Simplified workflow for early-stage development.
+- Clear scaling path from local experimentation to production
+deployment.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When developing machine learning models, you often need to
+experiment with multiple algorithms, configurations, and
+hyperparameters before finding an optimal solution. The choice
+between local training and cloud-based training significantly
+impacts both development speed and cost efficiency.
+
+Local training is most advantageous during early experimentation
+phases when working with small datasets. This approach reduces the
+overhead of provisioning cloud resources and waiting for training
+clusters to spin up for each experiment iteration. Your
+development cycle becomes more agile as you can quickly test
+hypotheses and make adjustments without incurring additional cloud
+costs.
+
+As your models and datasets grow in size and complexity,
+transitioning to cloud-based training becomes necessary. Cloud
+environments offer scalable computing resources that can handle
+large datasets and complex models that would be impractical to
+process on local machines. By right-sizing your compute instances
+based on your specific workload requirements, you can maintain
+cost efficiency while gaining the performance benefits of cloud
+infrastructure.
+
+### Implementation steps
+
+- **Evaluate your training
+requirements**. Before deciding on local or
+cloud-based training, assess your dataset size, model
+complexity, and computational requirements. Small datasets
+(typically under a few gigabytes) and simpler models are
+generally good candidates for local training, especially
+during initial experimentation.
+- **Set up Amazon SageMaker AI local
+mode**. When experimenting with small datasets, use
+Amazon SageMaker AI's local mode to train models directly on
+your notebook instance. This approach allows you to test and
+iterate on your code without provisioning separate training
+clusters. To implement local mode:
+
+```
+`from sagemaker.estimator import Estimator
+
+estimator = Estimator(
+image_uri="your-container-image",
+role="your-sagemaker-role",
+instance_count=1,
+instance_type="local"
+)
+
+estimator.fit({"train": "s3://your-bucket/train-data"})`
+```
+- **Use local development environment
+with SageMaker AI SDK**. For development outside of
+SageMaker AI notebooks, install the SageMaker AI Python SDK on
+your local machine. This allows you to develop and test
+locally while still having the ability to deploy models to
+AWS:
+
+```
+`pip install sagemaker`
+```
+- **Profile your workloads for cloud
+deployment**. As your models mature and datasets
+grow, prepare for cloud deployment by profiling your
+workloads. Identify memory usage, CPU and GPU requirements,
+and processing time to determine appropriate instance types
+for cloud-based training.
+- **Right-size cloud-based training
+clusters**. When moving to cloud training, select
+appropriate instance types based on your workload profiling.
+Consider factors such as:
+
+Model architecture (CPU and GPU requirements)
+- Memory needs
+- Dataset size and I/O patterns
+- Training time constraints
+- Cost constraints
+
+- **Implement distributed training for
+large-scale workloads**. For large datasets or
+complex models, configure distributed training across
+multiple instances to reduce training time.
+- **Monitor and optimize cloud resource
+usage**. Regularly review your training job metrics
+to identify opportunities for optimization. Use SageMaker AI
+Experiments to track and compare resource utilization across
+different training configurations.
+- **Use enhanced local development
+capabilities**. Use improved SageMaker AI local mode
+with better debugging and monitoring capabilities, allowing
+for more efficient local experimentation before scaling to
+cloud resources.
+- **For generative AI workloads, use
+foundation models efficiently**. When working with
+generative AI and foundation models, consider using Amazon SageMaker AI JumpStart for local experimentation with smaller,
+distilled versions of foundation models before fine-tuning
+larger models in the cloud. This approach allows for rapid
+prototyping while managing costs effectively.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+training](https://docs.aws.amazon.com/sagemaker/latest/dg/train-model.html)
+- [AWS Pricing Calculator](https://calculator.aws/#/createCalculator/SageMaker AI)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [SageMaker AI
+Python SDK Documentation](https://sagemaker.readthedocs.io/en/stable/)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Generative
+AI Cost Optimization Strategies](https://aws.amazon.com/blogs/enterprise-strategy/generative-ai-cost-optimization-strategies/)
+
+**Related videos:**
+
+- [Train
+with Amazon SageMaker AI on your local machine](https://www.youtube.com/watch?v=K3ngZKF31mc)
+
+**Related examples:**
+
+- [SageMaker AI
+Local Mode Examples](https://github.com/aws-samples/amazon-sagemaker-local-mode)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp03.html*
+
+---
+
+# MLCOST04-BP04 Select an optimal ML framework
+
+Selecting the most cost-effective machine learning (ML) framework
+for your requirements can significantly impact your operational
+efficiency and return on investment. By systematically comparing
+frameworks like TensorFlow, PyTorch, and Scikit-learn, you can
+determine which delivers the best performance for your specific use
+cases at the optimal cost.
+
+**Desired outcome:** You establish a
+systematic approach for evaluating ML frameworks and instance types,
+and you can select the optimal combination based on performance,
+cost, and use case requirements. You can track, compare, and analyze
+experiments across different frameworks, leading to informed
+decisions that maximize performance while minimizing costs.
+
+**Common anti-patterns:**
+
+- Selecting ML frameworks based on popularity rather than
+suitability for your specific use case.
+- Using a single framework for ML projects regardless of workload
+characteristics.
+- Not tracking experiment metrics systematically across different
+frameworks.
+- Failing to benchmark performance and cost metrics before moving
+to production.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced operational costs through optimized infrastructure
+selection.
+- Improved model performance by selecting the most suitable
+framework.
+- Enhanced productivity by streamlining experiment tracking and
+comparison.
+- Faster iteration and deployment of ML models.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Selecting the optimal ML framework involves evaluating different
+options against your specific requirements and constraints.
+Consider factors such as model complexity, data volume,
+performance requirements, and team expertise when choosing between
+frameworks. Tracking experiments systematically assists you to
+compare approaches objectively and make data-driven decisions.
+
+When implementing this best practice, use AWS' comprehensive ML
+infrastructure, which supports major frameworks and provides tools
+for experiment tracking and resource optimization. Regular
+performance benchmarking and cost analysis should become standard
+procedures in your ML development process.
+
+### Implementation steps
+
+- **Implement systematic experiment
+tracking with SageMaker AI Experiments**. Amazon SageMaker AI Experiments enables you to organize, track,
+compare, and evaluate your machine learning experiments.
+Create experiments to group related trials, assign
+parameters, metrics, and artifacts to each trial, and track
+the lineage of model artifacts to experiments for governance
+and reproducibility.
+- **Compare multiple ML
+frameworks**. Evaluate frameworks like TensorFlow,
+PyTorch, Apache MXNet, and Scikit-learn for your specific
+use cases. Use
+[AWS Deep Learning AMIss](https://aws.amazon.com/machine-learning/amis/) and
+[AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/) to experiment with different
+frameworks using consistent infrastructure. These AMIs come
+with popular frameworks preinstalled, making it simple to
+switch between them for comparison.
+- **Benchmark framework
+performance**. Design standardized benchmarking
+tests for your specific workloads across different
+frameworks. Track metrics such as training time, inference
+latency, memory usage, and accuracy to determine which
+framework performs best for your use case.
+- **Implement right-sizing strategies
+for ML instances**. Use SageMaker AI's managed
+instances to automatically select the most appropriate and
+cost-effective instance type for your workloads. Experiment
+with different instance types to find the optimal balance
+between performance and cost.
+- **Use SageMaker AI's
+bring-your-own-container capability**. If you need
+to use specialized ML frameworks or versions not available
+in standard containers, use SageMaker AI's flexibility to bring
+your own containers so that you can use a framework while
+maintaining the benefits of SageMaker AI's managed
+infrastructure.
+- **Implement automatic resource
+scaling**. Configure automatic scaling for
+inference endpoints based on traffic patterns to optimize
+costs during varying load conditions. Use SageMaker AI
+Inference Recommender to identify the best configuration for
+deployment.
+- **Use enhanced experiment tracking
+with MLflow**. Use
+[managed
+MLflow on SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to create, manage, analyze, and
+compare your machine learning experiments across different
+frameworks with better organization and tracking
+capabilities.
+- **Monitor and optimize costs
+continuously**. Implement cost monitoring using AWS Cost Explorer and SageMaker AI's built-in monitoring
+capabilities. Set up alerts for unusual spending patterns
+and regularly review resource utilization to identify
+optimization opportunities.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Deep Learning AMIss](https://aws.amazon.com/machine-learning/amis/)
+- [Machine
+Learning Frameworks and Languages](https://docs.aws.amazon.com/sagemaker/latest/dg/frameworks.html)
+- [Accelerate
+generative AI development with Amazon SageMaker AI and
+MLflow](https://aws.amazon.com/sagemaker/ai/experiments/)
+- [Amazon SageMaker AI Studio Classic](https://docs.aws.amazon.com/sagemaker/latest/dg/studio.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp04.html*
+
+---
+
+# MLCOST04-BP05 Use automated machine learning
+
+Automate your model development process by using systems that
+experiment with and select the best algorithms from high-performing
+options. These automated systems test various solutions and
+parameter settings to achieve optimal models, significantly speeding
+up development while reducing the need for manual experimentation
+and comparisons.
+
+**Desired outcome:** You gain the
+ability to develop high-quality machine learning models in a
+fraction of the time traditionally required. By using automated
+machine learning tools like Amazon SageMaker AI Autopilot, you can
+focus on business problems rather than algorithm selection and
+parameter tuning. Your team can produce optimized models with better
+performance, reduce development costs, and accelerate time-to-market
+for ML-powered solutions.
+
+**Common anti-patterns:**
+
+- Manually testing multiple algorithms and configurations one by
+one.
+- Spending excessive time on hyperparameter tuning without
+systematic approach.
+- Using the same algorithm for each problem without considering
+alternatives.
+- Neglecting cross-validation during model selection.
+
+**Benefits of establishing this best
+practice:**
+
+- Dramatically reduced time to develop production-ready models.
+- Access to a broader range of algorithms and optimization
+techniques.
+- Improved model performance through systematic evaluation.
+- Lower costs through optimized resource utilization.
+- Ability for domain experts to build models without deep ML
+expertise.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Automated machine learning (AutoML) systems democratize the
+process of building machine learning models. By automating key
+steps in model development—from data preparation to algorithm
+selection and hyperparameter tuning—these systems enable even
+those without extensive machine learning expertise to develop
+high-quality models.
+
+When using AutoML solutions like Amazon SageMaker AI Autopilot,
+you provide your dataset and define your objective, and the system
+handles the complex work of exploring potential algorithms,
+optimizing parameters, and evaluating model performance. The
+system applies cross-validation procedures automatically to check
+that models can generalize well to new data. By ranking optimized
+models by their performance, AutoML can identify the best solution
+for your specific problem.
+
+Beyond simply producing models, modern AutoML systems provide
+visibility into the development process, allowing you to
+understand what choices were made and why. This transparency
+builds trust in the models and provides learning opportunities for
+your team to understand what approaches work best for different
+problem types.
+
+### Implementation steps
+
+- **Evaluate your use case
+compatibility**. Determine if your ML problem is
+suitable for automated machine learning solutions. AutoML
+works particularly well for standard machine learning tasks
+like classification, regression, and some time series
+forecasting scenarios.
+- **Prepare your data for
+AutoML**. Clean your dataset, handle missing
+values, and convert categorical features appropriately.
+While AutoML handles feature engineering, providing
+high-quality data improves results. Use
+[Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/) to simplify this preparation
+process.
+- **Set up Amazon SageMaker AI Autopilot
+with Canvas**. Open
+[Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html), import your dataset into Amazon S3,
+and configure to access this data. Define your target
+variable and specify your problem type (classification or
+regression) if known.
+- **Launch the automated ML
+job**. Start Canvas training and let it analyze
+your data, select algorithms, and optimize models. Specify
+resources like maximum runtime and instance types to control
+costs. Canvas will automatically handle data preprocessing,
+feature engineering, algorithm selection, and hyperparameter
+optimization.
+- **Review candidate models**.
+Examine the generated models along with their performance
+metrics. Autopilot provides detailed reports on the data
+exploration, feature engineering decisions, and model
+optimization steps it performed.
+- **Deploy the best model**.
+Select the best-performing model from the Canvas
+recommendations and deploy it using Amazon SageMaker AI's
+deployment capabilities. You can deploy as a real-time
+endpoint or for batch inference depending on your needs.
+- **Monitor and evaluate
+performance**. Set up model monitoring to track
+your model's performance in production and detect concept
+drift. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automate this process.
+- **Customize and refine
+models**. If needed, extract and customize the
+models generated by Autopilot. The solution provides full
+visibility into the notebooks and artifacts it creates,
+allowing you to further refine specific aspects of the
+model.
+- **Enhance model development with
+foundation models**. Use
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to incorporate foundation model capabilities
+into your AutoML workflow for tasks like text processing,
+content generation, and multimodal applications. Foundation
+models can complement traditional ML approaches handled by
+Autopilot.
+- **Use enhanced Canvas capabilities
+with Q integration**. Use
+[SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html) with improved natural language support and Q
+integration for conversational data analysis, enabling
+business users to build models through natural language
+interactions.
+- **Implement intelligent preprocessing
+with generative AI**. Use generative AI tools to
+enhance data preprocessing, augment training datasets,
+generate synthetic data for edge cases, and improve feature
+engineering through intelligent text and image processing.
+
+## Resources
+
+**Related documents:**
+
+- [Getting
+started with using Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-getting-started.html)
+- [SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Amazon SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/)
+
+**Related examples:**
+
+- [SageMaker AI Autopilot](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/automl/README.rst)
+- [Amazon SageMaker AI Autopilot Sample Notebooks](https://github.com/aws/amazon-sagemaker-examples/tree/main/autopilot)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp05.html*
+
+---
+
+# MLCOST04-BP06 Use managed training capabilities
+
+Machine learning model training can be an iterative,
+compute-intensive, and time-consuming process. Instead of using the
+notebook itself, which might be running on a small instance,
+offloading the training to a managed cluster of compute resources
+including both CPUs and GPUs enables more efficient and
+cost-effective model training.
+
+**Desired outcome:** By using managed
+training capabilities, you optimize your machine learning training
+workflows and infrastructure management. You gain access to scalable
+computing resources that automatically adjust based on your workload
+needs, from single GPUs to thousands, without managing the
+underlying infrastructure. You can significantly reduce training
+costs through specialized hardware options, compiler optimizations,
+and spot instance utilization while maintaining visibility into
+metrics and logs for proper monitoring and governance.
+
+**Common anti-patterns:**
+
+- Running complex model training jobs on notebook instances,
+leading to resource constraints and inefficiency.
+- Managing your own GPU clusters for training, requiring
+significant operational overhead.
+- Using exclusively on-demand instances for training jobs,
+resulting in higher costs.
+- Not using specialized training optimizations like distributed
+training or compiler acceleration.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower training costs by up to 90% using managed spot instances.
+- Accelerate training time by up to 50% with training compiler
+optimizations.
+- Scale resources automatically based on training job
+requirements.
+- Track and monitor training experiments and resource utilization
+effectively.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning training is computationally intensive and can
+become prohibitively expensive when not optimized properly. Using
+managed training capabilities allows you to focus on model
+development while the infrastructure scales and optimizes
+automatically to your needs. Managed training services provide a
+range of optimization options from distributed training across
+multiple GPUs to cost-saving options through spot instances.
+Additionally, these services integrate with monitoring tools to
+track resource utilization, model metrics, and training progress
+to continually refine your training approach.
+
+For example, when training large language models, you can use
+SageMaker AI's distributed training libraries to split the model
+across multiple GPUs and instances, reducing training time from
+weeks to days while maintaining control over your training costs
+through automatic scaling and spot instance usage.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI managed
+training capabilities**. Amazon SageMaker AI
+reduces the time and cost to train and tune ML models
+without the need to manage infrastructure. With SageMaker AI, you can train and tune ML models using built-in tools to
+manage and track training experiments, automatically choose
+optimal hyperparameters, debug training jobs, and monitor
+the utilization of system resources such as GPUs, CPUs, and
+network bandwidth. SageMaker AI can automatically scale
+infrastructure up or down based on your training job
+requirements, from one GPU to thousands, or from terabytes
+to petabytes of storage. SageMaker AI also offers the
+highest-performing ML compute infrastructure currently
+available-including
+[Amazon EC2 P4d instances](https://aws.amazon.com/ec2/instance-types/p4/), which can reduce ML training costs
+by up to 60% compared with previous generations. And, since
+you pay only for what you use, you can manage your training
+costs more effectively.
+- **Use Spot Instances for cost
+optimization**. Amazon SageMaker AI makes it simple
+to train machine learning models using managed Amazon EC2
+Spot Instances. Managed Spot training can optimize the cost
+of training models up to 90% over On-demand Instances.
+SageMaker AI manages the Spot interruptions on your behalf.
+You can specify which training jobs use Spot Instances and a
+stopping condition that specifies how long SageMaker AI
+waits for a job to run using Spot Instances. Metrics and
+logs generated during training runs are available in Amazon CloudWatch.
+- **Configure optimal data
+sources**. Select the appropriate data source for
+your training job to optimize performance and cost. Consider
+using [Amazon S3](https://aws.amazon.com/s3/) for persistent storage,
+[Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) for high-performance file systems, or
+[Amazon EFS](https://aws.amazon.com/efs/) based on your specific training requirements and
+dataset characteristics.
+- **Implement experiment tracking and
+management**. Use
+[Amazon SageMaker AI Experiments](https://aws.amazon.com/sagemaker/ai/experiments/) to track training jobs, compare
+results, and manage different versions of your models. This
+provides visibility into model performance, resource
+utilization, and training metrics to optimize future
+iterations.
+- **Use SageMaker AI HyperPod for
+large-scale training**. Use
+[SageMaker AI
+HyperPod](https://aws.amazon.com/sagemaker/ai/hyperpod/) to scale and accelerate generative AI model
+development across thousands of AI accelerators with
+purpose-built infrastructure, automatic checkpoint storage
+and recovery, and support for both Slurm and Amazon EKS for
+cluster orchestration.
+- **For generative AI, optimize large
+language model training**. Use
+[SageMaker AI
+Model Parallelism](https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-v2.html) to efficiently distribute model
+parameters across multiple devices and instances. Consider
+using
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for foundation model access and fine-tuning
+capabilities to further reduce the computational cost of
+training generative AI models from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Train
+a Model with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html)
+- [Model
+training](https://docs.aws.amazon.com/sagemaker/latest/dg/train-model.html)
+- [Distributed
+training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training.html)
+- [Accelerate
+generative AI development with Amazon SageMaker AI and
+MLflow](https://aws.amazon.com/sagemaker/ai/experiments/)
+
+**Related examples:**
+
+- [SageMaker AI
+Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples)
+- [SageMaker AI
+Training Workshop](https://github.com/aws-samples/amazon-sagemaker-immersion-day)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp06.html*
+
+---
+
+# MLCOST04-BP07 Use distributed training
+
+Accelerate your machine learning model training process by utilizing
+distributed computing resources, which can significantly reduce
+training time and optimize costs. Amazon SageMaker AI distributed
+training capabilities enable efficient processing of large models
+and datasets across multiple compute instances.
+
+**Desired outcome:** You achieve
+faster training times for your machine learning models by
+distributing the workload across multiple instances. You optimize
+resource utilization and reduce overall training costs by using
+SageMaker AI's managed distributed training capabilities, which
+automatically handle infrastructure provisioning and termination
+when training completes. This approach allows you to train complex
+models that may be too large for a single machine or train standard
+models much faster through parallel processing.
+
+**Common anti-patterns:**
+
+- Training large models on a single instance even when they could
+benefit from distribution.
+- Manually managing distributed training infrastructure rather
+than using managed services.
+- Keeping training instances running after training is complete.
+- Implementing custom distributed training code when built-in
+libraries would suffice.
+
+**Benefits of establishing this best
+practice:**
+
+- Significantly reduced training time for large models and
+datasets.
+- Cost optimization through efficient resource utilization.
+- Ability to train models that are too large to fit on a single
+GPU.
+- Automatic infrastructure management with no need to maintain
+distributed training clusters.
+- Enhanced team productivity by reducing waiting time for model
+results.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Distributed training allows you to split your machine learning
+workloads across multiple compute instances to accelerate the
+training process. This approach is particularly valuable when
+working with large models or datasets that would otherwise take
+too long to train on a single instance. Amazon SageMaker AI provides
+built-in support for distributed training through its specialized
+libraries that handle the complexity of distributing workloads
+efficiently.
+
+When implementing distributed training, you need to consider the
+most appropriate approach based on your model architecture and
+data size. Data parallelism works by dividing your dataset across
+multiple GPUs, with each GPU having a complete copy of the model.
+This approach is ideal for scenarios where your model fits on a
+single GPU but training on the full dataset is time-consuming.
+Alternatively, model parallelism is designed for situations where
+your model is too large to fit on a single GPU. In this case, the
+model itself is partitioned across multiple GPUs.
+
+SageMaker AI's distributed training libraries automatically handle
+the communication between nodes and optimize the distribution
+strategy, making it straightforward to scale your training
+workloads without managing the underlying infrastructure.
+
+### Implementation steps
+
+- **Evaluate your workload for
+distributed training suitability**. Assess if your
+training job would benefit from distribution by considering
+factors like model size, dataset size, and current training
+times. Ideal candidates are models that take hours or days
+to train on a single instance or models too large to fit in
+a single GPU's memory.
+- **Choose the appropriate distributed
+training approach**. Select between data
+parallelism and model parallelism based on your specific
+needs. Use data parallelism when your model fits on a single
+GPU but you want to process data faster. Use model
+parallelism when your model is too large to fit on a single
+GPU.
+- **Utilize Amazon SageMaker AI distributed
+training libraries**. Implement distributed
+training using
+[SageMaker AI's
+distributed training libraries](https://aws.amazon.com/sagemaker/distributed-training/), which automatically
+handle the complexities of distributing workloads across
+multiple instances. These libraries provide optimized
+implementations for both data parallelism and model
+parallelism strategies.
+- **Configure your training
+cluster**. Define the number and type of instances
+for your training cluster in your SageMaker AI training job
+configuration. Consider using GPU-optimized instance types
+like P3, P4d, or G4dn based on your model requirements and
+budget constraints.
+- **Adapt your training script for
+distributed processing**. Modify your training code
+to work with SageMaker AI's distributed training libraries. For
+data parallelism, you'll need to use the SageMaker AI data
+parallelism library to distribute data across workers. For
+model parallelism, you'll integrate the SageMaker AI model
+parallelism library to partition your model across devices.
+- **Monitor and optimize training
+performance**. Use
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) to monitor your distributed
+training jobs, identify bottlenecks, and optimize resource
+utilization. Analyze metrics like GPU utilization,
+communication overhead, and training throughput to fine-tune
+your distributed training configuration.
+- **Consider Amazon SageMaker AI HyperPod
+for persistent training clusters of foundation
+models**. For workloads requiring long-running or
+repeated distributed training jobs, use
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) to create persistent, managed
+clusters that can handle multiple training jobs efficiently
+while maintaining cost optimization through automatic
+scaling and resource management.
+- **Use SageMaker AI HyperPod for
+persistent training clusters**. Use
+[SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) for workloads requiring long-running or
+repeated distributed training jobs, providing persistent,
+managed clusters with automatic scaling, checkpoint storage
+and recovery, and support for various instance types
+including P5e, G6, and Trn2.
+- **Use AI-powered code generation for
+distributed training implementation**. Use
+AI-powered development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+complex distributed training code, automate infrastructure
+setup scripts, and accelerate the implementation of
+distributed training workflows.
+- **Consider Amazon Bedrock for
+fine-tuning foundation models**. For generative AI
+applications, consider using
+[Amazon
+Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/custom-model-fine-tuning.html/) for fine-tuning foundation models, model
+distillation, or continued pretraining, which provides
+optimized distributed training capabilities specifically
+designed for large language models.
+
+## Resources
+
+**Related documents:**
+
+- [Run
+distributed training with the SageMaker AI distributed data
+parallelism library](https://docs.aws.amazon.com/sagemaker/latest/dg/data-parallel.html)
+- [SageMaker AI
+model parallelism library v2](https://docs.aws.amazon.com/sagemaker/latest/dg/model-parallel-v2.html)
+- [Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+- [Distributed
+Training](https://sagemaker-examples.readthedocs.io/en/latest/training/distributed_training/index.html)
+- [Amazon SageMaker AI XGBoost now offers fully distributed GPU
+training](https://aws.amazon.com/blogs/machine-learning/amazon-sagemaker-xgboost-now-offers-fully-distributed-gpu-training/)
+
+**Related examples:**
+
+- [Distributed
+Training](https://github.com/aws/amazon-sagemaker-examples/blob/master/training/distributed_training/index.rst)
+- [Distributed
+training using Amazon SageMaker AI Distributed Data Parallel
+library and debugging using Amazon SageMaker AI Debugger](https://github.com/aws-samples/amazon-sagemaker-dist-data-parallel-with-debugger)
+- [SageMaker AI
+developer guide on distributed training](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/distributed-training.md#distributed-training-optimize)
+- [Distributed
+Training Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/training/distributed_training)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp07.html*
+
+---
+
+# MLCOST04-BP08 Stop resources when not in use
+
+Stop resources that are not in use to reduce cost. For example,
+hosted Jupyter environments used to explore small samples of data
+can be stopped when not actively in use. Where practical, commit the
+work, stop them, and restart when needed. The same approach can be
+used to stop the computing and the data storage services.
+
+**Desired outcome:** You
+significantly reduce your ML infrastructure costs by only paying for
+resources when they are actively being used. You have automated
+systems in place to monitor and shut down idle resources, along with
+proper alerts to track spending patterns and avoid unexpected
+charges. You maintain the ability to quickly restart resources when
+needed while minimizing wasteful spending on idle compute and
+storage.
+
+**Common anti-patterns:**
+
+- Leaving development environments running regardless of actual
+usage.
+- Neglecting to set up automatic shutdown mechanisms for idle
+resources.
+- Ignoring cost monitoring tools and billing alerts.
+- Using persistent storage for temporary data that could be
+deleted.
+
+**Benefits of establishing this best
+practice:**
+
+- Significant cost savings (up to 75% by running resources only
+during business hours compared to running continually).
+- Better alignment of spending with actual usage patterns.
+- Reduced environmental impact through more efficient resource
+consumption.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Optimizing costs is a crucial aspect of running machine learning
+workloads in the cloud. ML workloads often require significant
+computational resources, but those resources aren't needed
+continuously. By implementing automatic shutdown mechanisms for
+idle resources, you can achieve substantial cost savings while
+maintaining the ability to rapidly resume work when needed.
+
+For ML development environments like SageMaker AI notebooks, the
+cost-optimization opportunity is particularly significant since
+these environments are typically used intermittently during the
+exploration and development phases. By committing code to
+repositories regularly and shutting down environments when not in
+use, you improve both cost efficiency and version control of your
+work.
+
+Additionally, proper monitoring of spending patterns assists you
+in identifying optimization opportunities and avoiding unexpected
+costs. With AWS tools, you can set up alerts, track resource
+utilization, and implement automated responses to idle resources.
+
+### Implementation steps
+
+- **Set up Amazon CloudWatch billing
+alarms**. Use
+[Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html) to monitor your estimated AWS charges.
+When you enable monitoring of estimated charges, these
+calculations are sent several times daily to CloudWatch as
+metric data. Configure alerts to be notified when your
+resource charges exceed predefined thresholds to stay within
+budget and quickly identify unexpected spending patterns.
+- **Configure Amazon SageMaker AI notebook
+lifecycle configurations**. Create
+[lifecycle
+configurations](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html) that include shell scripts to run when
+you create or start notebook instances. These scripts can
+check for notebook instance activity and automatically shut
+down idle instances. This way, you're not paying for compute
+resources when they aren't actively processing workloads.
+- **Implement Amazon SageMaker AI Studio
+idle shutdown**. For
+[Amazon SageMaker AI Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-idle-shutdown.html) environments, install the
+auto-shutdown JupyterLab extension either
+[manually
+or automatically](https://github.com/aws-samples/sagemaker-studio-auto-shutdown-extension). This extension detects idle Studio
+resources and can shut down individual components, including
+notebooks, terminals, kernels, applications, and instances
+when they're not being used.
+- **Use AWS Cost Explorer to identify
+optimization opportunities**. Regularly analyze
+your ML infrastructure spending patterns using
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) to identify resources that might be
+consistently underutilized. Look for patterns that indicate
+resources could benefit from scheduled shutdowns during
+off-hours.
+- **Implement instance
+scheduling**. Use the
+[AWS Instance Scheduler](https://aws.amazon.com/solutions/implementations/instance-scheduler/) to create automated schedules for
+starting and stopping resources based on your team's working
+hours. This is particularly useful for development
+environments that are only needed during business hours.
+- **Train teams on cost-aware
+practices**. Educate your ML teams on the
+importance of shutting down resources when not in use and
+committing their work regularly. Create a cost-aware culture
+where resource efficiency is valued alongside development
+productivity.
+- **Implement enhanced auto-shutdown
+capabilities**. Use improved SageMaker AI Studio
+auto-shutdown features with better idle detection and more
+granular control over resource shutdown policies to minimize
+costs from unused resources.
+- **Use Spot Instances for interruptible
+workloads**. For ML training jobs that can handle
+interruptions, use
+[Amazon EC2 Spot Instances](https://aws.amazon.com/ec2/spot/) to achieve significant cost
+savings compared to on-demand pricing. Make sure your
+workloads are designed to checkpoint progress and can resume
+from interruptions.
+
+## Resources
+
+**Related documents:**
+
+- [Idle
+shutdown](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-updated-idle-shutdown.html)
+- [Customization
+of a SageMaker AI notebook instance using an LCC script](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html)
+- [Instance
+Scheduler on AWS](https://aws.amazon.com/solutions/implementations/instance-scheduler/)
+- [Create
+a billing alarm to monitor your estimated AWS charges](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [Amazon SageMaker AI Pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [Cloud
+Financial Management with AWS](https://aws.amazon.com/aws-cost-management/)
+
+**Related videos:**
+
+- [Saving
+cost on your machine learning training and inference on
+AWS](https://www.youtube.com/watch?v=keowy9YfxlcDeploy)
+- [Deploy
+an ML model for best performance, cost, and prediction
+quality](https://www.youtube.com/watch?v=ftCFf57dQQY)
+
+**Related examples:**
+
+- [AWS CloudFormation templates for automated instance
+scheduling](https://github.com/aws-solutions/aws-instance-scheduler)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp08.html*
+
+---
+
+# MLCOST04-BP09 Start training with small datasets
+
+Start experimentation with smaller datasets on a small compute
+instance or local system. This approach allows you to iterate
+quickly at low cost. After the experimentation period, scale up to
+train with the full dataset available on a separate compute cluster.
+Choose the appropriate storage layer for training data based on the
+performance requirements.
+
+**Desired outcome:** You can develop
+your machine learning models cost-effectively by starting with small
+datasets for rapid iteration and experimentation. When you're
+confident in your approach, you scale up to the full dataset on
+appropriate compute resources. This progressive scaling methodology
+optimizes both development time and infrastructure costs while
+maintaining the flexibility to refine your models before committing
+to full-scale training.
+
+**Common anti-patterns:**
+
+- Immediately training with the full dataset on large instances,
+leading to excessive costs during experimentation.
+- Using the same compute resources for both experimentation and
+full-scale training.
+- Not planning for the transition from small-scale to large-scale
+training.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced costs during the experimentation phase.
+- Faster iteration cycles for model development.
+- More efficient use of compute resources.
+- Ability to identify and fix issues early in the development
+process.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning development often requires multiple iterations to
+achieve optimal results. Using smaller, representative samples of
+your dataset during initial experimentation can significantly
+reduce costs and increase productivity. This approach lets you
+rapidly test various model architectures, hyperparameters, and
+preprocessing techniques without the expense and time required to
+process the full dataset.
+
+When implementing this approach, check that your smaller dataset
+properly represents the characteristics of your full dataset to
+avoid developing models that don't generalize well. Once you've
+established effective approaches using the smaller dataset, you
+can scale up your training to use the complete dataset on
+appropriately sized compute resources.
+
+The cloud makes this approach particularly powerful, as you can
+scale your compute resources to match your current phase of
+development. For example, you might use a notebook instance with
+modest resources during experimentation, then transition to
+distributed training on a cluster of more powerful instances when
+you're ready for full-scale training.
+
+### Implementation steps
+
+- **Create a representative subset of
+your data**. Extract a small but representative
+sample of your full dataset that maintains the same
+distribution of features and classes as your original data.
+Aim for 10-20% of your data or a size that can be processed
+on your local machine or small instance.
+- **Set up SageMaker AI notebook instances
+for experimentation**.
+[Amazon SageMaker AI notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html) provide a hosted Jupyter
+environment ideal for exploring and experimenting with your
+sample dataset. Choose a smaller instance type to keep costs
+low during experimentation.
+- **Configure notebook lifecycle
+management**. Use
+[lifecycle
+configuration scripts](https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples) to automate the setup of your
+development environment, including installing necessary
+libraries and dependencies when your notebook instance
+starts.
+- **Develop and iterate on your
+model**. Use the notebook environment to build,
+train and evaluate your models on the sample data. Take
+advantage of this faster iteration cycle to explore
+different approaches, hyperparameters, and preprocessing
+techniques.
+- **Test scaling
+considerations**. Before moving to full-scale
+training, test your code with slightly larger data samples
+to identify scaling issues that might arise when processing
+the full dataset.
+- **Prepare for distributed
+training**. Once your approach is validated with
+the sample data, refactor your code as needed to support
+distributed training using SageMaker AI's distributed training
+capabilities.
+- **Scale up compute resources for full
+training**. Launch appropriately sized training
+instances or clusters for your full-scale training job.
+SageMaker AI training jobs allow you to select the instance
+type and count that matches your workload requirements.
+- **Monitor training metrics and
+costs**. Use Amazon CloudWatch to track the
+performance and resource utilization of your training jobs
+to check that they're running efficiently.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi.html)
+- [Amazon SageMaker AI Studio Lab](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lab.html)
+- [Customization
+of a SageMaker AI notebook instance using an LCC script](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html)
+- [Distributed
+training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Notebook Instance Lifecycle Config Samples](https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples)
+- [SageMaker AI
+Local Mode](https://github.com/aws-samples/amazon-sagemaker-local-mode)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp09.html*
+
+---
+
+# MLCOST04-BP10 Use warm start and checkpointing hyperparameter tuning
+
+When training machine learning models, you can significantly reduce
+time and costs by using previous training efforts. This practice
+shows how to use warm start and checkpointing techniques in
+hyperparameter tuning to accelerate your model development process
+and optimize resource utilization.
+
+**Desired outcome:** You can create
+more efficient hyperparameter tuning jobs by using knowledge from
+previous tuning efforts and saved model states. By implementing warm
+start capabilities, you can initialize new tuning jobs with
+information from previous runs, avoiding unnecessary repetition.
+With checkpointing, you can save intermediate model states during
+training, allowing you to resume jobs from the last checkpoint
+rather than starting from scratch. These techniques enable you to
+accelerate your model development process, reduce computational
+costs, and find optimal hyperparameter configurations more
+efficiently.
+
+**Common anti-patterns:**
+
+- Starting every hyperparameter tuning job from scratch without
+using previous knowledge.
+- Not saving model checkpoints during lengthy training jobs,
+risking complete loss of progress if interrupted.
+- Using unnecessarily wide hyperparameter search ranges when
+previous jobs have already identified promising areas.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower computational costs through more efficient resource
+utilization.
+- Accelerated convergence to optimal model configurations.
+- Improved resilience to training interruptions through checkpoint
+recovery.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Hyperparameter tuning is an essential but computationally
+intensive part of machine learning model development. Without warm
+start capabilities, each tuning job begins with no prior
+knowledge, potentially wasting resources by exploring
+already-evaluated hyperparameter combinations. Without
+checkpointing, an interrupted training job must restart from the
+beginning, losing progress.
+
+You can overcome these inefficiencies by implementing warm start
+and checkpointing strategies in your ML workflow. Warm start
+allows you to use knowledge from previous hyperparameter tuning
+jobs, focusing the search on promising areas of the hyperparameter
+space. Checkpointing enables you to save model states periodically
+during training, providing a recovery point if training is
+interrupted.
+
+Amazon SageMaker AI offers built-in support for both warm start and
+checkpointing capabilities. For warm start, you can specify one or
+more parent tuning jobs whose results inform the new job's
+hyperparameter search. SageMaker AI offers two warm start types:
+TRANSFER_LEARNING for adapting knowledge to new
+datasets and IDENTICAL_DATA_AND_ALGORITHM for
+continuing tuning with the same dataset. For checkpointing, you
+can configure your training jobs to periodically save model states
+to Amazon S3, which can be used to resume training if needed.
+
+### Implementation steps
+
+- **Configure warm start for
+hyperparameter tuning jobs**. Set up a new
+hyperparameter tuning job that builds upon the knowledge
+gained from previous tuning jobs. In Amazon SageMaker AI, you
+can configure this by specifying one or more parent tuning
+jobs and selecting an appropriate warm start type. This
+approach is particularly effective when you want to refine
+hyperparameter search after initial exploration or adapt a
+model to a similar dataset.
+- **Select appropriate parent jobs for
+warm start**. Choose parent jobs that are relevant
+to your current tuning objective. The best parent jobs are
+those that used similar datasets, algorithms, or
+optimization objectives. In SageMaker AI, you can specify up to
+five parent jobs when configuring a warm start tuning job.
+- **Choose the right warm start
+type**. Select
+IDENTICAL_DATA_AND_ALGORITHM when
+continuing tuning with the same dataset and algorithm, or
+TRANSFER_LEARNING when adapting knowledge
+to a new but related dataset or problem. The warm start type
+determines how SageMaker AI will use information from the
+parent jobs.
+- **Configure checkpointing for training
+jobs**. Enable checkpointing in your training
+script by saving model states at regular intervals. In
+SageMaker AI, specify a checkpoint S3 location where these
+model states will be stored. This allows you to resume
+training from the last saved checkpoint if a job is
+interrupted or if you want to extend training later.
+- **Implement checkpoint saving in your
+training code**. Add callback functions in your ML
+framework (such as TensorFlow, PyTorch, or MXNet) to
+periodically save model states during training. These
+frameworks typically provide built-in checkpoint
+functionality that you can configure with minimal code
+changes.
+- **Set up checkpoint recovery
+mechanisms**. Configure your training jobs to check
+for existing checkpoints at startup and resume from the
+latest checkpoint if available. In SageMaker AI, you can
+specify the checkpoint configuration when creating a
+training job, including the S3 location where checkpoints
+are stored.
+- **Optimize hyperparameter search
+ranges based on previous results**. When using warm
+start, refine your hyperparameter search ranges based on
+promising values identified in parent jobs. Narrowing search
+ranges around previously successful values can significantly
+improve tuning efficiency.
+- **Run parallel hyperparameter tuning
+jobs strategically**. Use warm start to distribute
+the hyperparameter tuning workload across multiple jobs that
+can share knowledge. This approach is particularly effective
+for exploring large hyperparameter spaces efficiently.
+- **Monitor and evaluate warm start
+efficiency**. Track the performance and efficiency
+gains from warm start by comparing with cold-start
+approaches. This analysis refines your warm start strategy
+for future jobs.
+- **Use enhanced hyperparameter tuning
+capabilities**. Use improved SageMaker AI
+hyperparameter tuning with better algorithms and support for
+multi-objective optimization to find optimal configurations
+more efficiently.
+- **Use generative AI for hyperparameter
+selection**. Use large language models to suggest
+promising hyperparameter ranges based on model architecture
+and dataset characteristics. Generative AI can identify
+sensible starting points for hyperparameter tuning jobs,
+especially for new model architectures.
+
+## Resources
+
+**Related documents:**
+
+- [Run
+a Warm Start Hyperparameter Tuning Job](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-warm-start.html)
+- [Checkpoints
+in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-checkpoints.html)
+- [Automatic
+model tuning in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [HyperparameterTuner](https://sagemaker.readthedocs.io/en/stable/api/training/tuner.html)
+
+**Related examples:**
+
+- [Automatic
+Model Tuning: Warm Starting Tuning Jobs](https://github.com/aws/amazon-sagemaker-examples/blob/master/hyperparameter_tuning/image_classification_warmstart/hpo_image_classification_warmstart.ipynb)
+- [Hyperparameter
+Optimization with Checkpointing Example](https://github.com/aws/amazon-sagemaker-examples/tree/master/hyperparameter_tuning)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp10.html*
+
+---
+
+# MLCOST04-BP11 Use hyperparameter optimization technologies
+
+Optimize your machine learning models through automatic
+hyperparameter tuning to find the optimal model configuration with
+minimal manual effort, reducing the time and resources needed to
+achieve peak model performance.
+
+**Desired outcome:** You achieve
+better performing machine learning models by using automatic
+hyperparameter optimization technologies that run multiple training
+jobs in parallel. You can efficiently explore a wide range of
+hyperparameter combinations to find the optimal configuration that
+maximizes model performance according to your specified metrics,
+ultimately delivering better business results while reducing the
+time and resources spent on manual tuning.
+
+**Common anti-patterns:**
+
+- Manually tuning hyperparameters through trial and error.
+- Using a narrow range of hyperparameter values that don't
+adequately explore the solution space.
+- Selecting arbitrary hyperparameter values without considering
+the specific requirements of your business problem.
+- Running one training job at a time instead of using parallel
+capabilities.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced time to develop high-performing machine learning models.
+- Lower computational costs by efficiently exploring the
+hyperparameter space.
+- Consistent and repeatable approach to model optimization.
+- Ability to scale hyperparameter tuning efforts across multiple
+algorithms.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+*Hyperparameter optimization (HPO)* is a
+critical aspect of developing effective machine learning models.
+Unlike model parameters that are learned during training,
+hyperparameters are configuration variables that govern the
+training process itself and significantly impact model
+performance. Finding the optimal combination of hyperparameters
+manually is time-consuming and inefficient.
+
+By implementing automatic hyperparameter tuning, you can
+systematically explore the hyperparameter space and identify the
+configuration that maximizes model performance. SageMaker AI's
+automatic model tuning service employs techniques like Bayesian
+optimization to intelligently search through the hyperparameter
+space, focusing computational resources on the most promising
+regions and accelerating the discovery of the optimal
+configuration.
+
+When implementing hyperparameter optimization, you should define
+appropriate search spaces for your hyperparameters based on domain
+knowledge and previous experiments. You also need to select
+relevant evaluation metrics that align with your business
+objectives. For classification problems, this might include
+accuracy, F1 score, or AUC-ROC, while for regression problems, it
+could be mean squared error or mean absolute error.
+
+### Implementation steps
+
+- **Identify key hyperparameters for
+your model**. Begin by determining which
+hyperparameters have the greatest impact on your model's
+performance. For neural networks, this might include
+learning rate, batch size, and network architecture
+parameters. For tree-based models, this could include tree
+depth, number of trees, and minimum samples per leaf.
+- **Define appropriate hyperparameter
+ranges**. Establish meaningful ranges for each
+hyperparameter based on domain knowledge and best practices
+for your chosen algorithm. Use logarithmic scales for
+parameters that span multiple orders of magnitude (like
+learning rate) for efficient exploration.
+- **Select relevant evaluation
+metrics**. Choose metrics that align with your
+business requirements and the problem you're solving. Check
+that these metrics provide a meaningful assessment of model
+performance in the context of your specific application.
+- **Configure SageMaker AI automatic model
+tuning**. Create a hyperparameter tuning job using
+the
+[SageMaker AI
+Python SDK](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html) or the SageMaker AI console. Specify the
+algorithm or framework you're using, the hyperparameter
+ranges, and the evaluation metric to optimize.
+- **Implement early stopping for
+efficiency**. Enable early stopping features to
+automatically terminate poorly performing training jobs,
+saving computational resources. SageMaker AI can monitor the
+evaluation metric during training and stop jobs that are
+unlikely to produce competitive models.
+- **Use warm start for incremental
+tuning**. Use the warm start feature to accelerate
+new hyperparameter tuning jobs by using information from
+previous tuning jobs, reducing the time and resources needed
+to find optimal configurations.
+- **Implement parallel training
+jobs**. Configure SageMaker AI to run multiple
+training jobs concurrently to explore different
+hyperparameter combinations simultaneously, dramatically
+reducing the time required to find optimal values.
+- **Analyze tuning job
+results**. Review the performance of different
+hyperparameter combinations to understand how each parameter
+affects model performance. Use this information to refine
+your hyperparameter ranges for future tuning jobs.
+- **Select the best model for
+deployment**. After the tuning job completes,
+identify the best-performing model based on your evaluation
+metric and deploy it using SageMaker AI's deployment
+capabilities.
+- **Use no-code hyperparameter
+optimization**. Use
+[SageMaker AI
+Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html) with enhanced capabilities for business users
+to perform hyperparameter optimization through natural
+language interfaces without requiring deep technical
+expertise.
+- **Document hyperparameter
+configurations**. Maintain comprehensive
+documentation of hyperparameter configurations, tuning
+strategies, and results to facilitate knowledge sharing and
+reproducibility.
+
+## Resources
+
+**Related documents:**
+
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [Stop
+Training Jobs Early](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-early-stopping.html)
+- [Best
+Practices for Hyperparameter Tuning](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html)
+- [Create
+a Hyperparameter Optimization Tuning Job for One or More
+Algorithms (Console)](https://docs.aws.amazon.com/sagemaker/latest/dg/multiple-algorithm-hpo-create-tuning-jobs.html)
+- [Run
+a Warm Start Hyperparameter Tuning Job](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-warm-start.html)
+
+**Related examples:**
+
+- [SageMaker AI
+examples - hyperparameter tuning](https://github.com/aws/amazon-sagemaker-examples/tree/main/hyperparameter_tuning)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp11.html*
+
+---
+
+# MLCOST04-BP12 Set up a budget and use resource tagging to track costs
+
+Setting up budgets and implementing resource tagging for machine
+learning workloads provides clear visibility into your ML-related
+expenses and optimizes costs across your organization. By tracking
+costs effectively, you can make data-driven decisions about resource
+allocation and identify opportunities for cost optimization.
+
+**Desired outcome:** You gain
+complete visibility into your machine learning costs across
+development, training, and production environments. You can track
+expenses by project, business unit, or environment, allowing for
+accurate cost allocation and forecasting. Through tagging and
+budgeting tools, you can proactively manage your ML spending,
+receive alerts before exceeding budgeted amounts, and make informed
+decisions about resource provisioning and termination.
+
+**Common anti-patterns:**
+
+- Running ML workloads without cost monitoring mechanisms in
+place.
+- Using generic cost tracking that doesn't differentiate between
+ML projects or environments.
+- Failing to tag ML resources consistently, making cost allocation
+difficult.
+- Ignoring budget alerts or failing to take action when exceeding
+thresholds.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear visibility into where ML spending occurs across your
+organization.
+- Ability to accurately allocate costs to specific projects or
+business units.
+- Early warning through alerts when costs exceed or are forecasted
+to exceed budgeted amounts.
+- Improved governance and financial accountability for ML
+initiatives.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Cost management is a critical aspect of running machine learning
+workloads in the cloud. Without proper cost tracking and budget
+controls, ML expenses can quickly escalate due to
+compute-intensive training jobs, large storage requirements for
+datasets, and continuous inference endpoints. By implementing
+comprehensive budgeting and tagging strategies, you gain
+visibility and control over these costs.
+
+AWS provides several tools that work together to track, analyze,
+and optimize your ML costs. AWS Budgets allows you to set custom
+budgets for your SageMaker AI resources, while AWS Cost Explorer
+provides visualization and analysis capabilities to understand
+spending patterns. Resource tagging serves as the foundation for
+detailed cost tracking, enabling you to categorize expenses by
+project, team, environment, or other dimension important to your
+organization.
+
+For example, you might tag resources related to a fraud detection
+model with a Project tag value of
+FraudDetection and an
+Environment tag value of
+Production. This allows you to track the total
+cost of this specific ML use case across its components, from
+development notebooks to training jobs to deployment endpoints.
+
+### Implementation steps
+
+- **Set up AWS Budgets for ML cost
+tracking**. Create customized budgets in AWS
+Budgets to monitor your Amazon SageMaker AI costs across
+development, training, and hosting. Configure the budget to
+track specific services (such as SageMaker AI) or specific
+tagged resources. Set thresholds for actual costs and
+forecasted costs to receive notifications before you exceed
+your budget. This gives you time to make adjustments to your
+resource usage if needed. Access your budgets through the
+[AWS Budgets console](https://aws.amazon.com/aws-cost-management/aws-budgets/) to track progress and make
+adjustments as necessary.
+- **Implement a tagging strategy for ML
+resources**. Develop a consistent tagging strategy
+for all your ML resources. Define mandatory tags such as
+Project, BusinessUnit, Environment (dev/test/prod), and
+Owner. Document your tagging standards and verify that team
+members understand and follow these standards. Apply these
+tags to relevant resources, including
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) notebook instances, training jobs, models,
+endpoints, and related resources like
+[Amazon S3](https://aws.amazon.com/s3/) buckets for dataset storage.
+- **Activate cost allocation
+tags**. After implementing your tagging strategy,
+activate your tags as cost allocation tags in the AWS Billing and Cost Management console. Note that it may take up to 24 hours for
+newly activated tags to appear in your cost management
+tools. Once activated, you can use your tags to filter and
+group costs in AWS Cost Explorer and other cost reporting
+tools.
+- **Configure detailed cost analysis
+using AWS Cost Explorer**. Use
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) to visualize and analyze your ML costs
+over time. Create custom reports that filter costs by
+specific tags (like Project or Environment) or by specific
+services like SageMaker AI. Set up regular reports to track
+spending trends, identify cost spikes, and understand usage
+patterns. Use the insights gained to optimize your resource
+allocation and scheduling for ML workloads.
+- **Create cost anomaly
+detection**. Set up
+[AWS Cost Anomaly Detection](https://aws.amazon.com/aws-cost-management/aws-cost-anomaly-detection/) to automatically identify
+unusual spending patterns in your ML workloads. Configure
+alerts to notify relevant stakeholders when anomalies are
+detected. This assists you in quickly identifying and
+addressing unexpected cost increases, which can happen with
+ML workloads due to extended training times or inefficient
+resource usage.
+- **Establish cost governance
+processes**. Create clear processes for reviewing
+costs, responding to budget alerts, and making cost
+optimization decisions. Assign responsibility for cost
+monitoring to specific individuals or teams. Conduct regular
+cost reviews with stakeholders to discuss spending trends,
+identify optimization opportunities, and align ML resource
+usage with business priorities. Document cost-saving actions
+taken and their impact on the overall budget.
+- **Optimize ML resources based on cost
+data**. Use the cost insights gained from your
+tagging and budgeting tools to optimize ML resource usage.
+Identify underutilized notebook instances that can be
+stopped when not in use. Select appropriate instance types
+based on workload requirements. Consider using
+[Amazon SageMaker AI Managed Spot Training](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html) to reduce training
+costs by up to 90%. Implement auto-scaling for inference
+endpoints to match capacity with demand.
+
+## Resources
+
+**Related documents:**
+
+- [Managing
+your costs with AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [Organizing
+and tracking costs using AWS cost allocation tags](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
+- [Getting
+started with AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html)
+- [Best
+Practices for Tagging AWS Resources](https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/tagging-best-practices.html)
+- [Cost
+Optimization Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
+- [Amazon SageMaker AI Pricing](https://aws.amazon.com/sagemaker/pricing/)
+- [AWS Cloud Financial Management](https://aws.amazon.com/aws-cost-management/)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 4: Training jobs](https://aws.amazon.com/blogs/machine-learning/part-4-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-4-training-jobs/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp12.html*
+
+---
+
+# MLCOST04-BP13 Enable data and compute proximity
+
+Positioning data and compute resources in the same AWS Region
+reduces data transfer costs and improves processing speeds for
+machine learning workloads. By minimizing the physical distance
+between data storage and compute resources, you can significantly
+decrease latency and avoid cross-region data transfer fees.
+
+**Desired outcome:** You achieve
+cost-efficient and high-performance machine learning operations by
+placing your data and compute resources in the same AWS Region. You
+experience faster training times, reduced latency, and avoid
+unnecessary data transfer costs that can significantly impact your
+ML project budgets.
+
+**Common anti-patterns:**
+
+- Storing data in one Region and running compute resources in
+another Region.
+- Repeatedly transferring large datasets across Regions for
+training or inference.
+- Failing to consider the impact of data transfer costs on overall
+ML project budgets.
+
+**Benefits of establishing this best
+practice:**
+
+- Decreased latency for data access during model training and
+inference.
+- Improved overall machine learning workflow performance.
+- Simplified management of data compliance and sovereignty
+requirements.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data transfer costs between AWS Regions can significantly impact
+your machine learning project's budget, especially when working
+with large datasets that are repeatedly accessed during model
+training. By keeping your compute resources in the same Region as
+your data storage, you minimize these costs and improve
+performance.
+
+When planning your machine learning infrastructure on AWS,
+consider data locality as a primary design principle. For example,
+if your organization stores datasets in Amazon S3 buckets in the
+US West (Oregon) Region, you should provision EC2 instances,
+SageMaker AI notebooks, or other ML compute resources in that same
+Region.
+
+This principle applies to various machine learning scenarios,
+including model training, data preprocessing, and inference. Even
+though AWS provides high-speed network connections between
+Regions, the laws of physics still impose latency limitations, and
+cross-Region data transfers incur additional costs that can be
+avoided.
+
+### Implementation steps
+
+- **Identify data storage
+locations**. Determine where your primary data is
+stored on AWS. Check which Regions contain your Amazon S3
+buckets, Amazon EFS file systems, or other storage services
+holding your training data. Use the AWS Management Console,
+AWS CLI, or infrastructure as code tools to inventory your
+data storage resources across Regions.
+- **Audit compute resource
+placement**. Review your current machine learning
+compute resources, including Amazon EC2 instances, Amazon SageMaker AI notebooks, and training jobs. Verify if they are
+in the same Regions as your data sources. Use AWS Cost Explorer and AWS Trusted Advisor to identify cross-Region
+data transfer costs that may indicate misaligned resources.
+- **Consolidate resources by
+Region**. When creating new compute resources for
+machine learning workloads, consistently provision them in
+the same Region as your data. For example, if using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/), create your notebook instances, training
+jobs, and endpoints in the Region where your training data
+is stored in Amazon S3.
+- **Use Regional data transfer
+analysis**. Review your AWS billing information to
+identify and quantify cross-Region data transfer costs. The
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) service can assist you in analyzing
+data transfer costs between AWS services and across Regions.
+Set up cost allocation tags to track expenses related to
+machine learning projects specifically.
+- **Consider data replication for
+specific use cases**. In scenarios requiring
+multi-Region deployments for high availability or disaster
+recovery, implement a data replication strategy to maintain
+copies of datasets in each Region where compute resources
+exist. Services like
+[Amazon S3 Cross-Region Replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html) can automate this process
+while managing costs.
+- **Leverage edge computing for
+distributed ML workloads**. When working with data
+that exists at the edge of the network, consider using
+[AWS Outposts](https://aws.amazon.com/outposts/),
+[AWS Wavelength](https://aws.amazon.com/wavelength/), or
+[AWS Local Zones](https://aws.amazon.com/about-aws/global-infrastructure/localzones/) to bring compute resources closer to your
+data sources, especially for applications requiring
+low-latency inference.
+- **Implement data caching
+strategies**. For frequently accessed data,
+implement caching solutions like
+[Amazon ElastiCache](https://aws.amazon.com/elasticache/) or
+[Amazon DynamoDB Accelerator (DAX)](https://aws.amazon.com/dynamodb/dax/) in the same Region as your
+compute resources to further reduce latency and data
+transfer costs.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [Replicating
+objects within and across Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html)
+- [AWS Data Transfer Pricing](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer)
+- [AWS Local Zones](https://aws.amazon.com/about-aws/global-infrastructure/localzones/)
+- [AWS Outposts](https://aws.amazon.com/outposts/)
+- [Regions
+and Zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)
+- [AWS Global Infrastructure](https://aws.amazon.com/about-aws/global-infrastructure/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp13.html*
+
+---
+
+# MLCOST04-BP14 Select optimal algorithms
+
+Selecting optimal algorithms for machine learning (ML) workloads is
+crucial for balancing cost efficiency and performance. By
+identifying appropriate ML paradigms and carefully evaluating
+algorithmic choices, you can optimize both technical performance and
+business outcomes while managing costs.
+
+**Desired outcome:** You are able to
+identify the most suitable ML algorithm for your specific use case
+that balances accuracy, explainability, computational requirements,
+and cost efficiency. You can conduct effective trade-off analyses
+between different approaches and use AWS services to optimize
+algorithm selection, training, and deployment.
+
+**Common anti-patterns:**
+
+- Using complex deep learning solutions without first exploring
+simpler algorithms.
+- Ignoring the explainability requirements of the business use
+case.
+- Failing to consider data constraints when selecting algorithms.
+- Not evaluating computational and maintenance costs alongside
+accuracy metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced computational costs by using algorithms appropriate for
+the specific problem.
+- Improved model performance through systematic comparison of
+algorithm options.
+- Enhanced model explainability when required by business
+stakeholders.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Selecting the optimal algorithm requires understanding your
+specific ML problem type and the business constraints around it.
+Begin by categorizing your problem into basic ML paradigms:
+supervised learning (for labeled data), unsupervised learning (for
+unlabeled data), or reinforcement learning (for sequential
+decision problems). Consider what matters most for your use case,
+whether it's prediction accuracy, model explainability, inference
+speed, or a balance of these factors.
+
+Algorithm selection significantly impacts both the performance and
+cost efficiency of your ML solutions. A computationally expensive
+algorithm might deliver marginally better accuracy but at
+substantially higher operational costs. Similarly, a complex but
+highly accurate algorithm might sacrifice the explainability
+needed for regulatory adherence or business transparency. Finding
+the right balance requires systematic experimentation and
+evaluation against your business requirements.
+
+AWS provides various services test, compare, and optimize
+algorithms, allowing you to make data-driven decisions about which
+approach delivers the best value for your specific use case.
+
+### Implementation steps
+
+- **Define your machine learning problem
+type**. Categorize your problem as supervised
+learning (classification, regression), unsupervised learning
+(clustering, dimensionality reduction), or reinforcement
+learning. This initial classification narrows down the
+appropriate algorithms to consider.
+- **Determine business requirements and
+constraints**. Document specific accuracy targets,
+explainability needs, inference time requirements, and
+budget constraints. These requirements will serve as
+criteria for evaluating algorithm options.
+- **Start with simple algorithms
+first**. Begin experimentation with simpler
+algorithms like linear or logistic regression, decision
+trees, or k-means clustering before moving to more complex
+approaches. These algorithms are computationally efficient,
+simpler to interpret, and establish important baselines for
+performance comparison.
+- **Conduct structured
+experimentation**. Use
+[Amazon SageMaker AI Experiments](https://docs.aws.amazon.com/sagemaker/latest/dg/experiments.html) to track different algorithm
+trials, hyperparameter configurations, and their results.
+This creates reproducibility and facilitates comparison
+between approaches.
+- **Perform comprehensive trade-off
+analysis**. When comparing algorithms, consider
+multiple dimensions beyond accuracy:
+
+Data requirements (amount needed for training)
+- Computational resources required for training and
+inference
+- Model explainability and interpretability
+- Deployment complexity and operational overhead
+- Long-term maintenance costs
+
+- **Use AWS optimized algorithms and
+frameworks**. Use
+[Amazon SageMaker AI built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) that are optimized for
+performance and cost-efficiency on AWS infrastructure. AWS
+also provides optimized versions of popular frameworks like
+TensorFlow, PyTorch, and MXNet that include performance
+enhancements for training across
+[Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html) instance families.
+- **Consider automated ML
+approaches**. For exploratory projects or when
+seeking optimal performance with minimal manual tuning, use
+SageMaker AI Canvas for rapid algorithm prototyping with the
+ability to export generated code to notebooks for further
+customization.
+- **Explore pre-trained
+models**. Search AWS Marketplace for pre-trained
+models that can accelerate development through transfer
+learning or direct deployment. Pre-trained models can
+significantly reduce computational costs and development
+time.
+- **Implement continuous
+evaluation**. As new algorithms and model versions
+emerge, periodically reassess whether your chosen approach
+remains optimal. Business requirements and available
+technologies evolve over time.
+- **Document algorithm selection
+rationale**. Create clear documentation explaining
+why specific algorithms were selected, what trade-offs were
+accepted, and how these decisions align with business
+requirements.
+- **For generative AI projects, consider
+foundation models from
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for natural language processing, image
+generation, and other tasks where these models can provide
+state-of-the-art performance with lower development
+costs.** Use techniques like prompt engineering and
+fine-tuning to adapt foundation models to your specific
+business needs while avoiding the computational expense of
+training from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [Built-in
+algorithms and pretrained models in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html#mlflow-tracking)
+- [How
+custom models work](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-build-model.html)
+- [Types
+of Algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algorithms-choose.html)
+- [SageMaker AI
+JumpStart pretrained Models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost04-bp14.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLCOST05.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLCOST05.md
@@ -1,0 +1,517 @@
+# MLCOST05
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLCOST05-BP01 Use an appropriate deployment option
+
+Use the right deployment option for your machine learning models to
+optimize cost and performance based on your specific use case
+requirements. Select real-time inference for low latency
+applications, batch transform for large datasets, or edge deployment
+for applications that require local processing.
+
+**Desired outcome:** You have an
+optimized model deployment strategy that balances performance and
+cost efficiency. You can choose the appropriate deployment option
+based on your specific use case requirements, whether that's
+real-time inference for low-latency applications, batch processing
+for large datasets, or edge deployment for scenarios requiring local
+processing.
+
+**Common anti-patterns:**
+
+- Using real-time endpoints for deployment scenarios regardless of
+traffic patterns.
+- Overlooking serverless or asynchronous options when they would
+be more cost-effective.
+- Deploying separate endpoints for each model when multiple models
+could be hosted more efficiently together.
+- Running inference in the cloud when edge deployment would be
+more efficient for local data processing.
+- Overprovisioning compute resources for inference endpoints.
+
+**Benefits of establishing this best
+practice:**
+
+- Cost optimization through selection of the most efficient
+deployment option for each use case.
+- Improved performance by matching deployment options to specific
+latency requirements.
+- Increased operational efficiency through managed inference
+services.
+- Flexibility to handle varying inference workloads and traffic
+patterns.
+- Simplified ML model management across cloud and edge
+environments.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When deploying machine learning models, selecting the right
+deployment option is crucial for achieving optimal performance and
+cost efficiency. Amazon SageMaker AI provides multiple deployment
+options that can be tailored to your specific use case
+requirements. Real-time inference is ideal for applications
+requiring low latency responses, such as real-time recommendations
+or fraud detection. Batch transform is better suited for
+processing large datasets in offline mode, such as document
+processing or periodic scoring jobs. Edge deployment brings
+inference capabilities directly to edge devices, reducing latency
+and bandwidth requirements while enabling offline processing.
+
+Consider the pattern of requests your application needs to handle.
+If you need consistent, low-latency responses for interactive
+applications with steady traffic, real-time inference is
+appropriate. If you process data in batches without immediate
+response requirements, batch transform offers cost efficiency. For
+applications with unpredictable or bursty traffic patterns,
+serverless inference can automatically scale to match demand while
+minimizing costs during idle periods. For workloads with large
+payloads or long processing times, asynchronous inference provides
+a queuing mechanism that improves efficiency.
+
+Also consider resource utilization. Multi-model endpoints and
+multi-container endpoints enable you to optimize costs by sharing
+resources across multiple models or containers. This approach is
+particularly valuable when you have many models with variable
+usage patterns or complementary resource requirements.
+
+### Implementation steps
+
+- **Evaluate your inference
+requirements**. Determine your application's needs
+for latency, throughput, payload size, and traffic patterns.
+Consider whether your application requires real-time
+responses or can process data in batches. Assess if your
+models should run in the cloud or at the edge based on
+connectivity, latency requirements, and data privacy
+considerations.
+- **Use Amazon SageMaker AI for model
+deployment**.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) offers a comprehensive set of deployment
+options to optimize price-performance for most use cases.
+It's a fully managed service that integrates with MLOps
+tools for effective model management in production with
+reduced operational burden.
+- **Select the appropriate inference
+option based on your use case**. Choose from
+several SageMaker AI inference options:
+
+[Amazon SageMaker AI Real-time Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html) for low-latency,
+interactive applications requiring immediate responses
+- [Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) for workloads with
+intermittent or unpredictable traffic patterns
+- [Amazon SageMaker AI Asynchronous Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html) for large
+payload sizes, long processing times, or when immediate
+responses aren't required
+- [Amazon SageMaker AI Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html) for offline processing
+of large datasets
+
+- **Implement multi-model endpoints for
+cost optimization**. Use
+[Amazon SageMaker AI Multi-Model Endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html) to deploy multiple
+models on a single endpoint with shared container resources.
+This approach improves endpoint utilization and reduces
+hosting costs compared to single-model endpoints. SageMaker AI
+manages the loading of models into memory and scales them
+based on traffic patterns.
+- **Deploy multiple containers on a
+single endpoint**. Implement
+[SageMaker AI
+multi-container endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html) to deploy multiple
+containers using different models or frameworks on a single
+endpoint. Run containers in sequence as an inference
+pipeline or access each container individually through
+direct invocation to improve endpoint utilization and
+optimize costs.
+- **Automate endpoint changes through a
+pipeline**. Use
+[Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) to automate the model deployment
+process. Create CI/CD pipelines that handle model training,
+evaluation, and deployment, enabling consistent and
+repeatable deployment processes.
+- **Monitor and optimize your
+deployment**. Implement continuous monitoring of
+your inference endpoints to track performance metrics, cost,
+and resource utilization. Use this data to fine-tune your
+deployment strategy and make adjustments as needed to
+optimize for cost efficiency and performance.
+- **Use AI-powered code generation for
+deployment automation**. Use AI-powered development
+tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+deployment scripts, automate infrastructure configuration,
+and accelerate the implementation of optimal deployment
+strategies.
+- **For generative AI workloads,
+consider deployment options for foundation
+models**. Evaluate specialized deployment options
+like
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for fully managed foundation models or
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart.html) for pre-trained models with optimized
+deployment configurations.
+
+## Resources
+
+**Related documents:**
+
+- [Deploy
+models for inference](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-model.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Batch
+transform for inference with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)
+- [Hosting
+options](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-options.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Model
+deployment at the edge with SageMaker AI Edge Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/edge.html)
+- [Inference
+pipelines in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Serverless Inference Walkthrough](https://github.com/aws/amazon-sagemaker-examples/blob/main/serverless-inference/Serverless-Inference-Walkthrough.ipynb)
+- [SageMaker AI
+Edge Manager Workshop](https://github.com/aws-samples/amazon-sagemaker-edge-manager-workshop)
+- [SageMaker AI
+Asynchronous Inference Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/async-inference)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost05-bp01.html*
+
+---
+
+# MLCOST05-BP02 Explore cost effective hardware options
+
+Machine learning models that power AI applications are becoming
+increasingly complex resulting in rising underlying compute
+infrastructure costs. Up to 90% of the infrastructure spend for
+developing and running ML applications is often on inference. Look
+for cost-effective infrastructure solutions for deploying their ML
+applications in production.
+
+**Desired outcome:** You achieve
+significant cost savings while maintaining or improving the
+performance of your machine learning inference workloads. By
+implementing cost-effective hardware options, you optimize your
+infrastructure spend, reduce operational costs, and can allocate
+resources more efficiently across your ML applications. Your ML
+models run on purpose-built hardware that provides the right balance
+of performance and cost for your specific use case.
+
+**Common anti-patterns:**
+
+- Using general-purpose compute instances for ML workloads without
+considering specialized hardware options.
+- Over-provisioning inference resources to handle peak loads
+without implementing scaling strategies.
+- Ignoring model optimization opportunities before deploying to
+production.
+- Selecting hardware based solely on performance metrics without
+considering cost-efficiency.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced infrastructure costs for ML model inference.
+- Improved inference throughput and latency.
+- More efficient use of computational resources.
+- Lower total cost of ownership for AI applications.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning inference costs represent a significant portion
+of the total expenses associated with running ML workloads in
+production. As models become more complex, their computational
+requirements increase, which can lead to higher infrastructure
+costs. Selecting the right hardware for your ML workloads is
+crucial for maintaining cost efficiency without sacrificing
+performance.
+
+AWS offers multiple options to optimize the cost and performance
+of your ML inference workloads. These include services that
+optimize models for specific hardware targets, instances that
+provide cost-effective acceleration for inference workloads, and
+deployment options that match your specific latency and throughput
+requirements.
+
+Evaluating your specific workload requirements is essential before
+selecting hardware options. Consider factors such as latency
+requirements, throughput needs, model complexity, batch size
+capabilities, and budget constraints. This evaluation will assist
+you to determine the most appropriate hardware solution for your
+use case.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI Neo for model
+optimization**. Amazon SageMaker AI Neo automatically
+optimizes machine learning models for inference on cloud
+instances and edge devices. For inference in the cloud,
+SageMaker AI Neo speeds up inference and saves cost by creating
+an inference optimized container in SageMaker AI hosting. For
+inference at the edge, SageMaker AI Neo saves developers months
+of manual tuning by automatically tuning the model for the
+selected operating system and processor hardware. Neo
+optimizes models trained in TensorFlow, PyTorch, MXNet, and
+other frameworks for deployment on ARM, Intel, and NVIDIA
+processors.
+- **Deploy on Amazon EC2 Inf2
+Instances**. Amazon EC2 Inf1 instances deliver
+high-performance ML inference at the lowest cost in the
+cloud. They deliver up to 2.3-times higher throughput and up
+to 70% lower cost per inference than comparable current
+generation GPU-based Amazon EC2 instances. Inf1 instances
+are built from the ground up to support machine learning
+inference applications. They feature up to 16 AWS Inferentia
+chips, high-performance machine learning inference chips
+designed and built by AWS. Additionally, Inf1 instances
+include second generation Intel Xeon Scalable processors and
+up to 100 Gbps networking to deliver high throughput
+inference.
+- **Explore Amazon EC2 Inf2
+Instances**. The second generation of AWS
+Inferentia-based instances, EC2 Inf2 instances, offer even
+greater performance improvements over previous generations.
+These instances are powered by AWS Inferentia2 chips and
+provide up to 4x higher throughput and up to 10x lower
+latency than Inf1 instances. They're ideal for more complex
+generative AI models and large language models (LLMs) that
+require high performance and cost-effective inference
+solutions.
+- **Consider Amazon SageMaker AI serverless
+inference**. SageMaker AI serverless inference is a
+purpose-built inference option that automatically
+provisions, scales, and shuts down compute capacity based on
+your workload needs. This pay-per-use model can reduce costs
+by avoiding the need to continuously run instances when
+there are no inference requests, making it ideal for
+workloads with intermittent traffic patterns.
+- **Evaluate batch and asynchronous
+inference options**. For non-real-time inference
+requirements, consider using SageMaker AI batch transform for
+offline inference processing or SageMaker AI asynchronous
+inference for workloads that can tolerate higher latency.
+These options often allow for more efficient resource
+utilization and lower costs compared to real-time inference
+endpoints.
+- **Implement automated scaling
+policies**. Configure auto-scaling for your
+SageMaker AI endpoints to dynamically adjust the number of
+instances based on workload demands. This way, you can pay
+for the resources you need while maintaining performance
+requirements during peak usage periods.
+- **Use enhanced SageMaker AI Inference
+Recommender**. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) with enhanced algorithms and
+support for multi-model endpoints to get sophisticated cost
+optimization recommendations for your specific workloads.
+- **Regularly monitor and analyze
+inference costs**. Use AWS Cost Explorer and Amazon CloudWatch metrics to track your inference costs and
+performance metrics. Regularly review this data to identify
+optimization opportunities and adjust your hardware strategy
+accordingly.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [Amazon EC2 Inf2 Instances](https://aws.amazon.com/ec2/instance-types/inf2/)
+- [AWS Inferentia](https://aws.amazon.com/machine-learning/inferentia/)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Deploy
+models for inference](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-model.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+
+**Related examples:**
+
+- [AWS Neuron SDK Examples for Inferentia and Trainium
+instances](https://github.com/aws-neuron/aws-neuron-sdk)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost05-bp02.html*
+
+---
+
+# MLCOST05-BP03 Right-size the model hosting instance fleet
+
+Use efficient compute resources to run models in production. In many
+cases, up to 90% of the infrastructure spend for developing and
+running an ML application is on inference, making it critical to use
+high-performance, cost-effective ML inference infrastructure.
+Selecting the right way to host and the right type of instance can
+have a large impact on the total cost of ML projects. Use automatic
+scaling for your hosted models. Auto scaling dynamically adjusts the
+number of instances provisioned for a model in response to changes
+in your workload.
+
+**Desired outcome:** You optimize
+your ML infrastructure costs while maintaining performance by using
+the right instance types and quantities for your model deployments.
+You use automated tools to recommend the most cost-effective
+configurations and implement dynamic scaling that adjusts capacity
+based on actual demand patterns, resulting in significant cost
+savings and consistent performance.
+
+**Common anti-patterns:**
+
+- Using the same instance types for each model regardless of their
+specific requirements.
+- Maintaining static instance counts rather than scaling with
+workload demands.
+- Selecting instance types based solely on performance without
+considering cost implications.
+- Not distributing model instances across multiple availability
+zones for resilience.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced ML infrastructure costs by up to 90% through optimal
+instance selection.
+- Improved model performance through use of appropriately sized
+resources.
+- Enhanced reliability through automatic scaling and multi-AZ
+deployment.
+- Better handling of variable workloads without performance
+degradation.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Optimizing ML inference costs requires a careful balance between
+performance and cost. When selecting compute resources for model
+hosting, consider both the model's specific requirements and the
+expected workload patterns. CPU instances may be sufficient for
+many traditional ML models, while GPU instances deliver better
+performance for deep learning models but at a higher cost. The key
+is using the right resource for the specific workload.
+
+Amazon SageMaker AI provides tools that can automatically select
+the optimal instance type and size for your models. By testing
+different configurations, you can find the sweet spot that
+delivers the required performance at the lowest possible cost.
+Additionally, implementing auto scaling assists in verifying that
+your deployment can handle varying loads efficiently, scaling up
+during peak demand and down during quiet periods to avoid
+unnecessary costs.
+
+### Implementation steps
+
+- **Use Amazon SageMaker AI Inference
+Recommender for instance selection**. Amazon SageMaker AI Inference Recommender automatically selects the
+right compute instance type, instance count, container
+parameters, and model optimizations for inference to
+maximize performance and minimize cost. You can use
+SageMaker AI Inference Recommender from SageMaker AI Studio,
+the AWS Command Line Interface (AWS CLI), or the AWS SDK,
+and within minutes, get recommendations to deploy your ML
+model. You can then deploy your model to one of the
+recommended instances or run a fully managed load test on a
+set of instance types you choose without worrying about
+testing infrastructure. You can review the results of the
+load test in SageMaker AI Studio and evaluate the tradeoffs
+between latency, throughput, and cost to select the most
+optimal deployment configuration.
+- **Configure auto scaling for SageMaker AI
+endpoints**. Amazon SageMaker AI supports an auto
+scaling feature that monitors your workloads and dynamically
+adjusts the capacity to maintain steady and predictable
+performance at the lowest possible cost. When the workload
+increases, auto scaling brings more instances online. When
+the workload decreases, auto scaling removes unnecessary
+instances, which can reduce your compute cost. SageMaker AI
+automatically attempts to distribute your instances across
+Availability Zones. So, we strongly recommend that you
+deploy multiple instances for each production endpoint for
+high availability. If you're using a VPC, configure at least
+two subnets in different Availability Zones so Amazon SageMaker AI can distribute your instances across those
+Availability Zones.
+- **Implement proper scaling
+policies**. Define appropriate scaling policies
+based on your model's performance characteristics and usage
+patterns. Set scaling metrics such as CPU utilization, GPU
+utilization, model latency, or custom metrics that reflect
+your workload's needs. Define appropriate target values and
+cooldown periods to avoid rapid scaling oscillations.
+- **Consider serverless inference
+options**. For workloads with unpredictable or
+intermittent traffic patterns, evaluate
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html), which automatically
+provisions and scales compute capacity based on traffic.
+This option reduces the need to select instance types or
+manage scaling policies while providing pay-per-use pricing.
+- **Regularly review and optimize
+deployments**. Set up a process to periodically
+review your model deployments' performance and cost metrics.
+As your models evolve and usage patterns change, rerun
+Inference Recommender tests to keep your infrastructure
+optimized. Look for opportunities to consolidate models or
+use multi-model endpoints where appropriate.
+- **Use SageMaker AI Training Plans for
+predictable access**. Use
+[SageMaker AI
+Training Plans](https://aws.amazon.com/sagemaker/pricing/) as a compute reservation system for
+predictable access to high-demand GPU resources, managing
+large-scale AI training workloads more efficiently with
+better resource planning and scheduling capabilities.
+- **Use model optimization
+techniques**. For large language models and other
+generative AI workloads, consider techniques like
+quantization, distillation, or pruning to reduce model size
+and computational requirements. Amazon SageMaker AI supports
+optimization techniques through
+[SageMaker AI
+Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) and integration with
+[AWS Neuron](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/) for optimized inference on AWS Inferentia and
+Trainium chips.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+
+**Related examples:**
+
+- [SageMaker AI Inference Recommender](https://github.com/aws/amazon-sagemaker-examples/blob/main/sagemaker-inference-recommender/inference-recommender.ipynb)
+- [Right-sizing
+your Amazon SageMaker AI Endpoints](https://github.com/aws-samples/aws-marketplace-machine-learning/blob/master/right_size_your_sagemaker_endpoints/Right-sizing%20your%20Amazon%20SageMaker AI%20Endpoints.ipynb)
+- [SageMaker AI
+Serverless Inference Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/serverless-inference)
+- [Automatically
+Scale Amazon SageMaker AI Models](https://github.com/awsdocs/amazon-sagemaker-developer-guide/blob/master/doc_source/endpoint-auto-scaling.md)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost05-bp03.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLCOST06.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLCOST06.md
@@ -1,0 +1,709 @@
+# MLCOST06
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLCOST06-BP01 Monitor usage and cost by ML activity
+
+Use cloud resource tagging to manage, identify, organize, search
+for, and filter resources. Tags categorize resources by purpose,
+owner, environment, or other criteria. Associate costs with
+resources using ML activity categories, such as re-training and
+hosting, by using tagging to manage and optimize cost in deployment
+phases. Tagging can be useful for generating billing reports with
+breakdown of cost by associated resources.
+
+**Desired outcome:** You gain
+visibility into your machine learning costs by activity type,
+allowing for better allocation, forecasting, and optimization of ML
+resources. You can track expenses across different phases of the ML
+lifecycle including development, training, and deployment. This
+enables data-driven decisions about resource allocation and
+identifies cost-saving opportunities while maintaining performance.
+
+**Common anti-patterns:**
+
+- Using default AWS account structure without proper tagging
+strategy for ML resources.
+- Not separating costs between development, training, and
+production environments.
+- Failing to automate tagging as part of resource provisioning.
+- Overlooking unused or idle resources that continue to incur
+costs.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear visibility into costs associated with different ML
+activities.
+- Ability to allocate costs to appropriate business units or
+projects.
+- Improved forecasting and budgeting for ML initiatives.
+- Identification of cost-saving opportunities across the ML
+lifecycle.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Monitoring and optimizing costs for machine learning workloads
+requires a systematic approach to resource tagging and usage
+tracking. ML workloads typically have distinct phases—development,
+training, inference, and experimentation—each with different
+resource requirements and cost profiles. By implementing a
+comprehensive tagging strategy, you can track and attribute costs
+to specific ML activities, making it more straightforward to
+understand where your cloud spend is going and identify
+opportunities for optimization.
+
+AWS provides various tools and services to implement cost
+monitoring for ML workloads. With proper tagging, you can generate
+detailed cost reports, set up budgets with alerts, and make
+data-driven decisions about resource allocation. This practice is
+particularly important for ML workloads, which can be
+compute-intensive and potentially costly if not properly managed.
+
+### Implementation steps
+
+- **Establish a tagging strategy for ML
+resources**. Create a consistent tagging schema
+that captures relevant dimensions for ML activities. Include
+tags for project name, environment (development, testing,
+and production), ML phase (training, inference, and
+experiment), owner, and cost center. Document this strategy
+and verify that your team members understand and follow it
+when creating resources.
+- **Implement AWS tagging**. A
+[tag](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+is a label that you or AWS assigns to an AWS resource. Each
+tag consists of a key and a value. For each resource, each
+tag key must be unique, and each tag key can have only one
+value. You can use tags to organize your resources, and cost
+allocation tags to track your AWS costs on a detailed level.
+AWS uses the cost allocation tags to organize your resource
+costs on your cost allocation report. This streamlines
+categorizing and tracking your AWS costs. AWS provides two
+types of cost allocation tags, an AWS-generated tag and
+user-defined tags.
+- **Activate cost allocation
+tags**. After creating your tags, you need to
+activate them for cost tracking in the AWS Billing and Cost Management and Cost
+Management console. Note that it can take up to 24 hours for
+new tags to appear in your billing reports.
+- **Automate resource
+tagging**. Use AWS CloudFormation templates, AWS CDK, or Terraform to automate the application of tags when
+provisioning resources. For SageMaker AI resources, implement
+tagging in your deployment pipelines and notebook
+initialization scripts. Consider using AWS Tag Editor for
+bulk tagging operations on existing resources.
+- **Use AWS Budgets to keep track of
+cost**. AWS Budgets can track your Amazon SageMaker AI cost, including development, training, and hosting. You
+can also set alerts and get a notification when your cost or
+usage exceeds (or is forecasted to exceed) your budgeted
+amount. After you create your budget, you can track the
+progress on the AWS Budgets console.
+- **Implement cost monitoring and
+reporting**. Use AWS Cost Explorer to visualize and
+analyze your ML costs across different dimensions. Create
+custom reports filtered by your ML activity tags to
+understand spending patterns. Schedule regular exports of
+cost reports for stakeholders review.
+- **Establish cost optimization
+processes**. Regularly review resource utilization
+and costs to identify optimization opportunities. Implement
+automated shutdown of idle resources such as SageMaker AI
+notebooks when not in use. Consider using SageMaker AI Managed
+Spot Training to reduce training costs by up to 90%.
+- **Create governance for
+tagging**. Use AWS Config Rules or AWS CloudFormation Hooks to enforce tagging policies. Implement
+processes to review and correct untagged or incorrectly
+tagged resources. Consider using AWS Organizations Tag
+Policies to standardize tags across multiple accounts.
+- **Implement enhanced cost tracking
+with improved tagging**. Use enhanced AWS tagging
+capabilities with better automation and governance features
+to make your cost allocation more consistent across ML
+workloads and improve your visibility into spending
+patterns.
+- **Use cost optimization
+services**. Use AWS Cost Anomaly Detection to
+identify unusual spending patterns in your ML workloads.
+Consider AWS Compute Optimizer for recommendations on
+right-sizing your ML compute resources based on historical
+utilization data.
+
+## Resources
+
+**Related documents:**
+
+- [Organizing
+and tracking costs using AWS cost allocation tags](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
+- [Managing
+your costs with AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+- [Getting
+started with AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html)
+- [What
+is Tag Editor?](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+- [Best
+Practices for Tagging AWS Resources](https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/tagging-best-practices.html)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 1: Overview](https://aws.amazon.com/blogs/machine-learning/part-1-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-1/)
+- [Analyze
+Amazon SageMaker AI spend and determine cost optimization
+opportunities based on usage, Part 4: Training jobs](https://aws.amazon.com/blogs/machine-learning/part-4-analyze-amazon-sagemaker-spend-and-determine-cost-optimization-opportunities-based-on-usage-part-4-training-jobs/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp01.html*
+
+---
+
+# MLCOST06-BP02 Monitor return on investment for ML models
+
+Once a model is deployed into production, establish a reporting
+capability to track the value which is being delivered. For example:
+
+- **If a model is used to support customer
+acquisition:** How many new customers are acquired and what
+is their spend when the model's advice is used compared with a
+baseline?
+- **If a model is used to predict
+when maintenance is needed:** What savings are being made
+by optimizing the maintenance cycle?
+
+Effective reporting compares the value delivered by an ML model
+against the ongoing runtime cost and to take appropriate action. If
+the ROI is substantially positive, are there ways in which this
+might be scaled to similar challenges, for example. If the ROI is
+negative, could this be addressed by remedial action, such as
+reducing the model latency by using serverless inference, or
+reducing the run time cost by changing the compromise between model
+accuracy and model complexity, or layering in an additional simpler
+model to triage or filter the cases that are submitted to the full
+model.
+
+**Desired outcome:** By implementing
+this practice, you establish a clear line of sight between your ML
+investments and business outcomes. You can continuously track the
+value delivered by your ML models in terms of measurable business
+KPIs, enabling data-driven decisions about scaling successful
+models, optimizing underperforming ones, or sunsetting those with
+negative ROI. Your organization has transparency into the
+cost-effectiveness of ML initiatives and can strategically allocate
+resources based on proven business value.
+
+**Common anti-patterns:**
+
+- Deploying ML models without defining success metrics or business
+KPIs.
+- Focusing only on technical metrics like accuracy without linking
+to business outcomes.
+- Measuring ROI only once after initial deployment rather than
+continuously.
+- Failing to account for the full costs of ML model operation in
+ROI calculations.
+- Ignoring opportunities to scale successful models to similar
+business challenges.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear visibility into the business value generated by ML
+investments.
+- Ability to make data-driven decisions about model optimization
+or retirement.
+- Improved accountability for ML investments across the
+organization.
+- Better allocation of ML resources to high-impact use cases.
+- Enhanced stakeholder confidence in ML initiatives through
+transparent reporting.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Monitoring the return on investment for your ML models requires an
+intentional approach that connects technical model performance
+with tangible business outcomes. You need to establish a
+continuous feedback loop between model operations and business
+metrics to understand the true value being generated. This means
+going beyond traditional ML metrics like accuracy or precision and
+focusing on how the model's predictions translate into business
+results.
+
+Start by defining clear business KPIs that your model is expected
+to influence before deployment. These KPIs should be measurable
+and directly tied to business objectives, such as increased
+revenue, reduced costs, or improved customer satisfaction. For
+customer acquisition models, track metrics like conversion rates,
+customer lifetime value, and acquisition costs. For predictive
+maintenance models, measure metrics like maintenance cost savings,
+reduced downtime, and extended equipment lifespan.
+
+Once deployed, collect data on both the model's performance and
+these business metrics to establish correlation between the two.
+Use A/B testing where possible to compare outcomes with and
+without the model's influence. This can isolate the specific
+impact of your ML investment against other factors that might
+affect business outcomes.
+
+Regularly review the ROI of your models and be prepared to take
+action based on the findings. For models with strong positive ROI,
+explore opportunities to scale the approach to similar business
+problems or increase the scope of the current implementation. For
+models with marginal or negative ROI, consider optimization
+strategies like reducing inference costs through more efficient
+infrastructure, simplifying model complexity while maintaining
+acceptable accuracy, or implementing a multi-tiered approach where
+simpler models handle routine cases and complex models only
+process edge cases.
+
+### Implementation steps
+
+- **Define business-oriented success
+metrics.** Before deploying your ML model, clearly
+define the business KPIs that will be used to measure its
+impact. Work with business stakeholders to connect these
+metrics directly to business outcomes and measure them
+practically. For example, for a customer churn prediction
+model, success metrics might include reduction in churn
+rate, increase in retention-driven revenue, and decreased
+cost of retention campaigns.
+- **Establish baseline
+performance.** Measure and document the current
+performance on your defined KPIs before implementing the ML
+model. This baseline is essential for determining the
+incremental value the model delivers. Consider using A/B
+testing approaches where feasible, sending some cases
+through the ML-driven process and others through the
+traditional approach.
+- **Implement data collection
+pipelines.** Set up automated data collection for
+both model metrics and business outcomes. Use AWS services
+like
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor technical aspects of your model
+and
+[Amazon Kinesis](https://aws.amazon.com/kinesis/) to capture business event data. Store this
+data in [Amazon S3](https://aws.amazon.com/s3/) or
+[Amazon Redshift](https://aws.amazon.com/redshift/) for further analysis.
+- **Create ROI dashboards using Quick.** Develop business-focused dashboards
+in
+[Quick](https://aws.amazon.com/quicksight/) that visualize the relationship between
+model performance and business outcomes. Include metrics
+that show both the value generated (increased revenue, cost
+savings) and costs incurred (infrastructure, maintenance,
+human review). Use QuickSight's ML Insights to automatically
+identify trends and anomalies in your ROI data.
+- **Schedule regular ROI
+reviews.** Establish a cadence for reviewing model
+ROI with both technical and business stakeholders. These
+reviews should assess whether the model continues to deliver
+positive business impact and identify opportunities for
+optimization. Use these sessions to make data-driven
+decisions about continuing investment, scaling successful
+approaches, or adjusting underperforming models.
+- **Optimize underperforming
+models.** For models not meeting ROI targets,
+implement strategic improvements. Consider
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) Serverless Inference to reduce costs for
+infrequent or variable workloads. Explore model compression
+techniques like
+[SageMaker AI
+Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to improve inference efficiency without
+sacrificing accuracy. Implement tiered prediction approaches
+where simple, low-cost models filter cases before routing to
+more complex models.
+- **Scale successful models.**
+When models demonstrate strong positive ROI, look for
+opportunities to expand their impact. Apply similar modeling
+approaches to related business problems, increase the scope
+of existing models, or integrate the model with additional
+business processes to maximize value creation.
+- **Use enhanced QuickSight capabilities
+for ROI analysis**. Use improved
+[Quick](https://aws.amazon.com/quicksight/) with generative AI insights and natural
+language query capabilities to automatically identify
+trends, anomalies, and optimization opportunities in your
+ROI data.
+- **Use generative AI for enhanced
+insights.** Use generative AI capabilities through
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to analyze patterns in your ROI data and
+suggest optimization strategies. Generative AI can identify
+non-obvious correlations between model configurations and
+business outcomes, leading to better ROI optimization
+decisions.
+
+## Resources
+
+**Related documents:**
+
+- [What
+is Quick?](https://docs.aws.amazon.com/quicksight/latest/user/welcome.html)
+- [Publish
+custom metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [What
+are AWS Cost and Usage Reports?](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html)
+- [Quick](https://aws.amazon.com/quicksight/)
+- [Cost
+Optimization Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
+- [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp02.html*
+
+---
+
+# MLCOST06-BP03 Monitor endpoint usage and right-size the instance fleet
+
+Use efficient compute resources to run models in production. Monitor
+your endpoint usage and right-size the instance fleet. Use automatic
+scaling (auto scaling) for your hosted models. *Auto
+scaling* dynamically adjusts the number of instances
+provisioned for a model in response to changes in your workload.
+
+**Desired outcome:** You have
+optimized SageMaker AI endpoints that automatically adjust to workload
+demands while maintaining performance and minimizing costs. Your
+model deployment uses appropriately sized instances that are neither
+over-provisioned nor under-provisioned, and you have continuous
+monitoring in place to inform scaling decisions.
+
+**Common anti-patterns:**
+
+- Provisioning static endpoint configurations that remain
+unchanged regardless of workload fluctuations.
+- Over-provisioning instances "just to be safe"
+without analyzing actual resource utilization.
+- Ignoring endpoint metrics and failing to adjust resource
+allocation based on usage patterns.
+- Deploying resources across different Availability Zones without
+consideration for data transfer costs.
+- Using default instance types without evaluating performance
+requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced compute costs by reducing over-provisioned resources.
+- Improved performance during peak usage periods through automatic
+scaling.
+- Higher resource utilization through right-sizing.
+- Increased availability by distributing instances across
+Availability Zones.
+- Better understanding of model usage patterns to inform future
+optimizations.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Monitoring and optimizing your SageMaker AI endpoints is essential
+for maintaining cost-efficiency while providing high availability
+and performance. By implementing CloudWatch monitoring and auto
+scaling, your deployments use only the resources they needs when
+they need them. Start by establishing baseline metrics for your
+endpoints to understand typical usage patterns and resource
+requirements. Then implement auto scaling policies based on these
+metrics to automatically adjust capacity in response to changing
+workloads.
+
+For production environments, distribute your endpoint deployment
+across multiple Availability Zones to maintain high availability.
+Consider the placement of related resources, such as data storage
+solutions like FSx for Lustre, to minimize cross-AZ data transfer
+costs and optimize performance. Regular review of your metrics and
+scaling configurations assists you to continuously refine your
+deployment for optimal cost and performance.
+
+### Implementation steps
+
+- **Monitor Amazon SageMaker AI endpoints
+with Amazon CloudWatch**. You can monitor Amazon SageMaker AI using
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), which collects raw data and processes it
+into readable, near real-time metrics. Use metrics such as
+CPUUtilization, GPUUtilization, MemoryUtilization, and
+DiskUtilization to view your endpoint's resource utilization
+and make informed decisions about right-sizing your endpoint
+instances. Set up CloudWatch dashboards to visualize these
+metrics over time and identify patterns in resource usage.
+- **Implement CloudWatch alarms for
+proactive monitoring**. Configure alarms for key
+metrics that can indicate when an endpoint is
+under-provisioned or over-provisioned. For example, set up
+alarms that go off when CPU utilization consistently exceeds
+80% (indicating potential under-provisioning) or remains
+below 20% (indicating over-provisioning). These alarms can
+notify your team to take action or run automated responses
+through AWS Lambda functions.
+- **Configure auto scaling for SageMaker AI
+endpoints**.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) supports auto scaling that monitors your
+workloads and dynamically adjusts capacity to maintain
+steady performance at the lowest possible cost. When
+workload increases, auto scaling brings more instances
+online. When workload decreases, auto scaling removes
+unnecessary instances, which can reduce compute costs.
+Define appropriate scaling policies based on your
+application's requirements, including minimum and maximum
+instance counts, target metrics, and scale-in and scale-out
+cooldown periods.
+- **Distribute instances across
+Availability Zones**. SageMaker AI automatically
+attempts to distribute your instances across Availability
+Zones, so deploy multiple instances for each production
+endpoint to provide high availability. If you're using a
+VPC, configure at least two subnets in different
+Availability Zones to allow SageMaker AI to distribute your
+instances across those zones, providing resilience against
+zone failures.
+- **Optimize resource placement for data
+access**. When using
+[Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) as an input data source for SageMaker AI,
+deploy FSx for Lustre and SageMaker AI in the same Availability
+Zone to avoid cross-AZ data transfer costs. This
+configuration removes the initial Amazon S3 download step,
+accelerating ML training jobs while minimizing costs.
+Consider similar placement strategies for other related
+resources to optimize performance and cost.
+- **Regularly review and adjust instance
+types**. Periodically evaluate whether your
+selected instance types are appropriate for your workload.
+SageMaker AI offers a variety of
+[instance
+types](https://aws.amazon.com/sagemaker/pricing/) optimized for different workload
+characteristics. Analyze your CloudWatch metrics to
+determine if you could achieve better price-performance by
+switching to a different instance family, such as
+compute-optimized, memory-optimized, or GPU instances.
+- **Use inference optimization
+techniques**. Implement model optimization
+techniques such as
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize models for
+your target hardware, improving performance and potentially
+allowing you to use smaller instance types. Consider
+techniques like model compression, quantization, and
+batching to improve inference efficiency and throughput.
+- **Use enhanced SageMaker AI Inference
+Recommender**. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) with enhanced algorithms and
+support for multi-model endpoints to get sophisticated
+instance selection and cost optimization recommendations.
+- **Implement specialized instance types
+for generative AI models**. For large language
+models and other generative AI workloads, use specialized
+instances like
+[AWS Inferentia](https://aws.amazon.com/machine-learning/inferentia/) or
+[AWS Trainium](https://aws.amazon.com/machine-learning/trainium/), which are designed specifically for machine
+learning inference and training. These instances can provide
+significant cost savings compared to general-purpose GPU
+instances when running transformer-based models. Consider
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) for fully managed generative AI capabilities
+with built-in scaling.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI metrics in Amazon CloudWatch](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html)
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [AWS Inferentia](https://aws.amazon.com/machine-learning/inferentia/)
+- [Best
+practices for deploying models on SageMaker AI Hosting
+Services](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp03.html*
+
+---
+
+# MLCOST06-BP04 Enable debugging and logging
+
+Implementing comprehensive logging and debugging capabilities for
+your machine learning workflows assists you to understand resource
+consumption patterns and identify optimization opportunities. By
+collecting and analyzing runtime metrics, you can reduce costs and
+enhance the efficiency of your ML training operations.
+
+**Desired outcome:** You gain
+visibility into training jobs through metrics and logs that reveal
+resource consumption patterns. This practice identifies optimization
+opportunities, reduces costs, and improves ML model training
+performance. You implement monitoring systems to track compute and
+storage utilization, and instrument code to record key metrics.
+
+**Common anti-patterns:**
+
+- Training ML models without performance visibility.
+- Ignoring resource consumption data until costs become
+problematic.
+- Deploying ML solutions without adequate logging infrastructure.
+- Using manual methods to track performance metrics.
+- Waiting for issues to arise before implementing monitoring.
+
+**Benefits of establishing this best
+practice:**
+
+- Early identification of model training inefficiencies.
+- Reduced compute and storage costs through resource optimization.
+- Faster troubleshooting of training job issues.
+- Enhanced visibility into ML pipelines.
+- Data-driven decisions for infrastructure provisioning.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Proper debugging and logging are crucial for cost management in
+machine learning workflows. As ML models grow in complexity, the
+computational resources required for training also increase. By
+implementing comprehensive monitoring, you can identify
+inefficiencies, optimize resource allocation, and reduce overall
+costs.
+
+Effective logging and debugging require instrumentation at
+multiple levels, from the ML code itself to the underlying
+infrastructure. This visibility provides an understanding of how
+resources are being utilized during training jobs and identifies
+bottlenecks so that you can make data-driven decisions about when
+and how to scale resources. The metrics and logs collected can
+reveal patterns of inefficient resource utilization that might
+otherwise go unnoticed.
+
+Additionally, monitoring storage consumption is important as data
+preparation and feature engineering can generate large
+intermediate datasets. By tracking both compute and storage
+metrics, you can identify opportunities for optimization across
+your entire ML pipeline.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI
+Debugger**.
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) captures training job states at
+regular intervals, providing visibility into the ML training
+process. It monitors, records, and analyzes data during
+training, enabling you to:
+
+Track model parameters, gradients, and tensor values
+- Identify training issues like vanishing gradients or
+tensor explosions
+- Receive automated alerts for common training problems
+- Visualize and analyze captured data interactively
+
+- **Implement CloudWatch
+logging**. Integrate
+[Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html) with your SageMaker AI training jobs to
+centralize and analyze log data. Configure CloudWatch to:
+
+Collect standard output and error logs from training
+jobs
+- Encrypt log data using an
+[AWS KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html) for security
+- Set up custom log groups and streams for different ML
+workflows
+- Create log retention policies to manage storage costs
+
+- **Instrument ML code for metrics
+collection**. Add instrumentation code to your ML
+training scripts to capture performance metrics and resource
+utilization data:
+
+Track timing information for different training phases
+- Monitor memory usage during training operations
+- Record batch processing statistics and convergence
+metrics
+- Log hyperparameter values and their impact on training
+performance
+
+- **Configure resource
+monitoring**. Set up monitoring for compute and
+storage resources used by your ML workflows:
+
+Use CloudWatch metrics to track instance utilization
+- Monitor data transfer volumes between storage and
+compute resources
+- Set up alerts for abnormal resource consumption patterns
+- Create dashboards to visualize resource utilization
+trends
+
+- **Implement automated
+alerting**. Configure notification systems to alert
+you when resource consumption exceeds expected thresholds:
+
+Set up CloudWatch alarms for high CPU, memory, or GPU
+utilization
+- Create alerts for extended training job durations
+- Configure notifications for storage capacity issues
+- Establish alerting for debugging rule violations in
+SageMaker AI Debugger
+
+- **Analyze and optimize training
+jobs**. Use the collected metrics and logs to
+identify optimization opportunities:
+
+Review resource utilization patterns to identify
+right-sizing opportunities
+- Analyze training job logs for inefficient code paths
+- Examine data loading and preprocessing bottlenecks
+- Optimize hyperparameters based on performance metrics
+
+- **Use enhanced debugging
+capabilities**. Use improved SageMaker AI Studio
+debugging and monitoring capabilities with better
+integration to popular ML frameworks and enhanced
+visualization tools for more efficient troubleshooting.
+- **Use generative AI for log
+analysis**. Use generative AI capabilities to
+analyze and extract insights from ML training logs. Utilize
+Q Diagnostics integrated into the console or your preferred
+IDE for log analysis.
+
+Implement natural language processing to summarize log
+patterns
+- Use Amazon Bedrock to build intelligent log analysis
+assistants
+- Deploy ML models that can predict resource needs based
+on historical data
+- Create automated reports of cost optimization
+opportunities from log data
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html)
+- [What
+is Amazon CloudWatch Logs?](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
+- [Analyzing
+log data with CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html)
+- [Logging
+and Monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-incident-response.html)
+- [Logging
+Amazon ML API Calls with AWS CloudTrail](https://docs.aws.amazon.com/machine-learning/latest/dg/logging-using-cloudtrail.html)
+- [Amazon SageMaker AI Debugger API](https://sagemaker.readthedocs.io/en/stable/api/training/debugger.html)
+
+**Related examples:**
+
+- [Debugger
+example notebooks](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-debugger))
+- [SageMaker AI
+Debugger GitHub Repository](https://github.com/awslabs/sagemaker-debugger)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlcost06-bp04.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLOPS01.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLOPS01.md
@@ -1,0 +1,466 @@
+# MLOPS01
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLOPS01-BP01 Develop the right skills with accountability and empowerment
+
+Artificial intelligence (AI) has many different and growing
+branches, such as machine learning, deep learning, and computer
+vision. Given the complexity and fast-growing nature of ML
+technologies, plan to hire specialists with the understanding that
+additional training will be needed as ML evolves. Keep teams
+learning new skills, engaged, and motivated while encouraging
+accountability and empowerment. Building ML models is a complex and
+iterative process that can infuse bias or unfair predictions against
+a certain entity. It's important to promote and enforce the ethical
+use of AI across enterprises. AWS provides clear guidance to
+customers for
+[responsible
+AI practices](https://aws.amazon.com/ai/responsible-ai/).
+
+**Desired outcome:** You establish a
+skilled, ethically responsible ML workforce that continuously
+evolves with technology advancements. You create an environment
+where your teams are empowered to innovate with AI/ML while
+maintaining accountability for fair and unbiased AI solutions. Your
+organization develops a strong foundation in ML concepts, end-to-end
+lifecycle processes, and efficient use of AWS ML infrastructure and
+tools, enabling you to maximize business value through ethical and
+responsible AI implementation.
+
+**Common anti-patterns:**
+
+- Hiring ML specialists without a continuous learning plan.
+- Focusing only on technical skills while ignoring ethical
+considerations.
+- Creating siloed ML teams without cross-functional collaboration.
+- Assuming ML models are inherently unbiased and fair.
+
+**Benefits of establishing this best
+practice:**
+
+- Increased innovation through skilled and empowered ML teams.
+- Reduced risk of biased or unfair AI predictions.
+- Improved ability to adapt to rapidly evolving ML technologies.
+- Greater business value through responsible and ethical AI
+implementation.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Building a successful ML workforce requires a comprehensive
+approach that includes both technical and ethical skill
+development. Organizations must invest in continuous learning
+across various ML domains while also establishing clear
+accountability frameworks for responsible AI. By developing these
+capabilities together, you can maximize the benefits of ML while
+minimizing potential risks.
+
+Creating an environment that fosters innovation while maintaining
+ethical standards is essential for sustainable ML success. This
+includes establishing clear guidelines for model development,
+testing for bias, and providing explainability of AI decisions.
+Cross-functional teams that combine technical expertise with
+domain knowledge and ethical considerations will deliver the most
+robust ML solutions.
+
+As ML technologies evolve rapidly, your organization must remain
+adaptable and committed to ongoing skill development. This
+includes staying current with AWS's latest ML services, tools, and
+best practices while also keeping pace with advances in
+responsible AI methodologies.
+
+### Implementation steps
+
+- **Develop comprehensive ML skills
+training programs**. Create structured learning
+paths for different roles within your ML teams. Provide
+training on fundamental ML concepts and algorithms,
+end-to-end ML lifecycle processes, and efficient use of ML
+infrastructure with
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/). Include training on AI-assisted
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) for code generation and productivity
+enhancement. Incorporate specialized training in areas
+aligned with your business needs, such as computer vision,
+natural language processing (NLP), and reinforcement
+learning. Utilize resources like
+[AWS Skill Builder](https://aws.amazon.com/training/learn-about/), and
+[Amazon Machine Learning University](https://www.amazon.science/tag/machine-learning-university-mlu)
+- **Establish cross-functional ML
+teams**. Form diverse teams with specialists from
+multiple disciplines including data science, engineering,
+ethics, legal, and domain experts. This multidisciplinary
+approach provides a holistic perspective on ML
+implementation and identifies potential issues early in the
+development process. Encourage collaboration across teams to
+share knowledge, best practices, and lessons learned from ML
+initiatives.
+- **Implement bias detection and
+fairness protocols**. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) to detect and mitigate bias in your
+datasets and model predictions. Establish guidelines for
+evaluating models for fairness across different demographic
+groups and protected attributes. Create checkpoints
+throughout the ML lifecycle to assess and address potential
+bias before models are deployed into production
+environments.
+- **Create an ML ethics
+framework**. Develop clear guidelines and
+principles for ethical AI use within your organization.
+Establish an AI Ethics Board comprising representatives from
+legal, ethics, IT, data science, and key business units.
+Their responsibility should include creating policies for
+responsible AI implementation, providing guidance on complex
+ethical questions, and improving adherence to relevant
+regulations and industry standards.
+- **Foster accountability through
+documentation and governance**. Implement
+comprehensive documentation processes for each aspect of the
+ML lifecycle, including data sources, model development
+decisions, testing procedures, and deployment criteria.
+Create clear ownership and accountability structures for ML
+projects, with designated responsibilities for model
+performance, fairness, and explainability. Use
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model details,
+intended uses, limitations, and ethical considerations.
+- **Empower continuous learning and
+experimentation**. Create opportunities for teams
+to expand their ML knowledge through immersion days,
+hackathons, certification programs, and participation in the
+broader ML community. Establish sandboxed environments using
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) for integrated data and AI
+workflows where teams can experiment with new ML techniques
+and tools without risk to production systems.
+- **Measure and improve ML
+operations**. Implement metrics to evaluate the
+effectiveness of your ML teams and processes, including
+model performance, development efficiency, and ethics.
+Regularly review these metrics to identify areas for
+improvement and adjust your approach accordingly. Establish
+feedback loops that incorporate insights from model
+performance in production to continuously refine both
+technical implementations and team capabilities.
+- **Implement responsible generative AI
+practices**. As you explore generative AI
+capabilities, establish clear guardrails for using large
+language models and other generative technologies. Use
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) to access foundation models through a single
+API with enterprise-grade security and compliance features.
+Implement content filtering, safety measures, and human
+review processes for generative AI outputs to align with
+your organization's values and ethical standards.
+
+## Resources
+
+**Related documents:**
+
+- [AWS ML Certification Paths](https://aws.amazon.com/certification/certified-machine-learning-specialty/)
+- [AWS Ramp-Up Guides for Machine Learning](https://aws.amazon.com/training/ramp-up-guides/)
+- [Create
+a model card](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards-create.html)
+- [Configure
+a SageMaker AI Clarify Processing Job](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-configure-parameters.html)
+- [Responsible
+use of Artificial Intelligence and Machine Learning](https://aws.amazon.com/ai/responsible-ai/)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [Building
+ML excellence: A practical training guide for Amazon SageMaker AI](https://aws.amazon.com/blogs/training-and-certification/building-ml-excellence-a-practical-training-guide-for-amazon-sagemaker-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops01-bp01.html*
+
+---
+
+# MLOPS01-BP02 Discuss and agree on the level of model explainability
+
+Establish clear expectations with business stakeholders about the
+level of model explainability needed for your machine learning use
+case. Explainability provides an understanding of how and why a
+model makes predictions, which builds trust, enables auditing, and
+supports adherence to regulatory requirements.
+
+**Desired outcome:** You establish
+explainability requirements early in your machine learning project
+lifecycle. You implement appropriate methods to provide the agreed
+level of model explainability, building stakeholder trust and
+improving your adherence to regulations. You use explainability
+metrics in your evaluations and tradeoff analyses, verifying that
+the model meets business needs while remaining interpretable.
+
+**Common anti-patterns:**
+
+- Treating explainability as an afterthought rather than a core
+requirement.
+- Choosing the most complex model without considering
+explainability requirements.
+- Failing to establish explainability metrics before model
+development.
+- Neglecting to communicate model decisions in terms
+understandable to business stakeholders.
+
+**Benefits of establishing this best
+practice:**
+
+- Increased stakeholder trust in model predictions.
+- Better ability to troubleshoot and improve models.
+- Enhanced ability to detect and address model biases.
+- Improved model adoption by users who understand how decisions
+are made.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When implementing machine learning models, you need to balance
+prediction accuracy with explainability. Highly complex models
+like deep neural networks might provide superior predictive
+performance but often function as an opaque system, making their
+decision-making processes difficult to interpret. In contrast,
+simpler models like decision trees offer greater transparency but
+may sacrifice some accuracy.
+
+The appropriate level of explainability depends on your specific
+use case. In regulated industries like healthcare, finance, or
+insurance, high explainability might be mandatory for
+compliance-aligned reasons. For applications where human safety or
+significant financial decisions are involved, understanding why a
+model made a specific prediction becomes critical.
+
+Work with your business stakeholders to understand their
+explainability requirements before selecting modeling approaches.
+Consider both technical and non-technical aspects of
+explainability - technical stakeholders may need detailed feature
+importance measures, while business users might need simple,
+intuitive explanations of model decisions.
+
+### Implementation steps
+
+- **Understand business requirements for
+explainability**. Meet with stakeholders to
+determine how much transparency is needed based on use case,
+industry regulations, and business objectives. In regulated
+industries like healthcare and finance, regulations often
+mandate that automated decisions be explainable to affected
+individuals.
+- **Evaluate model types based on
+explainability needs**. Consider inherently
+interpretable models (linear regression, decision trees) for
+high explainability requirements, or more complex models
+with following explanation techniques when higher accuracy
+is the priority.
+- **Set up SageMaker AI
+Clarify**. Implement Amazon SageMaker AI Clarify to
+create explainability reports and detect potential biases in
+your datasets or models. Clarify includes enhanced bias
+detection and new fairness metrics for more comprehensive
+explainability analysis. SageMaker AI Clarify integrates
+with SageMaker AI's model building, training, and deployment
+capabilities.
+- **Choose appropriate SHAP
+baselines**. Shapley Additive exPlanations (SHAP)
+values determine how each feature contributes to
+predictions. Configure appropriate baselines in SageMaker AI
+Clarify based on your data characteristics. You can choose
+baselines with "low information content" (for
+example, average values from the training dataset) or high
+information content (representing a specific class of
+interest).
+- **Generate and interpret feature
+attribution reports**. Use SageMaker AI Clarify to
+generate feature attribution reports showing which features
+most influenced model predictions and how they did so.
+Review these reports with stakeholders to verify that they
+provide the required level of understanding.
+- **Create user-friendly explanation
+interfaces**. Develop appropriate visualization
+tools or explanation interfaces that present model insights
+in ways that are meaningful to various stakeholders, from
+data scientists to business users.
+- **Implement continuous explainability
+monitoring**. Set up ongoing monitoring of model
+explanations to detect drift in feature importance or
+unexpected behavior patterns over time.
+- **Apply responsible AI principles to
+generative models**. For generative AI
+applications, implement additional explainability measures
+such as prompt transparency, citation of sources, and
+confidence scores to assist users in understanding how
+outputs were generated.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Configure
+a SageMaker AI Clarify Processing Job](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-configure-parameters.html)
+- [SHAP
+Baselines for Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-feature-attribute-shap-baselines.html)
+- [Explain
+text classification model predictions using Amazon SageMaker AI
+Clarify](https://aws.amazon.com/blogs/machine-learning/explain-text-classification-model-predictions-using-amazon-sagemaker-clarify/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops01-bp02.html*
+
+---
+
+# MLOPS01-BP03 Monitor model adherence to business requirements
+
+Machine learning models degrade over time due to changes in the real
+world, such as *data drift* and *concept
+drift*. If not monitored, these changes could lead to
+models becoming inaccurate or even obsolete over time. It's
+important to have a periodic monitoring process in place to make
+sure that your ML models continue to comply to your business
+requirements and that deviations are captured and acted upon
+promptly.
+
+**Desired outcome:** You implement a
+robust model monitoring framework that continuously evaluates model
+performance against your business requirements. This enables early
+detection of model drift, keeping your ML models accurate and
+effective over time. You establish clear metrics tied to business
+outcomes and have automated processes to respond to detected drifts,
+minimizing potential negative impacts.
+
+**Common anti-patterns:**
+
+- Implementing monitoring without clear metrics tied to business
+requirements.
+- Focusing only on technical metrics while ignoring business
+impact metrics.
+- Lacking a clear action plan for when drift is detected.
+- Monitoring models infrequently or irregularly.
+- Not establishing thresholds for acceptable levels of drift.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation.
+- Maintained alignment between model outputs and business goals.
+- Reduced risk of financial or operational impact from degraded
+models.
+- Increased stakeholder confidence in deployed ML systems.
+- Improved model lifecycle management.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model monitoring is a critical aspect of maintaining ML systems
+that continue to deliver business value over time. As real-world
+conditions evolve, your models can experience both data drift
+(changes in the distribution of input data) and concept drift
+(changes in the relationship between inputs and outputs). These
+drifts can significantly impact model accuracy and reliability.
+
+To effectively monitor model adherence to business requirements,
+establish a comprehensive monitoring strategy that bridges
+technical metrics with business outcomes. This involves defining
+clear thresholds for acceptable performance, implementing
+automated monitoring solutions, and creating response plans for
+different drift scenarios.
+
+Amazon SageMaker AI Model Monitor provides capabilities to
+automatically monitor models in production and detect deviations
+from the baseline. By using these capabilities, you can
+proactively address potential issues before they impact your
+business operations.
+
+### Implementation steps
+
+- **Define relevant metrics aligned with
+business objectives.** Begin by clearly
+establishing the metrics that are most relevant to your
+business outcomes. Include both technical metrics (like
+accuracy, precision, and recall) and business metrics (like
+revenue impact and customer satisfaction). Make sure these
+metrics directly relate to the business requirements the
+model is expected to fulfill.
+- **Establish baseline performance and
+thresholds.** Create a performance baseline using
+your validation dataset. Using Amazon SageMaker AI Model
+Monitor, you can automatically generate statistics and
+constraints from your baseline data that define normal
+behavior. Set appropriate thresholds that will alert when
+model performance deviates beyond acceptable limits.
+- **Implement automated data quality
+monitoring.** Configure SageMaker AI Model Monitor to
+regularly check the quality of input data against the
+baseline. This can detect data drift that could affect model
+performance. Monitor features for statistical changes in
+distributions, missing values, or other quality issues.
+- **Configure model quality
+monitoring.** Set up monitoring for model outputs
+and quality metrics. SageMaker AI Model Monitor can track
+prediction distributions and performance metrics over time,
+alerting you when they deviate from expected patterns.
+- **Set up bias drift
+detection.** Use SageMaker AI Clarify integration with
+Model Monitor to detect changes in bias metrics over time.
+This keeps your model fair and unbiased as production data
+evolves.
+- **Create visualization
+dashboards.** Implement dashboards using Amazon CloudWatch, Amazon Managed Grafana, or use
+[Quick with GenBI capabilities](https://aws.amazon.com/quicksight/generative-bi/) to automatically
+generate monitoring dashboards. These dashboards should
+present both technical and business metrics in an
+understandable format for stakeholders.
+- **Develop response protocols for drift
+detection.** Create clear action plans for
+different types and severities of detected drift. These
+might include automated retraining pipelines, manual
+reviews, or temporary fallback strategies depending on the
+scenario.
+- **Implement alert
+mechanisms.** Configure alerts using Amazon CloudWatch to notify appropriate team members when metrics
+exceed thresholds. Check that your alerts provide actionable
+information about the nature and potential impact of the
+drift.
+- **Establish regular review
+processes.** Schedule periodic reviews of
+monitoring results even when no alerts go off. This can
+identify gradual drifts that might not immediately alert but
+could impact performance over time.
+- **Document monitoring systems and
+processes.** Maintain comprehensive documentation
+of your monitoring setup, including metrics definitions,
+thresholds, alert configurations, and response protocols to
+preserve organizational knowledge.
+- **Leverage generative AI for root
+cause analysis.** Use generative AI capabilities to
+analyze complex patterns in your monitoring data and provide
+human-readable explanations of potential drift causes. Tools
+like
+[Amazon
+Bedrock Knowledge Bases](https://aws.amazon.com/bedrock/knowledge-bases/) can interpret changes in
+model behavior and suggest remediation approaches.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Schema
+for Violations (constraint_violations.json file)](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-interpreting-violations.html)
+- [Amazon SageMaker AI metrics in Amazon CloudWatch](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html)
+- [What
+is Amazon CloudWatch?](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html)
+- [Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/)
+- [Amazon SageMaker AI ML Governance](https://aws.amazon.com/sagemaker/ml-governance/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops01-bp03.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLOPS02.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLOPS02.md
@@ -1,0 +1,1118 @@
+# MLOPS02
+
+**Pillar**: Unknown  
+**Best Practices**: 6
+
+---
+
+# MLOPS02-BP01 Establish ML roles and responsibilities
+
+Clearly defining roles, responsibilities, and team interactions in
+machine learning projects creates an efficient operational framework
+that maximizes overall effectiveness. By understanding who does what
+and how teams collaborate, organizations can streamline their ML
+initiatives and deliver better business outcomes.
+
+**Desired outcome:** You establish
+well-defined roles and responsibilities across your ML teams,
+enabling proper collaboration and accountability. You have
+mechanisms to efficiently manage access controls for various ML
+functions, providing your team members access to the tools and
+resources they need while maintaining appropriate security
+boundaries. This creates a foundation for successful ML operations
+that supports both innovation and governance.
+
+**Common anti-patterns:**
+
+- Undefined or overlapping responsibilities causing confusion
+among team members.
+- Relying on a single person to perform ML-related tasks rather
+than building specialized expertise.
+- Over-privileged access controls that compromise security.
+- Manual, one-time processes for managing user permissions that
+don't scale.
+- Siloed teams with poor communication channels between technical
+and business stakeholders.
+
+**Benefits of establishing this best
+practice:**
+
+- Clear accountability and ownership throughout the ML lifecycle.
+- Improved collaboration between technical and business teams.
+- Streamlined decision-making processes and faster project
+initiation.
+- Better governance and risk management through proper access
+controls.
+- Enhanced ability to scale ML operations across the organization.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing clear ML roles and responsibilities requires
+thoughtful planning about how teams will work together throughout
+the entire ML lifecycle. Machine learning projects span multiple
+domains including business expertise, data engineering, model
+development, and operations, each requiring specialized skills.
+Without clearly defined roles, projects often face delays, quality
+issues, or governance challenges.
+
+Begin by identifying which functions are critical for your
+organization's ML initiatives. Consider your business objectives,
+technical requirements, and regulatory constraints. Develop a team
+structure that balances specialization with collaboration,
+allowing for efficient workflows while maintaining appropriate
+separation of duties for governance purposes.
+
+For enterprise-grade ML solutions, establish cross-functional
+teams with clear responsibilities for each role. Consider how
+these roles interact throughout the ML lifecycle and create
+communication channels to facilitate collaboration. Pay special
+attention to governance responsibilities, as these are often
+overlooked in early ML initiatives but become critical as projects
+move into production.
+
+### Implementation steps
+
+- **Map ML functions to organizational
+needs**. Begin by identifying the ML capabilities
+required to support your business objectives. Consider the
+entire ML lifecycle from problem definition through to
+production monitoring. Review your current organizational
+structure and identify gaps in skills or functions that need
+to be addressed. Create a matrix showing the relationship
+between ML functions and existing teams or roles.
+- **Establish cross-functional teams
+with defined roles**. Create a formal structure for
+your ML organization with clear roles and responsibilities
+for each team member. Gather representation from both
+technical and business domains to maintain alignment with
+business outcomes. The following roles should be considered:
+
+**Domain expert:**
+Provides functional knowledge about the business problem
+and validates ML approaches against real-world
+requirements.
+- **Data engineer:**
+Transforms raw data into formats suitable for analysis
+and model training.
+- **Data scientist:**
+Applies statistical modeling and machine learning
+techniques to derive insights from data.
+- **ML engineer:** Converts
+data science prototypes into production-ready software
+systems.
+- **MLOps engineer:**
+Builds automation pipelines for model training, testing,
+and deployment.
+- **IT auditor:** Analyzes
+system access, identifies anomalies, and recommends
+remediations.
+- **Model risk manager:**
+Checks that models meet internal and external control
+requirements.
+- **Cloud security
+engineer:** Configures and manages cloud
+resources with appropriate security controls.
+- **Prompt engineer:**
+Designs effective interactions with foundation models
+for generative AI applications.
+
+- **Implement role-based access
+control**. Design a permissions framework that
+follows the principle of least privilege while enabling
+teams to be productive. Avoid one-time methods for managing
+access policies that don't scale. Instead, use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to efficiently control
+access based on pre-defined templates aligned with your
+organizational roles. This allows administrators to quickly
+create appropriate access policies within minutes, reducing
+the time and effort required to onboard users and manage
+permissions over time.
+- **Establish governance
+processes**. Create clear processes for model
+lifecycle management, including approval workflows,
+validation requirements, and regulatory checks. Document who
+is responsible for key decisions at each stage of
+development. Implement model monitoring mechanisms to track
+performance and alert when intervention is needed. Use
+[Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) to maintain visibility
+across your model inventory and track performance metrics.
+- **Develop collaboration
+frameworks**. Establish standard communication
+channels and collaboration tools to facilitate interaction
+between different roles. Create documentation templates that
+promote knowledge sharing and make handoffs between teams
+more efficient. Schedule regular cross-functional reviews to
+gain alignment throughout the ML lifecycle. Consider using
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) as a collaborative
+environment that unifies data and AI workflows where data
+scientists and engineers can work together.
+- **Train teams on responsibilities and
+interfaces**. Provide training to verify that your
+team members understand not only their own responsibilities
+but also how their work impacts others in the ML lifecycle.
+Create reference materials that clarify handoff points and
+dependencies between different roles. Consider establishing
+a center of excellence or community of practice to share
+knowledge and best practices across teams.
+- **Adapt roles for generative AI
+initiatives**. When implementing generative AI
+projects, consider how traditional ML roles need to adapt.
+Prompt engineers may be needed to design effective
+interactions with foundation models. Ethical AI specialists
+can address concerns around bias, transparency, and
+responsible use. Integration engineers may be required to
+connect foundation models from services like
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) with enterprise applications and data
+sources.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Personas
+for an ML platform](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/personas-for-an-ml-platform.html)
+- [ML
+Learning Paths](https://aws.amazon.com/training/learning-paths/machine-learning/)
+- [Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html)
+- [Why
+should you use MLOps?](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects-why.html)
+- [Amazon SageMaker AI ML Governance](https://aws.amazon.com/sagemaker/ml-governance/)
+- [Define
+customized permissions in minutes with Amazon SageMaker AI
+Role Manager](https://aws.amazon.com/blogs/machine-learning/define-customized-permissions-in-minutes-with-amazon-sagemaker-role-manager/)
+- [New
+ML Governance Tools for Amazon SageMaker AI – Simplify Access
+Control and Enhance Transparency Over Your ML Projects](https://aws.amazon.com/blogs/aws/new-ml-governance-tools-for-amazon-sagemaker-simplify-access-control-and-enhance-transparency-over-your-ml-projects/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp01.html*
+
+---
+
+# MLOPS02-BP02 Prepare an ML profile template
+
+Creating an ML profile template allows you to systematically capture
+machine learning workload characteristics across different lifecycle
+phases. Use this template to evaluate your ML workload's current
+maturity status and strategically plan for improvements that align
+with your business requirements.
+
+**Desired outcome:** You gain a
+comprehensive understanding of your ML workload's deployment
+characteristics by creating templated profiles that capture critical
+metrics and thresholds. By maintaining current and target profiles,
+you can effectively track your ML workload maturity journey and make
+data-driven decisions about architecture, resources, and deployment
+options that best align with your business needs.
+
+**Common anti-patterns:**
+
+- Creating ML profiles without clear thresholds or maturity
+rankings.
+- Failing to document rationale for architectural and deployment
+choices.
+- Focusing on technical metrics without connecting to business
+requirements.
+- Not considering future state or alternative deployment options.
+- Ignoring cost implications of different deployment scenarios.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables objective assessment of ML workload maturity status.
+- Provides a structured approach to planning ML workload
+improvements.
+- Creates alignment between technical implementation and business
+requirements.
+- Facilitates better resource planning and cost optimization.
+- Supports strategic decision-making with documented rationale.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning workloads have unique characteristics that impact
+their deployment architecture, infrastructure requirements, and
+operational management. Create a standardized ML profile template
+to document these characteristics systematically across the stages
+of the ML lifecycle. By capturing key metrics and establishing
+thresholds, you can objectively assess the maturity level of your
+ML workloads and identify areas for improvement.
+
+For each ML workload, you should maintain at least two profiles:
+one representing the current state and another representing the
+target or future state. This approach creates a clear path for
+improvement while documenting the rationale behind architectural
+and deployment decisions.
+
+When developing your ML profile template, focus on the most
+impactful characteristics that influence infrastructure choices,
+deployment options, and operational considerations. Include
+metrics that span model characteristics, architectural decisions,
+and operational requirements. For each characteristic, establish a
+spectrum from lower to higher ranges to position your workload on
+a maturity scale.
+
+### Implementation steps
+
+- **Capture ML workload deployment
+characteristics**. Identify and document the most
+impactful deployment characteristics of your ML workload.
+These characteristics can determine optimal deployment
+architecture, computing requirements, and instance sizing.
+Use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html), which includes more
+sophisticated instance selection algorithms and support for
+multi-model endpoints, to optimize instance selection based
+on your model's performance and cost requirements.
+- **Document model deployment
+characteristics**. Record key metrics about your ML
+models, including:
+
+Model size (model.tar.gz) in bytes
+- Number of models deployed per endpoint
+- Instance size (for example,
+r5dn.4x.large) as suggested by the
+inference recommender
+- Retraining and model endpoint update frequency (hourly,
+daily, weekly, monthly, or per-event)
+- Model deployment location (on premises, Amazon EC2,
+container, serverless, or edge)
+
+- **Map architectural deployment
+characteristics**. Capture information about the
+internal architecture of your ML solution:
+
+Inference pipeline architecture (single endpoint or
+chained endpoints)
+- Neural architecture (single framework like Scikit-learn
+or multi-framework like PyTorch, Scikit-learn,
+TensorFlow)
+- Containers (SageMaker AI prebuilt container, bring your
+own container)
+- Location of containers and models (on premises, cloud,
+or hybrid)
+- Serverless inferencing (pay as you go) options like
+Amazon SageMaker AI Serverless Inference
+- [Inference
+Components](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html) for modular inference pipeline
+architecture (mix and match pre-processing, model
+serving, and post-processing components)
+
+- **Define traffic pattern
+characteristics**. Document how your ML model will
+be used:
+
+Traffic pattern (steady or spiky)
+- Input size (number of bytes)
+- Latency requirements (low, medium, high, or batch)
+- Concurrency needs (single thread or multi-thread)
+
+- **Determine cold start
+tolerance**. Document the acceptable latency for
+cold starts in milliseconds, as this impacts the choice
+between always-on and serverless deployment options.
+- **Evaluate network deployment
+characteristics**. Assess and document
+network-related requirements, including AWS KMS encryption
+needs, multi-variant endpoints, network isolation
+requirements, and use of third-party Docker repositories.
+- **Analyze cost
+considerations**. Document cost considerations for
+different deployment options, including the potential use of
+Amazon EC2 Spot Instances for non-critical workloads, Amazon SageMaker AI Serverless Inference for pay-per-use models, or
+multi-model endpoints for cost sharing.
+- **Create a provisioning
+matrix**. Develop a matrix of expected capacity
+requirements across different environments (development,
+staging, production) and regions. This should include the
+number and types of instances needed for training, batch
+inference, real-time inference, and development notebooks.
+- **Map workload characteristics across
+maturity spectrum**. For each characteristic in
+your profile, establish a spectrum from lower to higher
+maturity. This spectrum positions your current
+implementation and defines targets for improvement.
+- **Document rationale for target
+profile**. Provide clear justification for the
+values selected in your target profile, linking them to
+specific business requirements and expected outcomes.
+- **Evaluate and update profiles
+regularly**. Revisit your ML profiles periodically
+to check that they remain aligned with evolving business
+requirements and to incorporate learnings from production
+experience.
+- **Foundation model deployment
+considerations**. For generative AI workloads,
+include additional profile characteristics such as model
+quantization level, context window requirements, token
+processing speed, and memory footprint using
+[optimized
+foundation model containers](https://docs.aws.amazon.com/sagemaker/latest/dg/large-model-inference.html) to properly size
+infrastructure for these resource-intensive models.
+
+## Resources
+
+**Related documents:**
+
+- [SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [AWS Pricing Calculator - SageMaker AI](https://calculator.aws/#/addService/SageMaker AI)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Amazon EC2 Instance Types](https://aws.amazon.com/ec2/instance-types/)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [Improved
+ML model deployment using Amazon SageMaker AI Inference
+Recommender](https://aws.amazon.com/blogs/machine-learning/improved-ml-model-deployment-using-amazon-sagemaker-inference-recommender/)
+- [Unlock
+cost savings with the new scale down to zero feature in
+SageMaker AI Inference](https://aws.amazon.com/blogs/machine-learning/unlock-cost-savings-with-the-new-scale-down-to-zero-feature-in-amazon-sagemaker-inference/)
+- [Beyond
+the basics: A comprehensive foundation model selection
+framework for generative AI](https://aws.amazon.com/blogs/machine-learning/beyond-the-basics-a-comprehensive-foundation-model-selection-framework-for-generative-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp02.html*
+
+---
+
+# MLOPS02-BP03 Establish model improvement strategies
+
+Planning improvement drivers for optimizing machine learning model
+performance is essential before development begins. By establishing
+a clear strategy for model enhancement, you can systematically
+improve your ML models through techniques like data collection,
+cross-validation, feature engineering, hyperparameter tuning, and
+ensemble methods.
+
+**Desired outcome:** By implementing
+this best practice, you establish a systematic approach for
+improving your machine learning models. You create a structured
+methodology for experimentation that allows you to progressively
+enhance model performance by testing different improvement
+strategies. You gain visibility into which approaches yield the best
+results for your specific use case, enabling you to make data-driven
+decisions about model development and optimization.
+
+**Common anti-patterns:**
+
+- Starting with overly complex models without establishing a
+baseline performance.
+- Ignoring data quality issues and focusing solely on model
+complexity.
+- Making arbitrary hyperparameter changes without systematic
+experimentation.
+- Neglecting to document experimental results and configurations.
+- Implementing advanced techniques without understanding
+fundamental model performance issues.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables structured experimentation and measurable model
+improvements.
+- Provides clarity on which improvement strategies deliver the
+best results.
+- Reduces time spent on ineffective optimization approaches.
+- Creates a systematic pathway from simple to more advanced
+modeling techniques.
+- Identifies the most important features and data for your
+specific business problem.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Effective model improvement requires a structured approach that
+follows a progression from simple to complex. Begin by
+establishing clear performance metrics tied to your business
+objectives, as these will guide your improvement efforts. Develop
+a baseline model using straightforward algorithms and minimal
+feature engineering to set initial performance benchmarks.
+
+Organizing your experiments systematically is crucial. Document
+your approach, model configurations, and results to track
+improvements and understand the impact of different strategies.
+This documentation serves as institutional knowledge that can
+guide future model development and improvement efforts.
+
+Work closely with domain experts who understand the business
+context. Their insights can identify key features, validate model
+outputs, and align your improvements with business objectives.
+Remember that model improvement is an iterative process requiring
+patience and methodical experimentation.
+
+### Implementation steps
+
+- **Create a baseline model with minimal
+complexity**. Start with minimal data cleaning and
+the most obvious data features. Train simple classical
+models using algorithms like linear regression or logistic
+regression for classification tasks. This establishes a
+performance benchmark against which you can measure
+improvements. Use
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to quickly develop these baseline models.
+- **Organize and track experiments using
+MLFlow on Amazon SageMaker AI**. Use
+[Amazon SageMaker AI MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to organize and track multiple
+tests comparing different configurations and algorithms.
+This allows you to maintain a structured approach to
+experimentation and compare results across different model
+versions so you can identify which changes lead to
+meaningful improvements.
+- **Implement effective feature
+selection**. Collaborate with subject matter
+experts to identify the most significant features related to
+target values. Iteratively add more complex features and
+remove less important ones to improve model accuracy and
+robustness. Test different feature engineering techniques
+such as one-hot encoding, normalization, and dimensionality
+reduction to understand their impact on model performance.
+- **Consider deep learning for complex
+patterns**. When you have large volumes of training
+data, consider deep learning models to discover previously
+unknown features and improve model accuracy.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides built-in algorithms for deep
+learning and supports popular frameworks like TensorFlow and
+PyTorch, making it simpler to experiment with neural network
+architectures.
+- **Explore ensemble methods**.
+Ensemble methods can provide further accuracy improvements
+by combining the best characteristics of various algorithms.
+Consider techniques like random forests, gradient boosting,
+or stacking different models. Be aware of the tradeoffs with
+computational performance and maintenance complexity,
+evaluating whether these approaches align with your specific
+business use case.
+- **Apply automatic machine learning
+(AutoML)**. Use
+[Amazon SageMaker AI Canvas](https://aws.amazon.com/sagemaker/canvas/) for no-code/low-code ML model
+development with natural language support for data
+exploration and preparation. Canvas includes
+[Amazon Q integration](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-q-integration.html) for conversational data analysis and
+can directly deploy models to production.
+- **Optimize hyperparameters
+systematically**. Fine-tune hyperparameters for
+each algorithm to obtain optimal performance. Use
+[Amazon SageMaker AI Hyperparameter Optimization](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-how-it-works.html) to automate
+this process through techniques like Bayesian optimization,
+grid search, or random search to find the most effective
+parameter combinations.
+- **Integrate experiments into automated
+workflows**.
+[Automate
+your experimental trials using SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-experiments.html) by
+using the integration with experiments. This fosters
+reproducibility and creates a systematic approach to model
+improvement that can be incorporated into your ML operations
+workflow.
+- **Use generative AI for synthetic data
+creation**. For scenarios with limited training
+data, use generative AI techniques like generative
+adversarial networks (GANs) to create synthetic data that
+can expand your training dataset.
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) provides an expanded library of
+pre-built generative AI models and more industry-specific
+solutions, while
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) offers foundation models that can augment
+your training data, especially for scenarios with limited or
+imbalanced datasets.
+- **For generative AI workloads, apply
+foundation models with RAG for knowledge-intensive
+tasks**. For tasks requiring domain knowledge,
+implement retrieval-augmented generation (RAG) using
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) to enhance foundation models with your
+organization's specific information, combining the power of
+large language models with your proprietary data.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Experiments in Studio Classic](https://docs.aws.amazon.com/sagemaker/latest/dg/experiments.html)
+- [Accelerate
+generative AI development using managed MLFlow on SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas.html)
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Amazon SageMaker AI Experiments Integration](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-experiments.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [LLM
+experimentation at scale using Amazon SageMaker AI Pipelines and
+MLFlow](https://aws.amazon.com/blogs/machine-learning/llm-experimentation-at-scale-using-amazon-sagemaker-pipelines-and-mlflow/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Experiments Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-experiments)
+- [Hyperparameter
+Tuning Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/hyperparameter_tuning)
+- [Ensemble
+Predictions from Multiple Models](https://sagemaker-examples.readthedocs.io/en/latest/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.html)
+- [Amazon SageMaker AI Autopilot Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/autopilot)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp03.html*
+
+---
+
+# MLOPS02-BP04 Establish a lineage tracker system
+
+Maintain a system that tracks changes for each release to enable
+reproducibility, speed up problem diagnosis, and improve regulatory
+adherence. Tracking lineage for model development includes changes
+in documentation, environment, model, data, code, and
+infrastructure.
+
+**Desired outcome:** You have a
+comprehensive lineage tracking system that records the history of
+artifacts involved in your ML model development and deployment
+lifecycle. This system enables you to reproduce previous model
+versions, diagnose issues quickly, roll back to stable versions when
+needed, and improve your regulatory adherence. Your organization can
+trace model results back to their originating data sources, code
+versions, and infrastructure configurations.
+
+**Common anti-patterns:**
+
+- Manually tracking changes in spreadsheets or documents.
+- Not capturing all dependent artifacts necessary for model
+reproduction.
+- Inconsistent tracking practices across teams.
+- Lacking integration between different components of the ML
+pipeline.
+- Failing to track infrastructure and environment configurations.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables reproducibility of model versions for debugging.
+- Accelerates problem diagnosis and resolution when issues arise.
+- Supports regulatory adherence and audit requirements.
+- Facilitates rollback to previous stable versions when needed.
+- Improves collaboration among team members with transparent
+tracking.
+- Enhances model governance and responsible AI practices.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Implementing a comprehensive lineage tracker system is essential
+for maintaining the traceability and reproducibility of your
+machine learning models. Without proper lineage tracking, your
+organization may struggle to debug issues, comply with
+regulations, or reproduce previous model versions when needed. The
+lineage tracker should capture information about components that
+influence your model's behavior, including the data used for
+training, preprocessing steps, hyperparameters, model
+architecture, evaluation metrics, and deployment environment.
+
+A robust lineage tracking system starts with identifying the key
+artifacts that need to be tracked throughout the ML lifecycle.
+Once identified, you can use AWS services like SageMaker AI ML
+Lineage Tracking to automatically record and store the
+relationships between these artifacts. This information becomes
+invaluable when you need to audit your models, reproduce results,
+or diagnose issues in production.
+
+For example, if a model suddenly begins producing unexpected
+results in production, your lineage tracking system should allow
+you to trace back to the exact version of the model, the data it
+was trained on, the code used to train it, and the infrastructure
+configuration at the time of deployment. This comprehensive
+tracking enables faster problem resolution and maintains trust in
+your ML systems.
+
+### Implementation steps
+
+- **Identify artifacts needed for
+tracking**. Begin by identifying artifacts that
+contribute to your model's development and deployment. This
+includes raw data, processed data, feature sets, model
+parameters, code versions, training environments, and
+deployment configurations. Understanding what needs to be
+tracked is essential for meeting regulatory requirements and
+enabling reproducibility. Refer to
+[Data
+and artifacts lineage tracking](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/data-and-artifacts-lineage-tracking.html) for guidance on the
+artifacts to include.
+- **Implement SageMaker AI ML Lineage
+Tracking**. Use
+[Amazon SageMaker AI ML Lineage Tracking](https://docs.aws.amazon.com/sagemaker/latest/dg/lineage-tracking-entities.html) to automatically record
+information about the steps in your ML workflow. SageMaker AI
+tracks relationships between datasets, algorithms, training
+jobs, and model artifacts, enabling you to reproduce
+workflows, track model and dataset lineage, and establish
+governance standards. The service creates entities for your
+ML workflow components and stores their relationships,
+making it more straightforward to audit and verify model
+provenance.
+- **Set up SageMaker AI Unified
+Studio**. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) as your integrated
+development environment that unifies data and AI workflows.
+SageMaker AI Unified Studio provides enhanced collaborative
+features, team sharing capabilities, and visual tools to
+track the lineage of your ML pipelines, making it more
+straightforward to understand the relationships between
+different components across data and AI personas.
+- **Configure SageMaker AI Feature
+Store**. Implement
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to create a centralized
+repository for storing, sharing, and managing features with
+enhanced feature management capabilities. This purpose-built
+repository enables you to organize features in a consistent
+way, making them easily accessible across teams. SageMaker AI
+Feature Store fosters feature consistency between training
+and inference phases without requiring additional code, and
+maintains a record of feature versions over time.
+- **Use SageMaker AI Model
+Registry**. Implement
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog models for
+production, manage model versions, and associate metadata
+with models. The Model Registry enables lineage tracking by
+maintaining a history of model versions, approval status,
+and deployment details. This creates a centralized
+repository for managing model lifecycles, which facilitates
+governance and improves adherence to regulations.
+- **Build ML pipelines with SageMaker AI
+Pipelines**. Create reproducible ML workflows using
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to automate and standardize the
+steps in your ML process. SageMaker AI Pipelines allows you to
+track data history within the pipeline and integrates with
+SageMaker AI ML Lineage Tracking to analyze input data, its
+sources, and generated outputs. This integration creates
+comprehensive lineage tracking across your entire ML
+workflow.
+- **Implement version control
+practices**. Use version control systems like Git
+for code, model configurations, and pipeline definitions.
+Integrate these systems with your lineage tracking to
+properly link code changes to model versions and training
+runs. This practice maintains a complete history of how your
+models have evolved over time.
+- **Establish model attributes for
+training runs**. Use model attributes in SageMaker AI
+to track specific details about your training runs. This
+allows you to compare different experiments, understand
+which parameters led to better model performance, and
+maintain records of training decisions. For more detail, see
+[Using
+model attributes to track your training runs on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/amazon-sagemaker-now-comes-with-new-capabilities-for-accelerating-machine-learning-experimentation/).
+- **Implement access controls and
+auditing**. Set up appropriate access controls for
+your lineage data and implement auditing capabilities to
+track who accesses or modifies lineage information. Use
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) with SageMaker AI Studio to control and
+audit data exploration activities, as demonstrated in this
+[example](https://github.com/aws-samples/amazon-sagemaker-studio-audit).
+- **Develop regular verification
+processes**. Establish procedures to regularly
+verify that your lineage tracking system is capturing
+necessary information for compliance-aligned purposes.
+Create automated reports that demonstrate the completeness
+of your lineage tracking to adhere to regulatory
+requirements.
+- **Foundation model lineage
+tracking**. Consider implementing
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) for tracking lineage in generative AI
+applications. With foundation models becoming increasingly
+important, tracking prompt engineering changes, model
+parameters, and fine-tuning datasets is critical for
+reproducibility and governance of generative AI systems. Use
+Amazon Bedrock's governance features to maintain
+comprehensive lineage tracking when working with foundation
+models.
+
+## Resources
+
+**Related documents:**
+
+- [Lineage
+Tracking Entities](https://docs.aws.amazon.com/sagemaker/latest/dg/lineage-tracking-entities.html)
+- [Track
+the lineage of a pipeline](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-lineage-tracking.html)
+- [MLOps
+Automation With SageMaker AI Projects](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects.html)
+- [Data
+and artifacts lineage tracking](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/data-and-artifacts-lineage-tracking.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+
+**Related examples:**
+
+- [End-to-End
+MLOps with Amazon SageMaker AI](https://github.com/aws-samples/amazon-sagemaker-mlops-workshop)
+- [Controlling
+and auditing data exploration activities with SageMaker AI Studio
+and AWS Lake Formation](https://github.com/aws-samples/amazon-sagemaker-studio-audit)
+- [SageMaker AI
+Feature Store Examples](https://github.com/aws/amazon-sagemaker-examples/tree/master/sagemaker-featurestore)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp04.html*
+
+---
+
+# MLOPS02-BP05 Establish feedback loops across ML lifecycle phases
+
+Establishing feedback loops across machine learning (ML) lifecycle
+phases is essential for continuous improvement of ML workloads. By
+implementing robust mechanisms to share successful experiments,
+analyze failures, and document operational activities, you can
+enhance model performance and adapt to changing data patterns over
+time. Feedback loops can identify model drifts and enable
+practitioners to refine monitoring and retraining strategies,
+allowing for experimentation with data augmentation and different
+algorithms until optimal outcomes are achieved.
+
+**Desired outcome:** You have
+established comprehensive feedback mechanisms across your ML
+lifecycle that facilitate continuous learning and improvement. Your
+organization can detect model drift early, automatically initiate
+retraining when needed, and incorporate human review when
+appropriate. This creates a culture of experimentation where
+successes and failures contribute equally to knowledge advancement,
+improving both model quality and operational efficiency over time.
+
+**Common anti-patterns:**
+
+- Treating model deployment as the final step without ongoing
+evaluation.
+- Failing to document experiments and operational learnings.
+- Ignoring model drift until it significantly impacts performance.
+- Working in silos without sharing insights across ML teams.
+- Lacking automated processes to respond to detected model issues.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation.
+- Reduced manual effort through automated monitoring and
+retraining.
+- Improved model quality through systematic experimentation.
+- Knowledge retention and sharing across teams.
+- Enhanced ability to adapt to changing data patterns.
+- Accelerated innovation through documented learnings.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Feedback loops are crucial to maintaining the effectiveness of ML
+models over time. As real-world data evolves, the performance of
+deployed models can deteriorate due to concept drift or model
+drift. By establishing systematic feedback mechanisms, you can
+monitor these changes, learn from them, and adapt your models
+accordingly.
+
+A comprehensive feedback loop strategy begins with monitoring
+model performance metrics and comparing them against baseline
+expectations. When deviations occur, automated alerts can notify
+teams or run retraining pipelines. The results of these actions
+should be documented to inform future development decisions. This
+creates a continuous cycle of learning where each iteration builds
+upon previous insights.
+
+For example, a financial services company deployed a fraud
+detection model that began showing decreased accuracy after six
+months. Their established feedback system detected this drift,
+automatically started a retraining pipeline using recent data, and
+documented the patterns that caused the drift. Data scientists can
+use this information to improve feature engineering in subsequent
+model versions, resulting in more resilient performance.
+
+Human review is also an essential component of feedback loops,
+especially for sensitive applications. Including human validation
+through tools like Amazon A2I provides ground truth data that can
+be used to further refine models and build trust in automated
+decisions.
+
+### Implementation steps
+
+- **Establish comprehensive model
+monitoring with SageMaker AI Model Monitor**.
+Amazon SageMaker AI Model Monitor provides capabilities to
+continuously monitor the quality of machine learning models
+in production. Configure it to detect data and concept drift
+by comparing production data statistics against the
+baseline. SageMaker AI Model Monitor supports monitoring data
+quality, model quality, bias drift, and feature attribution
+drift, providing a complete view of your model's performance
+over time.
+- **Configure CloudWatch alerts and
+notifications**. Set up
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor metrics generated by SageMaker AI
+Model Monitor and create custom dashboards to visualize
+model performance. Configure CloudWatch Alarms to send
+notifications when thresholds are exceeded, indicating
+potential model drift. These notifications can be delivered
+using SNS topics to email, SMS, or other channels for prompt
+attention.
+- **Implement the SageMaker AI Model
+Dashboard**. Use the
+[SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) as the central interface for
+tracking models and their performance. The dashboard
+provides a comprehensive view of deployed models, their
+endpoints, monitoring schedules, and historical behavior.
+This allows teams to quickly identify issues and understand
+performance trends across multiple models.
+- **Automate retraining
+pipelines**. Create automated retraining workflows
+using
+[AWS Step Functions](https://aws.amazon.com/step-functions/) and
+[SageMaker AI
+Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html). Configure
+[EventBridge
+Events](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html) rules to run these pipelines when SageMaker AI
+Model Monitor detects drift or anomalies. This verifies that
+models are retrained with fresh data when performance begins
+to degrade, maintaining high accuracy with minimal manual
+intervention.
+- **Incorporate human review with Amazon
+A2I**. Implement
+[Amazon
+Augmented AI (A2I)](https://aws.amazon.com/augmented-ai/) to route predictions with low
+confidence scores to human reviewers. This creates a
+human-in-the-loop feedback mechanism where reviewers can
+validate model outputs and provide corrections. The reviewed
+data becomes valuable ground truth that can be used to
+improve model performance in future iterations.
+- **Document and share
+learnings**. Create a knowledge repository using
+services like
+[Quick with GenBI capabilities](https://aws.amazon.com/quicksight/generative-bi/) to automatically
+generate visualizations and dashboards, and
+[Amazon S3](https://aws.amazon.com/s3/) for storing experiment results and operational
+reports. This documentation should include successful
+approaches, failed experiments, and operational insights to
+facilitate knowledge sharing across teams.
+- **Establish regular feedback review
+sessions**. Schedule recurring meetings with
+stakeholders to review monitoring results, discuss model
+performance, and prioritize improvements. These sessions
+should include data scientists, ML engineers, and business
+stakeholders to align between technical improvements and
+business outcomes.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html)
+- [Amazon
+Augmented AI (A2I)](https://aws.amazon.com/augmented-ai/)
+- [Train
+a machine learning model using Amazon SageMaker AI](https://docs.aws.amazon.com/step-functions/latest/dg/sample-train-model.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Creating
+rules that react to events in Amazon EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule.html)
+- [Monitoring
+Amazon ML with Amazon CloudWatch Metrics](https://docs.aws.amazon.com/machine-learning/latest/dg/cw-doc.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp05.html*
+
+---
+
+# MLOPS02-BP06 Review fairness and explainability
+
+Evaluating model fairness and explainability verifies that your
+machine learning solutions are ethical, transparent, and equitable
+across user groups. By systematically addressing these concerns
+throughout the ML lifecycle, you build trust with stakeholders and
+reduce the risk of harmful bias in your models.
+
+**Desired outcome:** You implement a
+comprehensive approach to fairness and explainability across your
+machine learning lifecycle. You can identify potential biases in
+data and models, explain model predictions to stakeholders, and know
+that your AI systems make equitable decisions across user segments.
+Your ML systems are continuously monitored for fairness, comply with
+relevant regulations, and maintain transparency that builds trust
+with users and stakeholders.
+
+**Common anti-patterns:**
+
+- Treating fairness as an afterthought rather than integrating it
+throughout the ML lifecycle.
+- Focusing solely on model accuracy without considering ethical
+implications.
+- Using non-representative training data that leads to biased
+outcomes.
+- Deploying complex, opaque models when explainability is
+required.
+- Failing to monitor models in production for drift in fairness
+metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Builds trust with customers and stakeholders through transparent
+AI systems.
+- Reduces the risk of regulatory issues related to algorithmic
+fairness.
+- Identifies and mitigates harmful biases before models enter
+production.
+- Enables better understanding of model decisions through
+explainability techniques.
+- Creates more inclusive AI systems that work equitably for user
+groups.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Fairness and explainability should be considered fundamental
+components of your machine learning development process rather
+than optional add-ons. Approaching these concerns proactively can
+verify that your models work equitably for your users while
+providing transparency into how decisions are made.
+
+Start by assessing the ethical implications of your ML solution
+during problem framing. Consider whether an algorithm is the
+appropriate approach and what impacts it might have on different
+user groups. For data management, analyze whether your training
+data adequately represents the diversity of your user population,
+and check for existing biases in labels or features that could be
+perpetuated by your model.
+
+During training and evaluation, consider incorporating fairness
+constraints directly into your optimization functions. Evaluate
+models using appropriate fairness metrics alongside traditional
+performance measures. When deploying models, carefully assess
+whether the deployment context matches the training conditions,
+especially regarding population characteristics. Finally,
+implement robust monitoring systems to track fairness metrics over
+time and detect emerging bias.
+
+Amazon SageMaker AI Clarify provides comprehensive tools for
+addressing fairness and explainability throughout the ML
+lifecycle. It offers bias detection capabilities for both data and
+models, along with explainability features through SHAP (Shapley
+Additive Explanations) values that provide an understanding of how
+individual features contribute to predictions.
+
+### Implementation steps
+
+- **Assess ethical implications during
+problem framing**. Before building an ML model,
+evaluate whether an algorithmic approach is ethical for your
+specific use case. Consider potential unintended
+consequences and whether the benefits outweigh potential
+risks. Document your assessment and decision-making process
+for transparency.
+- **Evaluate and prepare representative
+training data**. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) with enhanced bias detection and
+new fairness metrics to analyze your training data for
+potential biases, particularly regarding protected
+attributes or sensitive groups. Verify that your data
+accurately represents the population on which the model will
+be deployed. Apply appropriate sampling or augmentation
+techniques to address identified representation gaps.
+- **Implement bias detection in the
+model development process**. Configure SageMaker AI
+Clarify to evaluate pre-training bias metrics that assess
+imbalances in your training data. These metrics can identify
+issues like class imbalance, label imbalance across groups,
+or feature distribution disparities that could lead to
+unfair outcomes.
+- **Select appropriate fairness metrics
+for evaluation**. Depending on your specific use
+case, choose relevant fairness metrics such as disparate
+impact, difference in positive proportions, or equal
+opportunity difference. These metrics quantify whether your
+model treats different groups equitably and should be
+tracked alongside traditional performance metrics.
+- **Apply explainability techniques to
+understand model decisions**. Implement
+[SHAP
+(Shapley Additive Explanations)](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html) through SageMaker AI
+Clarify to understand feature importance and how different
+features influence model predictions. This can identify
+whether protected attributes or proxies for them are
+disproportionately influencing outcomes.
+- **Consider model complexity tradeoffs
+with explainability requirements**. If
+explainability is a critical requirement, consider using
+simpler model architectures (like linear models or decision
+trees) that are inherently more interpretable. For complex
+models like deep neural networks, implement robust
+explainability tools.
+- **Implement bias monitoring in
+production environments**. Configure
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously track fairness metrics
+for deployed models. Set up alerts for drift in fairness
+metrics that might indicate emerging bias issues requiring
+intervention.
+- **Establish governance processes for
+addressing detected bias**. Create clear procedures
+for when bias is detected, including who is responsible for
+review, what remediation steps should be taken, and how
+stakeholders should be informed. Document these processes to
+verify that they are consistently applied.
+- **Train teams on fairness and
+explainability concepts**. Verify that data
+scientists, ML engineers, and other stakeholders understand
+fairness concepts, bias mitigation techniques, and how to
+interpret explainability outputs. Regular training sessions
+build organizational capacity for responsible AI.
+- **Document fairness and explainability
+considerations**. Maintain comprehensive
+documentation of fairness evaluations, explainability
+analyses, and mitigation strategies applied. This
+documentation supports transparency, aids regulatory
+adherence efforts, and communicates your responsible AI
+approach to stakeholders.
+- **Foundation model fairness
+considerations**. Use foundation models and
+generative AI to enhance fairness and explainability efforts
+by generating diverse synthetic data to address
+representation gaps, creating plain-language explanations of
+complex model decisions for different stakeholder groups,
+and automating the generation of comprehensive documentation
+about model fairness evaluations and mitigations.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Feature
+Attributions that Use Shapley Values](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/)
+- [Responsible
+AI Practices](https://aws.amazon.com/ai/responsible-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops02-bp06.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLOPS03.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLOPS03.md
@@ -1,0 +1,326 @@
+# MLOPS03
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLOPS03-BP01 Profile data to improve quality
+
+Data profiling is essential for understanding data characteristics
+such as distribution, descriptive statistics, data types, and
+patterns. By systematically reviewing source data for content and
+quality, you can filter out or correct problematic data, leading to
+significant quality improvements in your machine learning workflows.
+
+**Desired outcome:** You gain
+comprehensive insights into your data's characteristics, enabling
+you to identify and remediate quality issues before they impact your
+machine learning models. Through systematic profiling, you establish
+a robust data preprocessing pipeline that provides high-quality,
+consistent data flows to your ML models, resulting in more accurate
+predictions and better business outcomes.
+
+**Common anti-patterns:**
+
+- Skipping data profiling and moving directly to model training.
+- Manually reviewing data without automated profiling tools.
+- Performing one-time data quality checks without continuous
+monitoring.
+- Ignoring data distribution shifts between training and inference
+data.
+- Failing to document data quality issues and their resolutions.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model performance through higher quality training data.
+- Earlier detection of data anomalies and inconsistencies.
+- Enhanced understanding of data characteristics and limitations.
+- Reduced time spent debugging model issues caused by data
+problems.
+- More transparent and reproducible machine learning workflows.
+- Increased stakeholder confidence in model outputs.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data profiling is a critical step in the machine learning
+workflow. By thoroughly examining your data before model training,
+you gain valuable insights that improve data quality and
+ultimately lead to better model performance. Data profiling
+involves analyzing the statistical properties, distributions, and
+patterns within your dataset to identify anomalies, missing
+values, outliers, and other quality issues.
+
+Effective data profiling requires both automated tools and human
+judgment. While tools can quickly generate statistical summaries
+and visualizations, subject matter experts should interpret these
+findings to determine appropriate actions for data cleaning and
+transformation. For instance, you might discover that a numerical
+feature has an unexpected distribution that requires
+normalization, or that categorical variables contain inconsistent
+values requiring standardization.
+
+Consider a retail company building a customer churn prediction
+model. Through data profiling, they discover that 15% of customer
+records have missing age values, 5% have impossibly high
+transaction amounts, and several categorical fields contain
+inconsistent formatting. By addressing these issues early, they
+can significantly improve their model's performance.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Unified
+Studio for visual data review**. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) with enhanced collaborative
+features and team sharing capabilities to visually review
+data characteristics and remediate data-quality problems
+directly in your integrated environment. The unified
+solution provides improved debugging and monitoring
+capabilities for data processing workflows, automatically
+generating charts to identify data quality issues and
+suggesting transformations to fix common problems.
+- **Implement Amazon SageMaker AI Data
+Wrangler for comprehensive data preparation**.
+Import, prepare, transform, visualize, and analyze data with
+[SageMaker AI Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/) with
+[Q
+integration for interactive analysis](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-q-integration.html). You can
+integrate Data Wrangler into your ML workflows to simplify
+and streamline data pre-processing and feature engineering
+with little to no coding. Import data from
+[Amazon S3](https://aws.amazon.com/s3/),
+[Amazon Redshift](https://aws.amazon.com/redshift/), or other data sources, and then query the
+data using
+[Amazon Athena](https://aws.amazon.com/athena/). Use Data Wrangler's built-in and custom data
+transformations and analysis features, including feature
+target leakage detection and quick modeling, to create
+sophisticated machine learning data preparation workflows.
+- **Build an automatic data profile and
+reporting system**. Use
+[AWS Glue Crawler](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html) to crawl your data sources and
+automatically create a data schema. The crawler detects the
+schema of your data and registers tables in the
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/populate-data-catalog.html), providing a comprehensive listing
+of tables and schemas. Use
+[Amazon Athena](https://aws.amazon.com/athena/) for serverless SQL querying to constantly
+profile your data, and create
+[Quick](https://aws.amazon.com/quicksight/) dashboards for data visualization and
+monitoring.
+- **Create a baseline dataset with
+SageMaker AI Model Monitor**. The training dataset
+used to train your model typically serves as a good baseline
+dataset. Verify that the training dataset schema and the
+inference dataset schema exactly match (the number and order
+of the features). With
+[SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-create-baseline.html), you can automatically detect
+concept drift in deployed models by comparing production
+data against this baseline.
+- **Implement continuous data quality
+monitoring**. Set up automated checks that
+continuously monitor data quality metrics like completeness,
+uniqueness, consistency, and validity. Configure alerts to
+notify relevant stakeholders when data quality issues arise,
+enabling prompt intervention and resolution. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to create dashboards and set up alerts for
+key data quality metrics.
+- **Document data profiling insights and
+transformations**. Maintain comprehensive
+documentation of data profiling findings, quality issues
+discovered, and the transformations applied to address them.
+This documentation promotes transparency, facilitates
+knowledge sharing across teams, and supports regulatory
+adherence in regulated industries.
+- **Use generative AI for enhanced data
+profiling**. Use large language models in
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) or
+[Amazon
+Nova](https://aws.amazon.com/ai/generative-ai/nova/) to automatically extract and enrich metadata,
+identify patterns in your data, and generate natural
+language summaries of data quality issues. Generative AI can
+analyze unstructured data fields and provide insights that
+traditional data profiling tools might miss, though you
+should validate AI-generated suggestions before
+implementation.
+
+## Resources
+
+**Related documents:**
+
+- [Prepare
+ML Data with Amazon SageMaker AI Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler.html)
+- [Get
+Started with Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-getting-started.html)
+- [Data
+quality](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-data-quality.html)
+- [Create
+a Baseline](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-create-baseline.html)
+- [AWS Glue Data Quality](https://docs.aws.amazon.com/glue/latest/dg/glue-data-quality.html)
+- [Data
+discovery and cataloging in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html)
+- [Amazon SageMaker AI notebooks](https://aws.amazon.com/sagemaker/notebooks/)
+- [What
+is Amazon Athena?](https://docs.aws.amazon.com/athena/latest/ug/what-is.html)
+- [What
+is Amazon Quick Suite?](https://docs.aws.amazon.com/quicksight/latest/user/welcome.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops03-bp01.html*
+
+---
+
+# MLOPS03-BP02 Create tracking and version control mechanisms
+
+Machine learning model development requires robust tracking and
+version control mechanisms due to its iterative and exploratory
+nature. By implementing proper tracking systems, you can maintain
+visibility of your experiments, data processing techniques, and
+model versions while enabling reproducibility and collaboration.
+
+**Desired outcome:** You have
+comprehensive tracking of ML model development with experiment
+tracking capabilities, version-controlled data processing code, and
+a model registry that enables you to identify the best performing
+models. Your development processes are reproducible, collaborative,
+and automated with CI/CD pipelines for model deployment.
+
+**Common anti-patterns:**
+
+- Manually tracking experiments in spreadsheets or documents.
+- Not documenting data processing steps or model configurations.
+- Keeping models and datasets in local environments without
+version control.
+- Starting new experiments from scratch instead of building on
+previous work.
+
+**Benefits of establishing this best
+practice:**
+
+- Enhanced reproducibility of experiments and model training.
+- Improved collaboration among data science teams.
+- Better visibility into the performance of different model
+iterations.
+- Faster identification of the best performing models.
+- Ability to roll back to previous model versions if needed.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning development involves experimenting with multiple
+combinations of data, algorithms, and parameters while observing
+how incremental changes impact model accuracy. Without proper
+tracking and version control, you risk losing valuable insights
+and the ability to reproduce successful experiments.
+
+To address these challenges, you need a systematic approach to
+track experiments, version control your code and data processing
+techniques, and manage model deployment. AWS SageMaker AI provides
+integrated tools for experiment tracking, version control, and
+model registry that can streamline your machine learning
+operations.
+
+By implementing proper tracking and versioning mechanisms, you can
+document your model development journey, track performance metrics
+across experiments, and reliability reproduce and deploy your
+models. This creates a foundation for continuous improvement of
+your machine learning applications.
+
+### Implementation steps
+
+- **Track your ML experiments with
+SageMaker AI Experiments**. Use Amazon SageMaker AI
+Experiments to you create, manage, analyze, and compare your
+machine learning experiments. SageMaker AI Experiments
+automatically tracks inputs, parameters, configurations, and
+results of your iterations as runs. You can assign, group,
+and organize these runs into experiments. SageMaker AI
+Experiments integrates with Amazon SageMaker AI Studio,
+providing a visual interface to browse active and past
+experiments, compare runs on key performance metrics, and
+identify the best-performing models.
+- **Process data with SageMaker AI
+Processing**. For analyzing data, documenting
+processing, and evaluating ML models, use
+[Amazon SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html). This capability can be used for
+feature engineering, data validation, model evaluation, and
+model interpretation. SageMaker AI Processing provides a
+standardized way to run your data processing workloads,
+fostering consistency and reproducibility.
+- **Use SageMaker AI Unified Studio for
+enhanced collaboration**. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) with enhanced collaborative
+features and team sharing capabilities for integrated data
+and AI workflows. The unified solution provides improved
+debugging and monitoring capabilities, VS Code server
+integration, and enhanced project sharing. This approach
+keeps your data processing code and documentation accessible
+while facilitating better collaboration and version tracking
+across teams.
+- **Use SageMaker AI Model
+Registry**. Catalog, manage, and deploy models
+using SageMaker AI Model Registry. Create a model group and,
+for each run of your ML pipeline, create a model version
+that you register in the model group. The Model Registry
+provides a centralized repository for model versions, making
+it more straightforward to track model lineage, compare
+model performance, and promote models to production.
+- **Implement CI/CD for model
+deployment**. Automate your model deployment
+process using CI/CD pipelines for consistent and reliable
+deployments. SageMaker AI Pipelines can be used to create
+end-to-end workflows that include model building,
+evaluation, and deployment steps. Implement CI/CD for model
+deployment to thoroughly test your models before they are
+deployed to production, reducing the risk of
+deployment-related issues.
+- **Integrate data version
+control**. Use tools like Data Version Control
+(DVC) in conjunction with SageMaker AI Experiments to track
+both your model code and the datasets used for training and
+evaluation. With these tools, you can completely reproduce
+your machine learning experiments.
+- **Create model cards for
+documentation**. For each model version in your
+registry, create comprehensive
+[SageMaker AI
+Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) with enhanced documentation and
+governance capabilities that document the model's purpose,
+training data, performance metrics, limitations, and usage
+guidelines. This documentation helps users understand when
+and how to use specific model versions and supports improved
+model governance.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Experiments in Studio Classic](https://docs.aws.amazon.com/sagemaker/latest/dg/experiments.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Git
+repositories with SageMaker AI Notebook Instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-git-repo.html)
+- [MLOps
+Automation With SageMaker AI Projects](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects.html)
+- [Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Experiment Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-experiments)
+- [SageMaker AI
+Model Registry Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-pipelines)
+- [Amazon SageMaker AI processing](https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_processing.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops03-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLOPS04.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLOPS04.md
@@ -1,0 +1,332 @@
+# MLOPS04
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLOPS04-BP01 Automate operations through MLOps and CI/CD
+
+Automate ML workload operations using infrastructure as code (IaC)
+and configuration as code (CaC). Select appropriate MLOps mechanisms
+to orchestrate your ML workflows and integrate with CI/CD pipelines
+for automated deployments. This approach creates consistency across
+your staging and production deployment environments. Enable model
+observability and version control across your hosting
+infrastructure.
+
+**Desired outcome:** You establish
+automated ML operations through MLOps practices and CI/CD pipelines
+for repeatable, consistent deployments across environments. Your ML
+workflows are orchestrated through infrastructure as code, providing
+traceability, version control, and model observability. This enables
+your teams to deliver ML models faster, with higher quality, and
+maintain governance throughout the model lifecycle from development
+to production.
+
+**Common anti-patterns:**
+
+- Manually deploying ML models to production environments.
+- Using different tools and processes across development and
+production environments.
+- Not versioning infrastructure, configuration, or model
+artifacts.
+- Lacking automated testing for ML models before deployment.
+- Creating one-off scripts for deployment instead of reusable
+templates.
+
+**Benefits of establishing this best
+practice:**
+
+- Accelerated ML model development and deployment cycles.
+- Consistent, reproducible environments across development and
+production.
+- Improved collaboration between data scientists and operations
+teams.
+- Enhanced governance and traceability for model artifacts and
+infrastructure.
+- Improved rollbacks and version management.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+MLOps combines machine learning, DevOps practices, and data
+engineering to streamline and automate the end-to-end ML
+lifecycle. By implementing infrastructure as code and
+configuration as code principles, you create consistent,
+reproducible environments while minimizing manual steps that can
+introduce errors. This approach makes ML operations more reliable,
+scalable, and maintainable.
+
+Creating automated CI/CD pipelines for ML workloads requires
+special consideration compared to traditional software
+applications. You need to track not only code changes but also
+data, model parameters, and training configurations. Using AWS
+services for MLOps provides integrated tools to manage these
+complexities while maintaining proper governance and
+observability.
+
+When implementing MLOps practices, start by defining your workflow
+patterns and choosing appropriate orchestration tools based on
+your specific requirements. AWS offers multiple options for ML
+workflow orchestration, from purpose-built services like SageMaker AI
+Pipelines to more general workflow engines like AWS Step Functions. Each provides different levels of abstraction, control,
+and integration capabilities.
+
+Model observability is crucial for ML systems in production,
+allowing you to monitor model performance, detect drift, and run
+retraining when necessary. Implementing comprehensive monitoring
+assists you to quickly identify and respond to changes in model
+behavior or data distributions.
+
+### Implementation steps
+
+- **Define your ML workflow
+architecture**. Begin by mapping out your
+end-to-end ML workflow, including data preparation, feature
+engineering, model training, evaluation, deployment, and
+monitoring stages. Identify which steps can be automated and
+which require human intervention. Determine the appropriate
+level of separation between development, testing, and
+production environments based on your requirements.
+- **Select an infrastructure as code
+approach**. Choose either AWS CloudFormation or AWS CDK to define your infrastructure.
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) enables you to create and provision
+AWS deployments predictably and repeatedly using template
+files. For teams more comfortable with programming
+languages,
+[AWS Cloud Development Kit (AWS CDK) (AWS CDK)](https://aws.amazon.com/cdk/) allows you to define cloud
+resources using familiar languages like Python, TypeScript,
+or Java.
+- **Implement version control for
+assets**. Establish a version control strategy for
+ML assets including code, configurations, infrastructure
+definitions, and model artifacts. Use AWS CodeCommit or
+third-party repositories to store and version these assets.
+Implement branching strategies that allow for
+experimentation while maintaining stable production
+environments. Version control enables you to track changes,
+collaborate effectively, and roll back to previous versions
+when needed.
+- **Choose an MLOps orchestration
+strategy**. Based on your workflow needs, select an
+appropriate orchestration mechanism:
+
+Use
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to create ML workflows with
+Python SDK, visualize, and manage them in Amazon SageMaker AI Studio. SageMaker AI Pipelines automatically logs
+every step, creating an audit trail of model components
+including training data, configurations, parameters, and
+learning gradients.
+- Use
+[AWS Step Functions Data Science SDK](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-python-sdk.html) to automate ML
+workflows with more complex orchestration requirements
+or when integrating with other AWS services beyond
+SageMaker AI.
+- Use third-party tools such as
+[Amazon
+Managed Workflows for Apache Airflow (MWAA)](https://aws.amazon.com/managed-workflows-for-apache-airflow/) to
+orchestrate workflows using Directed Acyclic Graphs
+(DAGs) written in Python, especially when you need to
+integrate with existing Apache Airflow deployments.
+
+- **Build CI/CD pipelines for ML
+models**. Implement CI/CD pipelines using
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) to automate the building, testing, and
+deployment of ML models. Include automated tests for data
+quality, model performance, and API functionality. Configure
+the pipeline to deploy to staging environments before
+production and implement approval gates where needed.
+Integrate model registration and versioning using Amazon SageMaker AI Model Registry.
+- **Set up model monitoring and
+observability**. Implement comprehensive monitoring
+for your deployed models using
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/). Configure data quality
+monitoring, model quality monitoring, bias drift monitoring,
+and feature attribution drift monitoring. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to create dashboards and alerts for model
+performance metrics.
+- **Establish automated rollback
+mechanisms**. Configure your deployment pipelines
+to support automated rollbacks when quality thresholds are
+not met. Implement canary or blue/green deployment
+strategies using
+[AWS CodeDeploy](https://aws.amazon.com/codedeploy/) to gradually shift traffic to new model
+versions while monitoring for issues. This minimizes the
+impact of problematic deployments and provides service
+continuity.
+- **Integrate security and governance
+controls**. Implement security checks throughout
+your MLOps pipeline. Use
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) to control access to
+resources and
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to log API calls for auditing. Configure
+[Amazon SageMaker AI Model Cards](https://aws.amazon.com/sagemaker/ml-governance/) to document model information,
+intended uses, limitations, and performance characteristics.
+- **Create environments for
+experimentation and testing**. Set up isolated
+environments for experimentation that don't impact
+production systems. Use
+[Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/) to provide data scientists
+with self-service environments for exploration while
+maintaining governance through integrated data and AI
+workflows. Implement environment-specific configurations
+through parameter files or environment variables managed in
+your IaC templates.
+
+## Resources
+
+**Related documents:**
+
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [What
+is AWS CodePipeline?](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html)
+- [Amazon
+Managed Workflows for Apache Airflow (MWAA)](https://aws.amazon.com/managed-workflows-for-apache-airflow/)
+- [AWS CloudFormation Documentation](https://docs.aws.amazon.com/cloudformation/index.html)
+- [What
+is the AWS CDK?](https://docs.aws.amazon.com/cdk/latest/guide/home.html)
+- [Step
+Functions Data Science SDK](https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/)
+- [Infrastructure
+as code](https://docs.aws.amazon.com/whitepapers/latest/introduction-devops-aws/infrastructure-as-code.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+
+**Related videos:**
+
+- [AWS re:Invent 2024 - Accelerate ML workflows with Amazon SageMaker AI
+Studio](https://www.youtube.com/watch?v=SAeZMA0KaFA)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops04-bp01.html*
+
+---
+
+# MLOPS04-BP02 Establish reliable packaging patterns to access approved public libraries
+
+Establishing reliable packaging patterns enables data scientists to
+access approved public libraries efficiently and consistently. By
+implementing structured access to public libraries and creating
+separate kernels for common ML frameworks, organizations can have
+both flexibility and security in their machine learning development
+environments.
+
+**Desired outcome:** You create a
+streamlined workflow where your data scientists have reliable access
+to approved libraries through internal repositories. You maintain
+separate kernels for common ML frameworks like TensorFlow, PyTorch,
+Scikit-learn, and Keras. This approach improves development
+productivity while improving security and adherence with
+organizational requirements.
+
+**Common anti-patterns:**
+
+- Allowing uncontrolled direct downloads from public repositories.
+- Using inconsistent or undocumented container configurations.
+- Maintaining duplicate library versions across different
+environments.
+- Not having a centralized strategy for package management.
+- Failing to version control dependencies.
+
+**Benefits of establishing this best
+practice:**
+
+- Better security through controlled library usage.
+- Improved reproducibility of ML workloads.
+- Reduced dependency conflicts.
+- Simplified adherence with organizational security policies.
+- Faster onboarding of new data scientists.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Creating reliable packaging patterns is essential for maintaining
+consistent, secure, and efficient machine learning workflows. You
+need to establish infrastructure that gives data scientists access
+to the libraries they need while maintaining organizational
+control over those dependencies. Container technologies provide a
+portable, consistent way to package ML environments with required
+dependencies, making them ideal for this purpose. Internal
+artifact repositories allow for centralized management of approved
+packages so that team members use consistent, vetted versions.
+
+Your packaging strategy should balance flexibility for data
+scientists with security and regulatory requirements. This means
+establishing both infrastructure (containers, repositories) and
+processes (approval workflows, versioning policies) that work
+together to create a streamlined experience. The use of
+standardized environments with separate kernels for different ML
+frameworks enables isolation when needed while providing the
+specific tools required for different types of projects.
+
+### Implementation steps
+
+- **Set up container infrastructure for
+ML workloads**. Create a container strategy using
+[Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html) (Amazon ECR) to store and
+manage your ML container images. Containers provide
+consistent environments that package dependencies,
+libraries, and runtime components needed for ML workloads.
+- **Create base container images for
+common ML frameworks**. Build and maintain separate
+base container images for frameworks like TensorFlow,
+PyTorch, Scikit-learn, and Keras using
+[optimized
+foundation model containers](https://docs.aws.amazon.com/sagemaker/latest/dg/large-model-inference.html) for efficient training
+and inference. These images should include standard
+configurations and commonly used libraries for each
+framework, with support for frameworks like Hugging Face
+Transformers and quantization techniques, providing
+consistency across your organization.
+- **Implement versioning and tagging
+policies**. Establish clear policies for versioning
+containers and artifacts for reproducibility of ML
+experiments and models. Use semantic versioning and proper
+tagging to track container image changes and library
+updates.
+- **Develop automation for container
+builds and updates**. Implement CI/CD pipelines
+using
+[AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html) to automatically build, test, and deploy
+updated container images when dependencies need to be
+updated or security patches are required.
+- **Document usage patterns and
+onboarding procedures**. Create comprehensive
+documentation that explains how data scientists should use
+the established packaging patterns, including how to access
+approved libraries and work with containerized environments.
+
+## Resources
+
+**Related documents:**
+
+- [What
+is Amazon Elastic Container Registry?](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html)
+- [What
+are AWS Deep Learning Containers?](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html)
+- [Docker
+containers for training and deploying models](https://docs.aws.amazon.com/sagemaker/latest/dg/docker-containers.html)
+- [What
+is AWS CodePipeline?](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html)
+- ["Publish
+Docker image to an Amazon ECR image repository" sample
+for CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html)
+
+**Related examples:**
+
+- [SageMaker AI
+Custom Container Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/advanced_functionality/custom-training-containers)
+- [Deep
+Learning Container Examples](https://github.com/aws/deep-learning-containers/tree/master/examples)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops04-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLOPS05.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLOPS05.md
@@ -1,0 +1,200 @@
+# MLOPS05
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLOPS05-BP01 Establish deployment environment metrics
+
+Establish comprehensive monitoring of machine learning operations to
+gain visibility into your deployed ML environments. By measuring
+metrics such as memory, CPU/GPU usage, disk utilization, endpoint
+invocations, and latency, you can provide optimal performance and
+improve the reliability of your ML systems.
+
+**Desired outcome:** You gain
+real-time visibility into your ML deployment environments through
+systematic collection and analysis of performance metrics. You
+establish robust monitoring dashboards, alerting systems, and
+automated responses to potential issues. This enables you to
+proactively address performance bottlenecks, optimize resource
+utilization, and maintain reliable ML services while managing costs
+effectively.
+
+**Common anti-patterns:**
+
+- Implementing monitoring only after experiencing production
+issues.
+- Focusing only on basic system metrics while ignoring ML-specific
+performance indicators.
+- Creating monitoring dashboards without establishing
+corresponding alerts.
+- Setting static thresholds that don't account for typical usage
+patterns.
+- Collecting metrics without regular review or actionable response
+plans.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of performance issues before they impact end
+users.
+- Improved resource optimization and cost efficiency.
+- Enhanced ability to scale ML services based on actual usage
+patterns.
+- Faster troubleshooting and reduced mean time to resolution.
+- Data-driven capacity planning and infrastructure decisions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing effective deployment environment metrics requires a
+systematic approach to monitoring both infrastructure and
+application-specific ML metrics. You need to focus on both
+system-level metrics like CPU, memory, and disk usage, as well as
+ML-specific metrics such as inference latency, throughput, and
+model accuracy. By using AWS services like Amazon CloudWatch, you
+can centralize your monitoring approach and gain comprehensive
+visibility into your ML operations.
+
+Start by identifying the key performance indicators that matter
+most for your specific ML workloads. For inference endpoints,
+these typically include latency, throughput, and resource
+utilization. For batch processing jobs, focus on processing time,
+error rates, and resource efficiency. With these KPIs established,
+you can implement automated monitoring and alerting to quickly
+identify when your systems deviate from expected performance.
+
+Regular review of your metrics can identify trends and potential
+areas for optimization. For example, you might discover that
+certain models require more memory than originally allocated, or
+that specific types of inference requests consistently take longer
+to process. This information guides your infrastructure decisions
+and prioritizes optimization efforts.
+
+### Implementation steps
+
+- **Record performance-related
+metrics.** Use a monitoring and observability
+service like Amazon CloudWatch to record performance-related
+metrics. These metrics can include database transactions,
+slow queries, I/O latency, HTTP request throughput, service
+latency, and other key data. For SageMaker AI endpoints,
+collect metrics such as CPUUtilization, MemoryUtilization,
+DiskUtilization, and model-specific metrics like
+ModelLatency and InvocationsPerInstance.
+- **Analyze metrics when events or
+incidents occur.** Use monitoring dashboards and
+reports to understand and diagnose the impact of an event or
+incident. Amazon CloudWatch Dashboards provide insight into
+what portions of the workload are not performing as
+expected. Correlate metrics, logs, and traces to quickly
+identify root causes when issues arise.
+- **Establish key performance indicators
+(KPIs) to measure workload performance.** Identify
+the KPIs that indicate whether the workload is performing as
+intended. An API-based ML endpoint might use overall
+response latency as an indication of overall performance,
+while a batch processing job might track throughput metrics.
+For generative AI applications, monitor additional metrics
+like token usage, cost per request, prompt engineering
+effectiveness, and use
+[SageMaker AI
+Training Plans](https://aws.amazon.com/sagemaker/pricing/) for cost optimization of large-scale
+AI training workloads.
+- **Use monitoring to generate
+alarm-based notifications.** Monitor metrics for
+the defined KPIs and generate alarms automatically when the
+measurements are outside expected boundaries. Configure
+Amazon CloudWatch Alarms to send notifications using Amazon SNS when thresholds are breached, which provides for timely
+responses to potential issues.
+- **Review metrics at regular
+intervals.** As routine maintenance, or in response
+to events or incidents, review what metrics are collected
+and identify the metrics that were key in addressing issues.
+Identify additional metrics that can identify, address, or
+avoid issues. Schedule periodic reviews to keep your
+monitoring strategy effective as your ML applications
+evolve.
+- **Monitor and alarm
+proactively.** Use KPIs, combined with monitoring
+and alerting systems, to proactively address
+performance-related issues. Configure CloudWatch to initiate
+automated actions to remediate issues where possible.
+Escalate the alarm to those able to respond if an automated
+response is not possible. Use anomaly detection to predict
+expected KPI values, and generate alerts and automatically
+halt or roll back deployments if KPIs are outside of the
+expected values.
+- **Use Amazon CloudWatch for
+comprehensive monitoring.** Use Amazon CloudWatch
+metrics for SageMaker AI endpoints to determine the memory,
+CPU usage, and disk utilization. Set up CloudWatch
+Dashboards to visualize the environment metrics and
+establish CloudWatch alarms to initiate a notification
+through Amazon SNS (email, SMS, or webHook) to notify on
+events occurring in the runtime environment. For model
+performance monitoring, implement Amazon SageMaker AI Model
+Monitor to detect data drift and quality issues.
+- **Use Amazon EventBridge for automated
+workflows.** Define an automated workflow using
+Amazon EventBridge to respond automatically to events. These
+events can include training job status changes, endpoint
+status changes, and increasing the compute environment
+capacity after it crosses a defined threshold (such as CPU
+or disk utilization). Create event rules that run Lambda
+functions to scale resources, update configurations, or
+notify specific teams based on the event type.
+- **Use AWS Application Cost Profiler
+for cost allocation.** Implement AWS Application Cost Profiler to report the cost per tenant (model or user).
+This assists you in tracking resource usage at a granular
+level and enables accurate cost attribution across different
+ML models, teams, or business units. Use
+[SageMaker AI
+Training Plans](https://aws.amazon.com/sagemaker/pricing/) for compute reservation and better
+resource planning of high-demand GPU resources. Use these
+insights to optimize resource allocation and identify
+opportunities for cost savings.
+- **Implement SageMaker AI Model Monitor
+for data drift detection.** Configure SageMaker AI
+Model Monitor to continuously monitor the quality of your
+machine learning models in production. Set up automated
+quality checks to detect data drift, model drift, and bias
+drift in your production workloads. This enables you to
+maintain high quality standards and take corrective actions
+when models start to deviate from expected behavior.
+- **Use AWS X-Ray for distributed
+tracing.** Implement AWS X-Ray to trace requests
+through your ML application components. This provides
+visibility into request flows, latency bottlenecks, and
+error points in distributed systems. X-Ray provides an
+understanding of the dependencies between components so you
+can optimize end-to-end performance of your ML applications.
+- **Implement Amazon SageMaker AI Clarify
+for bias monitoring.** Use SageMaker AI Clarify to
+detect bias in your deployed models. Set up regular
+monitoring jobs to track bias metrics and alert when they
+exceed acceptable thresholds so that your ML systems
+continue to make fair and unbiased predictions in
+production.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Metrics
+in Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html)
+- [Using
+Amzon CloudWatch dashboards](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html)
+- [DevOps
+and AWS](https://aws.amazon.com/devops/?ref=wellarchitected-wp)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops05-bp01.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLOPS06.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLOPS06.md
@@ -1,0 +1,389 @@
+# MLOPS06
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLOPS06-BP01 Synchronize architecture and configuration, and check for skew across environments
+
+Synchronize your systems and configurations across development and
+deployment phases for consistent machine learning model inference
+results. By maintaining identical environments, you can avoid
+discrepancies that arise from architectural differences, leading to
+more reliable and predictable model performance.
+
+**Desired outcome:** You have
+established a systematic approach to foster architectural and
+configuration consistency across development, staging, and
+production environments for machine learning models. This includes
+automated infrastructure deployment, continuous model quality
+monitoring, and proactive detection of environmental skew. Your
+machine learning systems deliver the same range of accuracy
+regardless of which environment they run in, and you can quickly
+identify and address deviations.
+
+**Common anti-patterns:**
+
+- Manually configuring each environment, leading to
+inconsistencies.
+- Neglecting to validate model performance across different
+environments.
+- Assuming model behavior will be identical across environments
+without verification.
+- Using different hardware specifications or software versions
+between environments.
+- Making changes only when needed to production environments
+without documenting or replicating them in other environments.
+
+**Benefits of establishing this best
+practice:**
+
+- Consistent model performance across environments.
+- Reduced debugging time for environment-specific issues.
+- Improved reliability of machine learning applications.
+- Straightforward identification of the root causes of performance
+deviations.
+- Streamlined promotion process from development to production.
+- Enhanced confidence in deployed models.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Synchronizing your machine learning environments is critical for
+checking that a model trained in one environment behaves the same
+way when deployed in another. Differences in system architectures,
+software dependencies, or configuration settings can cause
+unexpected variations in model performance, leading to inaccurate
+predictions or even system failures.
+
+By treating your infrastructure as code and implementing automated
+monitoring, you can maintain consistency across environments and
+quickly detect deviations. This approach allows you to focus on
+improving your models rather than debugging environment-specific
+issues. It also provides a reliable foundation for continuous
+delivery of machine learning solutions.
+
+Environmental skew can occur in various ways, such as through
+differences in hardware capabilities, software versions, or system
+configurations. For example, a model trained on a development
+environment with specific CPU architecture might behave
+differently when deployed to a production environment with
+different specifications. Similarly, differences in underlying
+libraries or dependencies can lead to subtle variations in model
+behavior.
+
+Regular validation of model performance across environments should
+be part of your standard promotion process. This includes
+comparing not only the accuracy metrics but also the distribution
+of predictions and the model's behavior for edge cases.
+
+### Implementation steps
+
+- **Define infrastructure as code using
+AWS CloudFormation**. Create CloudFormation
+templates that define resources, configurations, and
+dependencies for your machine learning environments. With
+this strategy, each environment is provisioned consistently
+and can be recreated identically when needed. Include
+compute resources, networking configurations, security
+settings, and machine learning-specific components.
+- **Implement version control for
+infrastructure templates**. Store your
+CloudFormation templates in a version control system like
+AWS CodeCommit or GitHub. This allows you to track changes
+over time, roll back to previous configurations if needed,
+and verify that your environments are using the same version
+of the infrastructure definition.
+- **Set up CI/CD pipelines for
+infrastructure deployment**. Use AWS CodePipeline
+or AWS CodeBuild to automate the deployment of your
+infrastructure changes across environments. This reduces
+manual intervention and the potential for human error when
+updating environments.
+- **Configure Amazon SageMaker AI Model
+Monitor for continuous quality evaluation**. Set up
+Model Monitor to automatically track the quality of your
+models in production and compare the results with the
+baseline established during training. This can identify when
+model performance starts to drift due to environmental
+factors or data changes.
+- **Implement data quality
+monitoring**. Use SageMaker AI Model Monitor's data
+quality monitoring capability to detect changes in the
+statistical properties of your input data across
+environments. This capability provides similar input
+distributions to your models regardless of environment.
+- **Set up model quality
+monitoring**. Configure SageMaker AI Model Monitor to
+track model quality metrics such as accuracy, precision, and
+recall over time. Compare these metrics between your
+development, staging, and production environments to detect
+inconsistencies.
+- **Enable bias drift
+monitoring**. Use SageMaker AI Model Monitor's bias
+drift monitoring to detect if your models exhibit different
+biases in different environments, which could indicate
+environment-specific issues.
+- **Configure alerts for
+deviations**. Set up Amazon CloudWatch alarms to
+notify you when SageMaker AI Model Monitor detects significant
+deviations in model performance or data characteristics
+across environments. This allows for proactive intervention
+before small issues become major problems.
+- **Establish a promotion
+checklist**. Create a formal checklist that
+includes verifying model performance consistency across
+environments before promoting a model to the next stage.
+Document the acceptable thresholds for performance
+differences between environments.
+- **Implement regular cross-environment
+validation**. Schedule periodic validation of model
+performance across your environments, even when no changes
+are being made. Use this validation to catch gradual drift
+that might occur due to external factors.
+- **Create environment comparison
+dashboards**. Use
+[Quick with GenBI capabilities](https://aws.amazon.com/quicksight/generative-bi/) to automatically
+generate visualizations and dashboards for model performance
+metrics across different environments, making it more
+straightforward to spot discrepancies and track trends over
+time.
+- **Utilize foundation models for
+anomaly detection**. Implement
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/knowledge-bases/) or
+[SageMaker AI
+JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) with expanded library of foundation models
+to analyze performance patterns and identify anomalous
+behavior that might indicate environmental inconsistencies,
+especially for complex ML systems where traditional
+monitoring might miss subtle differences.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [What
+is AWS CloudFormation?](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html)
+- [What
+is AWS Config?](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
+- [Detect
+unmanaged configuration changes to stacks and resources with
+drift detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html)
+- [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)
+- [Amazon SageMaker AI best practices](https://docs.aws.amazon.com/sagemaker/latest/dg/best-practices.html)
+
+**Related examples:**
+
+- [Introduction
+to Amazon SageMaker AI Model Monitor](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_model_monitor/introduction/SageMaker AI-ModelMonitoring.html)
+- [Model
+Monitor Visualization](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_model_monitor/visualization/SageMaker AI-Model-Monitor-Visualize.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops06-bp01.html*
+
+---
+
+# MLOPS06-BP02 Enable model observability and tracking
+
+Establish model monitoring mechanisms to identify and proactively
+avoid inference issues. ML models can degrade in performance over
+time due to drifts. Monitor metrics that are attributed to your
+model's performance. For real time inference endpoints, measure the
+operational health of the underlying compute resources hosting the
+endpoint and the health of endpoint responses. Establish lineage to
+trace hosted models back to versioned inputs and model artifacts for
+analysis.
+
+**Desired outcome:** You can
+continuously monitor your machine learning models in production to
+detect and avoid performance degradation over time. You have
+mechanisms in place to track model lineage, identify various types
+of drift, and receive alerts when models deviate from expected
+behavior. Your monitoring solution provides clear visibility into
+both the technical health of model endpoints and the business
+performance of the models themselves, enabling you to maintain
+high-quality predictions and make informed decisions about model
+updates.
+
+**Common anti-patterns:**
+
+- Deploying models without monitoring capabilities.
+- Failing to establish model lineage tracking for audit and
+governance.
+- Not monitoring for data drift or concept drift in production
+models.
+- Ignoring model bias and fairness considerations after
+deployment.
+- Lacking documentation of model information and performance
+metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation.
+- Improved model governance and adherence through comprehensive
+documentation.
+- Enhanced ability to explain model predictions and address bias
+concerns.
+- Reduced operational risk through proactive monitoring of model
+health.
+- Streamlined model updates and improvements based on real-world
+performance data.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model observability is critical for maintaining the reliability,
+fairness, and performance of machine learning systems in
+production. Without proper monitoring mechanisms, ML models can
+silently degrade over time as the data they process begins to
+differ from the data they were trained on, a phenomenon known as
+drift.
+
+You need to implement comprehensive monitoring across several
+dimensions: data quality to check that inputs remain consistent
+with training data, model quality to track performance metrics,
+bias detection to verify fairness, and explainability to
+understand model decisions. Additionally, model lineage tracking
+can trace issues back to specific model versions, training
+datasets, and hyperparameters.
+
+Amazon SageMaker AI provides integrated tools that make implementing
+these monitoring capabilities straightforward. SageMaker AI Model
+Monitor can automatically detect deviations in your model's data
+and performance characteristics, while SageMaker AI Clarify
+identifies bias and explains predictions. By setting up proper
+alerts, you can be notified when issues arise and take corrective
+action before they impact your business.
+
+Documentation is equally important for model governance. SageMaker AI
+Model Cards provide a centralized location to store important
+model information, including performance metrics, intended use
+cases, and potential limitations.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Model
+Monitor**. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automatically monitor the
+quality of your ML models in production. Create baseline
+statistics and constraints during model training, then
+monitor for deviations in production data. Set up the
+following types of monitoring:
+
+Data quality monitoring to detect changes in data
+distributions
+- Model quality monitoring to track accuracy and other
+performance metrics
+- Bias drift monitoring to detect changes in model
+fairness
+- Feature attribution drift monitoring to track changes in
+feature importance
+
+- **Integrate with Amazon CloudWatch**. SageMaker AI Model Monitor automatically
+sends metrics to
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), allowing you to track usage statistics
+for your ML models. Set up CloudWatch dashboards to
+visualize key metrics and create alarms that go off when
+metrics exceed predefined thresholds. Configure
+notifications through Amazon SNS to alert relevant teams
+when issues are detected.
+- **Implement SageMaker AI Model
+Dashboard**. Use the
+[SageMaker AI
+Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) to gain a centralized view of your
+models. From the SageMaker AI console, you can search, view,
+and explore your models in one place. Set up monitors to
+track the performance of models deployed on real-time
+inference endpoints and identify models that violate
+thresholds for data quality, model quality, bias, and
+explainability.
+- **Enable bias detection with SageMaker AI
+Clarify**. Deploy
+[SageMaker AI
+Clarify](https://aws.amazon.com/sagemaker/clarify/) to identify various types of bias that can
+emerge during model training or when the model is in
+production. Configure both pre-training and post-training
+bias metrics to understand how your model's predictions
+affect different segments of your user base. Use Clarify's
+monitoring capabilities to detect bias drift in production
+models.
+- **Implement model
+explainability**. Configure SageMaker AI Clarify's
+feature attribution capabilities to explain how your models
+make predictions. This builds trust with stakeholders and
+can identify potential issues with model logic. Set up
+monitoring to detect when feature attribution patterns drift
+from baseline, which could indicate underlying problems with
+the model.
+- **Establish ML lineage
+tracking**. Implement
+[SageMaker AI
+ML Lineage Tracking](https://sagemaker.readthedocs.io/en/v2.77.0/workflows/lineage/) to create and store information
+about each step in your machine learning workflow, from data
+preparation to model deployment. This creates a running
+history of your ML experiments and establishes model
+governance by tracking model lineage artifacts for auditing
+and adherence verification.
+- **Create Model Cards for
+documentation**. Use
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) with enhanced documentation and
+governance capabilities to document critical information
+about your models in a single location. Include business
+requirements, key decisions, observations during
+development, performance goals, risk ratings, and evaluation
+results. This streamlines documentation throughout a model's
+lifecycle and supports approval workflows, registration, and
+audits.
+- **Implement shadow testing for model
+validation**. Before deploying new model versions
+to production, use
+[Amazon SageMaker AI Shadow Testing](https://docs.aws.amazon.com/sagemaker/latest/dg/shadow-tests.html) to compare the performance
+of new models against production models using real-world
+inference request data. Configure SageMaker AI to route copies
+of production inference requests to the new model variant
+and generate dashboards displaying performance differences
+across key metrics in real-time.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html)
+- [Shadow
+tests](https://docs.aws.amazon.com/sagemaker/latest/dg/shadow-tests.html)
+- [Lineage
+Tracking Entities](https://docs.aws.amazon.com/sagemaker/latest/dg/lineage-tracking-entities.html)
+- [Using
+CloudWatch outlier detection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html)
+- [Monitoring
+Amazon ML with Amazon CloudWatch Metrics](https://docs.aws.amazon.com/machine-learning/latest/dg/cw-doc.html)
+- [New
+for Amazon SageMaker AI – Perform Shadow Tests to Compare
+Inference Performance Between ML Model Variants](https://aws.amazon.com/blogs/aws/new-for-amazon-sagemaker-perform-shadow-tests-to-compare-inference-performance-between-ml-model-variants/)
+- [Integrate
+Amazon SageMaker AI Model Cards with the model registr](https://aws.amazon.com/blogs/machine-learning/integrate-amazon-sagemaker-model-cards-with-the-model-registry/)
+- [Improve
+governance of your machine learning models with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/improve-governance-of-your-machine-learning-models-with-amazon-sagemaker/)
+
+**Related examples:**
+
+- [Monitoring
+bias drift and feature attribution drift with Amazon SageMaker AI
+Clarify](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker_model_monitor/fairness_and_explainability/SageMaker AI-Model-Monitor-Fairness-and-Explainability.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlops06-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLPERF01.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLPERF01.md
@@ -1,0 +1,162 @@
+# MLPERF01
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLPERF01-BP01 Determine key performance indicators
+
+Use guidance from business stakeholders to capture key performance
+indicators (KPIs) relevant to the business use case. The KPIs should
+be directly linked to business value to guide acceptable model
+performance. Consider that machine learning inferences are
+probabilistic and will not provide exact results. Identify a minimum
+acceptable accuracy and maximum acceptable error in the KPIs. This
+enables you to achieve the required business value and manage the
+risk of variable results.
+
+**Desired outcome:** By defining
+direct, measurable KPIs, ML initiatives deliver quantifiable
+business outcomes, such as cost savings, expanded scale, and faster
+response times. Clear performance thresholds set realistic
+stakeholder expectations and enable risk management based on the
+probabilistic nature of ML.
+
+**Common anti-patterns:**
+
+- Implementing ML solutions without defining clear
+business-oriented success metrics.
+- Focusing solely on technical metrics (like model accuracy)
+without connecting them to business outcomes.
+- Setting unrealistic expectations for ML performance without
+accounting for probabilistic results.
+- Failing to define acceptable error thresholds for critical
+business processes.
+- Neglecting to quantify the actual business value of ML
+implementations.
+
+**Benefits of establishing this best
+practice:**
+
+- Aligns machine learning (ML) outcomes with business objectives
+for measurable value.
+- Creates clear expectations about model performance that account
+for ML's probabilistic nature.
+- Enables objective evaluation of ML solution success based on
+business impact.
+- Improves prioritization of ML investments based on tangible
+results.
+- Accelerates decision-making by translating ML insights into
+business actions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Start by identifying business challenges ML aims to solve and how
+success translates into specific, quantifiable benefits. Engage
+stakeholders throughout KPI selection to verify that business
+priorities drive metric design. Use metrics that reflect business
+value—such as cost reduction, customer retention rate, or time
+savings—rather than technical measures alone.
+
+Regularly review KPIs to stay aligned with strategic shifts.
+Feedback from business results informs necessary adjustments to
+both models and evaluation metrics. Common pitfalls include
+proceeding without clear business KPIs, focusing only on technical
+metrics such as accuracy, or establishing unrealistic expectations
+that ignore the probabilistic nature of ML results. Failing to set
+acceptable error thresholds exposes critical business processes to
+unmanaged risk, and overlooking the business value of ML adoption
+makes it hard to measure impact or secure stakeholder support.
+
+### Implementation steps
+
+- **Quantify the value of machine
+learning for the business**. Consider measures of
+how machine learning and automation will impact the
+business:
+
+How much will machine learning reduce costs?
+- How many more users will be reached by increasing scale?
+- How much time will the business save by being able to
+respond faster to changes, such as in demand and supply
+disruptions?
+- How many hours of manual effort will be reduced by
+automating with machine learning?
+- How much will machine learning be able to change user
+behavior, such as reducing churn?
+
+- **Evaluate risks and the tolerance for
+error**. Quantify the impact of machine learning on
+the business. Rank order the value of impacts to identify
+the primary KPIs to optimize with machine learning. Define
+the cost of error for automated inferences that will be
+performed by ML models in the use case. Determine the
+tolerance of the business for error. For example, determine
+how far off a cost reduction estimate would have to be to
+negatively impact the business goals. Finally, evaluate the
+risks of machine learning for the business, and whether the
+benefits of ML solutions are of high enough value to
+outweigh those risks.
+- **Establish baseline
+metrics**. Before implementing ML solutions,
+document current performance metrics to create a baseline
+against which to measure improvements. Collect data on
+existing processes, including costs, time requirements,
+error rates, and other relevant performance indicators. This
+baseline will serve as a reference point for demonstrating
+the business value of your ML implementation.
+- **Define predictive and prescriptive
+KPIs**. Move beyond retrospective metrics to
+develop KPIs that offer predictive and prescriptive
+insights. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) and
+[Quick](https://aws.amazon.com/quicksight/) to create dashboards that visualize these
+forward-looking KPIs, making them accessible to business
+stakeholders.
+- **Create a KPI governance
+framework**. Develop a structured approach for
+monitoring, reviewing, and refining your KPIs over time.
+Gather executive alignment on metrics, establish consistent
+data collection processes, and define protocols for taking
+corrective actions when negative trends emerge. Regularly
+analyze trends and periodically refine KPIs to accurately
+gauge the business impact of ML implementations.
+- **Leverage advanced analytics for
+insights**. Enhance KPI discovery and accessibility
+by integrating advanced analytics services, such as
+[Amazon Q](https://aws.amazon.com/q/). These tools uncover hidden business patterns and
+translate complex results into conversational analytics for
+non-technical audiences.
+
+## Resources
+
+**Related documents:**
+
+- [Improve
+Business Outcomes with Machine Learning](https://aws.amazon.com/machine-learning/ml-use-cases/)
+- [AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html)
+- [Machine
+Learning (ML) Governance with Amazon SageMaker AI](https://aws.amazon.com/sagemaker/ai/ml-governance/)
+- [Amazon Q for
+Business Analytics](https://aws.amazon.com/q/)
+- [AI/ML
+| AWS Executive Insights](https://aws.amazon.com/executive-insights/generative-ai-ml/)
+- [Thought
+Leadership | Artificial Intelligence - AWS](https://aws.amazon.com/blogs/machine-learning/category/post-types/thought-leadership/)
+- [Keys
+to maximizing AI value](https://aws.amazon.com/isv/resources/keys-to-maximizing-generative-ai-value-in-software-companies/)
+
+**Related videos:**
+
+- [How
+to Drive Business Value with AI/ML](https://www.youtube.com/watch?v=W4Xd8mPqqKU)
+- [Creating
+Business Value with AWS AI/ML](https://www.youtube.com/watch?v=A2bIIznG-80)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf01-bp01.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLPERF02.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLPERF02.md
@@ -1,0 +1,420 @@
+# MLPERF02
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLPERF02-BP01 Define relevant evaluation metrics
+
+Establishing clear, meaningful evaluation metrics is essential for
+validating machine learning model performance against business
+objectives. By selecting metrics that directly relate to your key
+performance indicators (KPIs), you can verify that your ML solutions
+deliver measurable business value.
+
+**Desired outcome:** You have a
+comprehensive set of evaluation metrics that accurately reflect your
+business requirements and tolerance for errors. These metrics enable
+you to tune your models directly to business objectives, monitor
+performance in production, and make data-driven decisions about
+model improvements.
+
+**Common anti-patterns:**
+
+- Using the same generic metrics for each model type regardless of
+business context.
+- Focusing only on technical metrics without considering business
+impact.
+- Overlooking the cost implications of different types of errors
+(false positives and false negatives).
+- Failing to establish baseline performance metrics before
+deployment.
+- Neglecting continuous monitoring of metrics after model
+deployment.
+
+**Benefits of establishing this best
+practice:**
+
+- Alignment of ML models with business goals and objectives.
+- Better decision-making through quantifiable performance
+measurement.
+- Early detection of model degradation or concept drift.
+- Improved ROI from ML investments.
+- Clearer communication between technical teams and business
+stakeholders.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When developing machine learning solutions, establish evaluation
+metrics that directly connect to your business objectives. These
+metrics must reflect how well your model performs in the context
+of your specific use case rather than relying solely on generic
+technical measures.
+
+Avoid focusing only on technical metrics without considering
+business impact. Many organizations use the same metrics for each
+model type regardless of business context, overlook the cost
+implications of different types of errors, fail to establish
+baseline performance metrics before deployment, and neglect
+continuous monitoring after deployment.
+
+For example, in a predictive maintenance scenario, the business
+impact of false positives (unnecessarily replacing functioning
+equipment) differs from false negatives (missing actual failures).
+Understand these business implications to select appropriate
+metrics like precision (minimizing false positives) or recall
+(minimizing false negatives) based on which error type is more
+costly to your business.
+
+Different ML problem types require different evaluation
+approaches. Classification models benefit from confusion matrices
+that break down performance by class, while regression models need
+error measurements that quantify prediction deviations. Custom
+metrics can be developed when standard metrics don't adequately
+capture business requirements.
+
+Continuous monitoring of these metrics in production is crucial
+for detecting model drift and improving ongoing performance.
+Setting up automated alerts when metrics fall below thresholds
+allows for timely intervention and model updates.
+
+### Implementation steps
+
+- **Align metrics to business
+objectives**. Begin by clearly understanding the
+KPIs established during the business goal identification
+phase. Determine how ML model performance directly impacts
+these KPIs and identify which types of errors are most
+costly to the business. For example, in fraud detection,
+false negatives (missed fraudulent transactions) may be more
+costly than false positives.
+- **Select appropriate evaluation
+metrics**. Choose metrics based on your ML problem
+type:
+
+**For classification
+problems:** Implement confusion matrix
+derivatives (precision, recall, accuracy, F1 score),
+AUC, or log-loss as appropriate for your use case
+- **For regression
+problems:** Utilize RMSE, MAPE, or other error
+measures that align with business sensitivity to
+prediction errors
+- **For recommendation
+systems:** Consider metrics like Normalized
+Discounted Cumulative Gain (NDCG) or precision@k
+- **For time series
+forecasting:** Apply metrics like Mean Absolute
+Scaled Error (MASE) or symmetric Mean Absolute
+Percentage Error (sMAPE)
+
+- **Develop custom metrics if
+needed**. When standard metrics don't adequately
+capture business requirements, create custom evaluation
+metrics that better reflect the business objectives. Use
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to implement these custom metrics during
+model training and evaluation.
+- **Establish performance
+thresholds**. Calculate the maximum acceptable
+error probability required for the ML model based on
+business tolerance levels. Document these thresholds as
+acceptance criteria for model deployment.
+- **Implement comparative
+experimentation**. Use
+[Amazon SageMaker AI Managed MLFlow 3.0](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to organize, track, and
+compare different models trained with various
+hyperparameters and approaches. The enhanced MLFlow
+integration provides robust experiment management at scale
+for complex ML projects. This structured experimentation
+identifies models that optimize your selected metrics within
+acceptable bounds.
+- **Monitor metrics in
+production**. Deploy
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to track model and concept
+drift in real time. Configure alerts when metrics deviate
+from expected performance thresholds, enabling prompt
+remediation actions.
+- **Incorporate feedback
+loops**. Establish mechanisms to collect real-world
+performance data and incorporate it into your evaluation
+process. This feedback assists you to refine metrics and
+models over time to better align with evolving business
+needs.
+- **Balance competing
+metrics**. When multiple metrics are relevant,
+establish a weighting system that reflects their relative
+importance to business outcomes. Document this
+decision-making framework for consistency in model
+evaluation.
+- **Implement bias detection and model
+explainability**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) to detect bias in your models and
+provide explanations for model predictions. Your evaluation
+framework should include fairness and interpretability
+considerations alongside performance metrics.
+- **Establish automated model evaluation
+pipelines**. Create automated evaluation workflows
+that run consistently across different model versions and
+training iterations. Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) to standardize your evaluation processes
+and provide reproducible results.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon CloudWatch Metrics for Monitoring and Analyzing Training
+Jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/training-metrics.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Evaluate,
+explain, and detect bias in models](https://docs.aws.amazon.com/sagemaker/latest/dg/model-explainability.html)
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+
+**Related videos:**
+
+- [Organize,
+Track, and Evaluate ML Training Runs with Amazon SageMaker AI
+Managed MLFlow](https://www.youtube.com/watch?v=zLOMYKZGxK0)
+- [Foundation
+model evaluation with SageMaker AI Clarify](https://aws.amazon.com/awstv/watch/31248d9d747/)
+- [How
+to efficiently manage ML and Gen AI experiments](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+
+**Related examples:**
+
+- [Scikit-Learn
+Data Processing and Model Evaluation](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_processing/scikit_learn_data_processing_and_model_evaluation)
+- [Amazon SageMaker AI Model Monitor Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf02-bp01.html*
+
+---
+
+# MLPERF02-BP02 Use purpose-built AI and ML services and resources
+
+Consider how the workload could be handled by pre-built AI services
+or ML resources. Better performance can often be delivered more
+efficiently by using pre-optimized components included in AI and ML
+managed services. Select an optimal mix of bespoke and pre-built
+components to meet the workload requirements.
+
+**Desired outcome:** You achieve a
+balanced approach to your machine learning workloads by implementing
+purpose-built AI and ML services and resources. You leverage
+pre-built components where appropriate to accelerate development,
+reduce management overhead, and improve performance while
+maintaining the flexibility to create custom solutions where your
+business needs demand it. This approach optimizes both your team's
+productivity and the overall effectiveness of your AI/ML solutions.
+
+**Common anti-patterns:**
+
+- Building ML components from scratch when suitable pre-built
+solutions exist.
+- Failing to evaluate the full range of AWS AI and ML services
+before starting development.
+- Over-customizing solutions when standard services would
+adequately meet requirements.
+- Underutilizing AWS marketplace solutions and pre-trained models.
+- Not considering hybrid approaches that combine managed services
+with custom ML models.
+
+**Benefits of establishing this best
+practice:**
+
+- Accelerated time-to-market for ML solutions.
+- Reduced operational overhead for maintaining ML infrastructure.
+- Lower development costs through leveraging pre-built components.
+- Access to continuously improved and updated AI technologies.
+- Ability to focus resources on high-value business
+differentiators.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Implement purpose-built AI and ML services to focus on business
+outcomes rather than infrastructure management. AWS provides a
+comprehensive portfolio of AI services, ranging from ready-to-use
+APIs to fully customizable ML solutions. Each service addresses
+different levels of complexity and customization requirements.
+
+When evaluating your ML workloads, assess which components could
+benefit from managed services. Tasks like image classification,
+regression, clustering, or time series forecasting can often be
+accomplished with
+[SageMaker AI
+built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) without requiring custom algorithm
+development. For more specialized needs, you can leverage
+pre-trained models through services like
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) or develop custom models using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/).
+
+Resist the temptation to over-customize solutions when standard
+services would adequately meet requirements. Organizations often
+underutilize AWS marketplace solutions and pre-trained models,
+missing opportunities to accelerate development. The key is
+finding the right balance between using managed services for
+common ML tasks and building custom solutions for your unique
+business requirements. Consider hybrid approaches that combine
+managed services with custom ML models rather than pursuing an
+all-or-nothing strategy.
+
+Consider your team's capabilities when making these decisions. If
+you lack specialized ML expertise, starting with fully managed AI
+services provides immediate value while your team builds skills.
+As your team's capabilities grow, you can selectively add custom
+components where they provide strategic advantage.
+
+### Implementation steps
+
+- **Assess your ML use cases and
+requirements**. Begin by clearly defining your
+business use cases and understanding the ML capabilities
+needed. Evaluate whether your requirements can be met by
+pre-built services or require custom development. Consider
+factors like accuracy requirements, latency needs, and the
+availability of training data.
+- **Learn about AWS managed AI
+services**. Determine whether
+[AWS managed AI services](https://aws.amazon.com/machine-learning/ai-services/) are applicable to the business
+use case. Understand how managed AWS AI services can relieve
+the burden of training and maintaining an ML pipeline. Use
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to develop in the cloud and understand the
+roles and responsibilities needed to maintain the ML
+workload. Consider combining managed AI services with custom
+ML models built on Amazon SageMaker AI.
+- **Explore SageMaker AI built-in
+algorithms and automated ML capabilities**. Learn
+about
+[SageMaker AI
+built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) for supervised learning tasks
+like classification, regression, and forecasting. Consider
+[SageMaker AI
+Autopilot](https://docs.aws.amazon.com/sagemaker/latest/dg/autopilot-automate-model-development.html) for automated machine learning that handles
+data analysis, feature engineering, algorithm selection, and
+hyperparameter tuning. Explore
+[Amazon SageMaker AI JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) for pre-trained models across
+various ML domains, including
+[foundation
+models](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-foundation-models.html) that can be fine-tuned for your specific ML
+tasks. For enterprise environments, implement
+[SageMaker AI
+JumpStart Private Model Hubs](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html) to create curated
+repositories of both prebuilt and custom models with
+centralized governance and version management.
+- **Investigate marketplace
+solutions**. Learn about
+[SageMaker AI
+Algorithms and Models in AWS Marketplace](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-marketplace.html), a curated
+digital catalog that makes it simple for you to find, buy,
+deploy, and manage third-party software and services.
+Explore specialized algorithms or pre-trained models that
+might be relevant to your use case.
+- **Implement a hybrid approach where
+appropriate**. Design your ML architecture to
+leverage the most suitable services for each component. Use
+AWS managed services for standard ML tasks and focus custom
+development on business differentiators. This balanced
+approach optimizes both development efficiency and solution
+effectiveness.
+- **Establish a model evaluation
+framework**. Create a systematic process for
+evaluating pre-built models against your requirements.
+Define clear metrics for accuracy, latency, cost, and other
+relevant factors. Use this framework to make data-driven
+decisions about which components to build versus buy.
+- **Plan for operational
+integration**. Verify that your chosen ML services
+can integrate effectively with your existing systems and
+workflows. Design appropriate data pipelines, APIs, and
+monitoring systems to support your hybrid ML architecture.
+For development flexibility, leverage remote IDE
+connectivity to securely connect third-party developer
+environments such as VS Code to SageMaker AI Studio, enabling
+professional MLOps workflows while maintaining centralized
+governance. Consider security, regulatory adherence, and
+governance requirements when implementing these
+integrations.
+- **Optimize model performance and
+deployment**. Use
+[SageMaker AI
+model optimization](https://docs.aws.amazon.com/sagemaker/latest/dg/model-optimize.html) capabilities including
+quantization, compilation, and speculative decoding to
+improve inference performance. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to automatically benchmark and
+select optimal instance types, configurations, and
+parameters for your inference endpoints. Deploy using
+[SageMaker AI
+deployment options](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html) such as real-time hosting,
+serverless inference, or batch transform based on your
+latency and throughput requirements.
+- **Implement model monitoring and
+governance**. Establish monitoring for model
+performance, data drift, and model drift using
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html). Implement proper model versioning, A/B
+testing capabilities, and rollback procedures to maintain
+model quality and reliability in production environments.
+
+## Resources
+
+**Related documents:**
+
+- [Built-in
+algorithms and pretrained models in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html)
+- [SageMaker AI
+JumpStart Foundation Models](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-foundation-models.html)
+- [Private
+curated hubs for foundation model access control in
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html)
+- [Best
+practices for deploying models on SageMaker AI Hosting
+Services](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html)
+- [Inference
+optimization for Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/model-optimize.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Model
+deployment options in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html)
+- [Distributed
+training optimization](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training-optimize.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Machine
+Learning on AWS](https://aws.amazon.com/machine-learning/)
+- [Architecture
+Best Practices for Machine Learning](https://aws.amazon.com/architecture/machine-learning/)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [SageMaker AI
+Algorithms and Models in AWS Marketplace](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-marketplace.html)
+- [Docker
+containers for training and deploying models](https://docs.aws.amazon.com/sagemaker/latest/dg/docker-containers.html)
+- [Train
+a Model with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html)
+
+**Related videos:**
+
+- [Building
+and Deploying ML Models Fast with Amazon SageMaker AI
+JumpStart](https://www.youtube.com/watch?v=i4W7SfP6_38)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf02-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLPERF03.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLPERF03.md
@@ -1,0 +1,231 @@
+# MLPERF03
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLPERF03-BP01 Use a modern data architecture
+
+Get the best insights from exponentially growing data using a modern
+data architecture. This architecture enables movement of data
+between a data lake and purpose-built stores including a data
+warehouse, relational databases, non-relational databases, ML and
+big data processing, and log analytics. A data lake provides a
+single place to run analytics across mixed data structures collected
+from disparate sources. Purpose-built analytics services provide the
+speed required for specific use cases like real-time dashboards and
+log analytics.
+
+**Desired outcome:** You implement a
+modern data architecture that enables seamless data movement between
+storage systems, provides unified governance, and supports diverse
+ML workloads. This architecture accelerates data preparation,
+improves data quality, and enables efficient feature engineering for
+machine learning models.
+
+**Common anti-patterns:**
+
+- Creating isolated data silos where different teams manage
+separate data stores without coordination.
+- Building data architecture without establishing proper
+governance, access controls, or compliance-aligned frameworks.
+- Using one-size-fits-all storage solutions without considering
+specific workload requirements.
+- Relying on manual processes for data movement, transformation,
+and quality checks.
+- Neglecting to implement proper data cataloging and discovery
+mechanisms.
+
+**Benefits of establishing this best
+practice:**
+
+- Unified data governance and access control across data stores.
+- Reduced data preparation time through integrated data services.
+- Improved data quality and consistency for ML model training.
+- Enhanced scalability for growing data volumes and ML workloads.
+- Better cost optimization through purpose-built storage
+solutions.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When building machine learning solutions, you need a modern data
+architecture that can handle diverse data types, support various
+ML workloads, and provide unified governance across data stores.
+This architecture enables efficient data movement between storage
+systems while maintaining security, quality, and cost
+optimization.
+
+Avoid creating isolated data silos where different teams manage
+separate data stores without coordination. Many organizations
+struggle with inconsistent data governance policies across
+different storage systems, lack unified access controls for ML
+teams, fail to implement proper data cataloging and discovery
+mechanisms, and neglect to optimize storage costs based on access
+patterns. These issues create bottlenecks in ML workflows and
+increase operational complexity.
+
+For example, in a retail ML use case, you might need to combine
+customer transaction data from a data warehouse, real-time
+clickstream data from streaming services, and product catalog
+information from operational databases. A modern data architecture
+enables seamless access to these data sources while maintaining
+consistent security policies and enabling efficient feature
+engineering for recommendation models.
+
+Different ML workloads require different data access patterns.
+Batch training jobs benefit from optimized data lake storage with
+efficient querying capabilities, while real-time inference
+requires low-latency access to feature stores and streaming data
+pipelines. Custom data processing workflows can be developed when
+standard ETL processes don't adequately support your specific ML
+requirements.
+
+Continuous monitoring of data quality and pipeline performance is
+crucial for maintaining reliable ML systems. Setting up automated
+data quality checks and pipeline monitoring allows for early
+detection of data issues that could impact model performance.
+
+### Implementation steps
+
+- **Design your data lake
+foundation**. Begin by establishing a centralized
+data lake using
+[Amazon S3](https://aws.amazon.com/s3/) as the primary storage layer. Organize data using
+a logical structure that supports both current and future ML
+use cases, such as organizing by business domain, data
+source, and processing stage. Implement data partitioning
+strategies based on common query patterns to optimize
+performance and reduce costs. For example, partition
+time-series data by date and customer data by region to
+enable efficient querying for ML feature extraction.
+- **Implement unified data
+governance**. Use
+[AWS Lake Formation](https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html) to build a scalable and secure data
+lake with centralized governance. Establish consistent
+security policies, access controls, and audit trails across
+data stores. Apply fine-grained permissions that enable
+self-service access for ML practitioners while maintaining
+security and and addressing requirements. Create data
+stewardship roles and processes to improve ongoing data
+quality and governance.
+- **Integrate purpose-built analytics
+services**. Build a high-speed analytic layer with
+purpose-built services selected based on your specific ML
+workload requirements:
+
+Use
+[Amazon Redshift](https://aws.amazon.com/redshift/) for data warehousing and complex
+analytical queries
+- Implement
+[Amazon Kinesis](https://aws.amazon.com/kinesis/) for real-time streaming data processing
+- Deploy
+[Amazon Athena](https://aws.amazon.com/athena/) for interactive queries and ad-hoc
+analysis
+- Consider
+[Amazon DynamoDB](https://aws.amazon.com/dynamodb/) for high-performance operational
+workloads
+- Use
+[Amazon Timestream](https://aws.amazon.com/timestream/) for time-series data applications
+
+- **Enable seamless data
+integration**. Use
+[AWS Glue](https://aws.amazon.com/glue/) to integrate data across services and data
+stores. Implement automated data cataloging to maintain
+metadata and enable data discovery across your organization.
+Create ETL pipelines that prepare data for ML workloads
+while maintaining data lineage and enabling reproducibility.
+Design workflows that can handle both batch and streaming
+data processing requirements.
+- **Optimize for ML
+workloads**. Design data pipelines that support
+both batch and real-time ML training scenarios. Implement
+feature stores using services like
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to manage and share ML
+features across teams and models. Create standardized
+feature engineering processes that can be reused across
+different ML projects and provide consistent data
+transformations.
+- **Establish data quality
+monitoring**. Implement automated data quality
+checks and monitoring for data reliability for ML models.
+Use
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) for data profiling and quality
+assessment. Set up automated alerts for data quality issues
+such as missing values, schema changes, or statistical
+anomalies that could impact ML model performance.
+- **Implement cost optimization
+strategies**. Use appropriate storage classes in
+Amazon S3 based on data access patterns. Implement lifecycle
+policies to automatically transition data to lower-cost
+storage tiers such as S3 Infrequent Access or Amazon Glacier for
+archival data. Monitor and optimize query performance to
+control compute costs, and use reserved capacity where
+appropriate for predictable workloads.
+- **Enable real-time data
+processing**. For ML use cases requiring real-time
+inference, implement streaming data pipelines using Amazon Kinesis and
+[AWS Lambda](https://aws.amazon.com/lambda/) to process data as it arrives and update
+feature stores in near real-time. Design architectures that
+can handle varying data volumes and provide consistent
+low-latency access to features for real-time ML predictions.
+- **Implement data lineage and
+versioning**. Establish comprehensive data lineage
+tracking to understand data flow from source to ML models.
+Use versioning for both datasets and feature definitions to
+enable reproducible ML experiments and model rollbacks when
+necessary. This is crucial for improving regulatory
+adherence and debugging ML model issues.
+- **Create self-service data
+access**. Build data catalogs and discovery tools
+that enable ML practitioners to find and access relevant
+data without requiring deep technical knowledge of the
+underlying storage systems. Implement standardized APIs and
+interfaces that abstract the complexity of the data
+architecture while providing the flexibility needed for
+diverse ML workloads.
+
+## Resources
+
+**Related documents:**
+
+- [The
+lakehouse architecture of Amazon SageMaker AI](https://aws.amazon.com/sagemaker/lakehouse/)
+- [Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/)
+- [What
+is AWS Lake Formation?](https://docs.aws.amazon.com/lake-formation/latest/dg/what-is-lake-formation.html)
+- [AWS Lake Formation: How it works](https://docs.aws.amazon.com/lake-formation/latest/dg/how-it-works.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [What
+is AWS Glue?](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html)
+- [Modern
+Data Architecture on AWS](https://aws.amazon.com/big-data/datalakes-and-analytics/data-lake-house/)
+- [Amazon SageMaker AI Lakehouse | AWS Big Data
+Blog](https://aws.amazon.com/blogs/big-data/category/analytics/amazon-sagemaker-lakehouse/)moving-from-notebooks-to-automated-ml-pipelines-using-amazon-sagemaker-and-aws-glue/)
+- [Amazon SageMaker AI | AWS Big Data Blog](https://aws.amazon.com/blogs/big-data/category/artificial-intelligence/sagemaker/)
+
+**Related videos:**
+
+- [Understanding
+Amazon S3 Tables: Architecture, performance, and
+integration](https://www.youtube.com/watch?v=e1ypMWSHgsM)
+- [Accelerate
+your Analytics and AI with Amazon SageMaker AI LakeHouse](https://www.youtube.com/watch?v=qZTbS0xPN-U)
+- [Unifying
+data governance with Immuta and AWS Lake Formation](https://www.youtube.com/watch?v=X09-n2jJZKw)
+- [The
+lake house approach to data warehousing with Amazon Redshift](https://www.youtube.com/watch?v=35wXL0Q1Dcc)
+
+**Related services:**
+
+- [AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/)
+- [Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/data-streams/)
+- [Amazon Athena](https://aws.amazon.com/athena/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf03-bp01.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLPERF04.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLPERF04.md
@@ -1,0 +1,1041 @@
+# MLPERF04
+
+**Pillar**: Unknown  
+**Best Practices**: 6
+
+---
+
+# MLPERF04-BP01 Optimize training and inference instance types
+
+Selecting appropriate instance types for training and inference
+workloads provides optimal performance, reduced costs, and faster
+time-to-market for your machine learning models. By understanding
+your model's specific requirements and data characteristics, you can
+choose the right computational resources to maximize efficiency.
+
+**Desired outcome:** You achieve
+optimal performance and cost-effectiveness for your machine learning
+workloads by selecting appropriate instance types for both training
+and inference. You understand how model complexity and data
+characteristics influence hardware decisions, enabling you to
+accelerate model development, improve inference speeds, and manage
+resources efficiently.
+
+**Common anti-patterns:**
+
+- Using the same instance type for both training and inference
+workloads.
+- Overprovisioning resources just to be safe without performance
+testing.
+- Selecting expensive GPU instances for inference when CPU
+instances would suffice.
+- Ignoring model-specific hardware requirements when selecting
+instances.
+- Not scaling training across multiple instances for large
+datasets.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced training time and faster model iterations.
+- Lower operational costs through right-sized resources.
+- Improved inference latency and throughput.
+- Better utilization of available computational resources.
+- Enhanced scalability for varying workloads.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Understanding how your model type and data characteristics
+influence instance selection is essential for optimizing machine
+learning workloads. For training, the computational requirements
+depend largely on the model complexity, dataset size, and training
+approach. Deep learning models, particularly those processing
+image, video, or language data, often benefit from GPU-accelerated
+instances due to their parallel processing capabilities.
+Meanwhile, traditional machine learning algorithms may be
+efficiently trained on CPU instances.
+
+For inference, requirements vary based on deployment scenarios.
+Real-time applications with strict latency requirements might need
+powerful compute-optimized instances, while batch prediction
+workloads can use more cost-effective options. Generally, CPUs are
+sufficient for many inference scenarios, though complex models may
+still benefit from GPU acceleration.
+
+When evaluating instance options, consider memory requirements
+(especially for large models or datasets), network performance for
+distributed training, and storage I/O capabilities when working
+with large datasets. The right balance between performance and
+cost is key to sustainable machine learning operations.
+
+### Implementation steps
+
+- **Analyze your model and data
+requirements**. Begin by understanding the
+computational needs of your machine learning algorithm.
+Assess memory requirements, model complexity, and dataset
+size. For deep learning models processing image, video, or
+language data, GPU instances like P4, G4, or P3 typically
+offer the best performance. For traditional ML algorithms,
+CPU instances may be more cost-effective.
+- **Benchmark different instance types
+for training**. Run small-scale training jobs
+across various instance types in
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to measure performance and cost metrics.
+Compare training times, resource utilization, and overall
+costs to identify the optimal instance type for your model.
+Track
+[Experiments
+with Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to track and compare results.
+- **Implement distributed training for
+large datasets**. For large datasets or complex
+models, leverage distributed training across multiple
+instances to reduce training time. Use
+[SageMaker AI
+distributed training libraries](https://docs.aws.amazon.com/sagemaker/latest/dg/distributed-training.html) to automatically
+partition data and optimize communication between nodes,
+which accelerates training for deep learning models.
+- **Optimize storage configuration for
+I/O performance**. Configure fast storage options
+to avoid I/O bottlenecks during training. Consider using
+[Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) for high-performance file systems or
+optimize your data pipeline to use
+[Amazon S3](https://aws.amazon.com/s3/) efficiently. Proper data formatting and efficient
+loading strategies can improve GPU utilization.
+- **Select appropriate inference
+instance types**. Evaluate latency and throughput
+requirements for your inference needs. For real-time
+inference with strict latency requirements, consider
+compute-optimized instances or GPU-accelerated instances for
+complex models. For batch inference, less expensive CPU
+instances often suffice. Use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to get automated
+recommendations for optimal deployment configurations.
+- **Monitor and optimize
+costs**. Implement continuous monitoring of
+resource utilization and costs. Use
+[AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and
+[SageMaker AI
+Studio](https://aws.amazon.com/sagemaker/studio/) resource monitoring to identify
+inefficiencies. Consider using
+[Amazon SageMaker AI Savings Plans](https://aws.amazon.com/savingsplans/ml-pricing/) for frequently used instance
+types to reduce costs.
+- **Consider model optimization
+techniques**. Implement model optimization
+techniques like quantization, pruning, or knowledge
+distillation to reduce computational requirements for both
+training and inference. Explore using
+[SageMaker AI
+Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize models for target
+hardware.
+- **Explore serverless inference
+options**. For variable or unpredictable workloads,
+consider
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) to automatically scale
+resources based on traffic and avoid the need to choose
+instance types manually.
+- **Leverage specialized ML
+hardware**. For large-scale training and inference
+workloads, consider
+[AWS Trainium instances](https://docs.aws.amazon.com/dlami/latest/devguide/trainium.html) for training and AWS Inferentia
+instances for inference to achieve better price-performance
+ratios compared to traditional GPU instances.
+
+## Resources
+
+**Related documents:**
+
+- [Train
+a Model with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html)
+- [Deploy
+models for inference](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-model.html)
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Recommended
+Trainium Instances](https://docs.aws.amazon.com/dlami/latest/devguide/trainium.html)
+- [What
+are AWS Deep Learning Containers?](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html)
+- [Learn
+how to select ML instances on the fly in Amazon SageMaker AI
+Studio](https://aws.amazon.com/blogs/machine-learning/learn-how-to-select-ml-instances-on-the-fly-in-amazon-sagemaker-studio/)
+- [Ensure
+efficient compute resources on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/right-sizing-resources-and-avoiding-unnecessary-costs-in-amazon-sagemaker/)
+
+**Related videos:**
+
+- [How
+to choose the right instance type for ML inference](https://www.youtube.com/watch?v=0DSgXTN7ehg)
+- [The
+right instance type in Amazon SageMaker AI](https://www.youtube.com/watch?v=vRB9Uncsia8)
+
+**Related examples:**
+
+- [Amazon SageMaker AI End-to-End Example](https://github.com/aws/amazon-sagemaker-examples/tree/main/end_to_end)
+- [SageMaker AI
+Inference Recommender Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-inference-recommender)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp01.html*
+
+---
+
+# MLPERF04-BP02 Explore alternatives for performance improvement
+
+Benchmarking your machine learning models allows you to
+systematically improve performance by evaluating and comparing
+different algorithms, features, and architectural resources. Use
+this practice to identify the optimal combination and achieve your
+desired performance metrics.
+
+**Desired outcome:** You implement a
+systematic approach to improving your machine learning model's
+performance through benchmarking various techniques. You'll
+establish a baseline model and methodically explore alternatives
+including data volume increases, feature engineering, algorithm
+selection, ensemble methods, and hyperparameter tuning. This results
+in optimized models that provide higher accuracy and better business
+value.
+
+**Common anti-patterns:**
+
+- Selecting a complex algorithm without establishing a baseline.
+- Ignoring feature engineering in favor of only trying different
+algorithms.
+- Using more data without understanding its quality or relevance.
+- Focusing exclusively on accuracy while ignoring other important
+metrics.
+- Manually testing hyperparameters without a systematic approach.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model accuracy and performance.
+- Better understanding of which factors most influence model
+performance.
+- More efficient use of computational resources.
+- Systematic approach to model improvement instead of random
+experimentation.
+- Ability to document and reproduce experiments for future
+reference.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Performance improvement in machine learning requires a structured,
+iterative approach. Benchmarking assists you in systematically
+comparing different approaches and determining the most effective
+path to improved model performance. Start by establishing a
+baseline with simple algorithms and obvious features, then
+methodically explore alternatives to improve upon that baseline.
+
+You can explore multiple avenues for improving performance:
+increasing data volume, engineering better features, selecting
+more appropriate algorithms, combining models through ensemble
+methods, and tuning hyperparameters. Each approach provides unique
+benefits and may be more or less effective depending on your use
+case. The key is to follow a systematic process, measure results
+accurately, and document what you learn.
+
+### Implementation steps
+
+- **Establish a baseline
+model**. Start with a simple architecture, obvious
+features, and a straightforward algorithm to create your
+baseline. Use
+[Amazon SageMaker AI built-in algorithms](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html) to quickly develop this
+initial model. This gives you a reference point for
+comparing future experiments and improvements.
+- **Set up experiment
+tracking**. Use
+[Amazon SageMaker AI Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to organize, track, compare,
+and evaluate your machine learning experiments. Create a
+structured framework that tracks performance metrics,
+algorithm choices, features used, and hyperparameter
+settings so you can effectively compare results across
+different approaches.
+- **Test different
+algorithms**. Systematically test various
+algorithms, starting with simpler ones and progressively
+trying more complex options. SageMaker AI provides many
+built-in algorithms that you can compare. Document how each
+algorithm performs relative to your baseline and identify
+which ones show the most promise for your data and problem.
+- **Apply feature
+engineering**. Extract important signals in your
+data through feature engineering. This may include feature
+selection, transformation, creation of new features,
+normalization, and encoding techniques. Use
+[SageMaker AI
+Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-create-feature-group.html) to manage and share features across
+experiments and teams.
+- **Increase data volume and
+quality**. Evaluate whether adding more data or
+improving data quality could assist your model. More data
+often broadens the statistical range and improve model
+performance, but only if the additional data is relevant and
+of good quality.
+- **Implement ensemble
+methods**. Combine multiple models to leverage
+different strengths and compensate for individual
+weaknesses. Techniques like bagging, boosting, and stacking
+can often improve overall accuracy. SageMaker AI makes it
+simple to implement ensemble predictions from multiple
+models.
+- **Perform hyperparameter
+tuning**. Use
+[Amazon SageMaker AI Automatic Model Tuning](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html) to optimize your
+model's hyperparameters. This service automates the search
+through different hyperparameter combinations to find
+optimal values that improve model performance. You can run
+multiple HPO jobs in parallel to speed up the process.
+- **Evaluate improvements
+systematically**. For each change, rigorously
+evaluate whether performance has improved based on relevant
+metrics for your problem. Use SageMaker AI's evaluation tools
+to compare results across experiments and determine which
+approaches deliver the most gains.
+- **Optimize for production**.
+Once you've identified the best performing approach,
+optimize it for production deployment. Consider factors like
+inference latency, model size, and resource requirements
+alongside pure performance metrics.
+- **Document findings and
+methodology**. Create comprehensive documentation
+of your benchmarking process, including what worked, what
+didn't, and why. This provides valuable information for
+future model improvements and builds institutional
+knowledge.
+
+## Resources
+
+**Related documents:**
+
+- [Built-in
+algorithms and pretrained models in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/algos.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [Use
+Feature Store with SDK for Python (Boto3)](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-create-feature-group.html)
+- [Feature
+Processing with Spark ML and Scikit-learn](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-mleap-scikit-learn-containers.html)
+- [Running
+multiple HPO jobs in parallel on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/running-multiple-hpo-jobs-in-parallel-on-amazon-sagemaker/)
+- [Optimizing
+portfolio value with Amazon SageMaker AI automatic model
+tuning](https://aws.amazon.com/blogs/machine-learning/optimizing-portfolio-value-with-amazon-sagemaker-automatic-model-tuning/)
+
+**Related videos:**
+
+- [How
+To Efficiently Manage ML experiments using Amazon SageMaker AI ML
+Flow](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+- [Train
+large models on Amazon SageMaker AI for scale and
+performance](https://www.youtube.com/watch?v=cryA1LFwS98)
+
+**Related examples:**
+
+- [Feature
+Engineering Immersion Day Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab1-feature-engineering)
+- [Ensemble
+Predictions From Multiple Models](https://sagemaker-examples.readthedocs.io/en/latest/introduction_to_applying_machine_learning/ensemble_modeling/EnsembleLearnerCensusIncome.html)
+- [Amazon SageMaker AI Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp02.html*
+
+---
+
+# MLPERF04-BP03 Establish a model performance evaluation pipeline
+
+Establish an end-to-end model performance evaluation pipeline that
+captures key metrics to evaluate your model's success, align with
+business KPIs, and automatically test performance when models or
+data are updated.
+
+**Desired outcome:** You can
+systematically evaluate model performance through automated
+pipelines that measure relevant metrics specific to your use case.
+Your evaluation process runs automatically whenever model or data
+updates occur, creating a continuous quality assessment. This
+assists you in maintaining high-performing models that deliver
+business value while providing transparency into model behavior and
+performance over time.
+
+**Common anti-patterns:**
+
+- Relying solely on training accuracy without considering
+real-world performance metrics.
+- Manual evaluation of models that leads to inconsistency.
+- Using generic metrics that don't align with business KPIs.
+- Waiting until deployment to evaluate model performance.
+- Not establishing automated evaluation triggers when models or
+data change.
+
+**Benefits of establishing this best
+practice:**
+
+- Verifies that models maintain expected performance levels over
+time.
+- Provides data-driven decision making for model selection and
+deployment.
+- Aligns machine learning outcomes with business objectives.
+- Enables faster identification and resolution of performance
+degradation.
+- Improves regulatory adherence through consistent evaluation
+protocols.
+- Increases stakeholder confidence through transparent performance
+reporting.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model performance evaluation is critical to verify that your
+machine learning solutions deliver on their intended business
+outcomes. By establishing a robust, automated evaluation pipeline,
+you can consistently assess how well your models perform against
+business KPIs and make data-driven decisions about deployment
+readiness.
+
+Avoid relying solely on training accuracy without considering
+real-world performance metrics. Many organizations use manual,
+ad-hoc evaluation of models that leads to inconsistency, use
+generic metrics that don't align with business KPIs, wait until
+deployment to evaluate model performance, and fail to establish
+automated evaluation runs when models or data change.
+
+Your evaluation pipeline should incorporate metrics specific to
+your use case. For regression problems, this might include Root
+Mean Squared Error (RMSE). For classification tasks, accuracy,
+precision, recall, F1 score, and area under the curve (AUC) are
+common metrics. These technical metrics should tie directly to
+business KPIs, helping stakeholders understand the model's
+contribution to business goals.
+
+Automating the evaluation process provides consistency and reduces
+manual errors. When new data arrives or models are updated, your
+pipeline should automatically run evaluations, providing
+continuous feedback on model performance and enabling rapid
+identification of any degradation issues.
+
+### Implementation steps
+
+- **Define business objectives and
+evaluation criteria**. Begin by clearly defining
+what success means for your machine learning use case.
+Identify relevant business KPIs and determine which
+technical metrics (like accuracy, precision, recall, F1
+score, RMSE, AUC) best align with these business goals.
+Document these metrics and their target values to establish
+clear evaluation criteria.
+- **Create an end-to-end workflow with
+Amazon SageMaker AI Pipelines**. Start with a workflow
+template to establish an initial infrastructure for model
+training and deployment.
+[SageMaker AI
+Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) can automate different steps of the ML
+workflow including data loading, data transformation,
+training, tuning, and deployment. Within SageMaker AI
+Pipelines, the
+[SageMaker AI
+Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) tracks model versions and respective
+artifacts, including metadata and lineage data collected
+throughout the model development lifecycle.
+- **Implement model evaluation
+components in your pipeline**. Design dedicated
+evaluation steps within your pipeline that calculate
+relevant metrics for your model. Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) jobs or custom Python scripts to perform
+evaluations on validation datasets. Store evaluation results
+in a central location for tracking performance over time.
+- **Set up automated prompts for
+evaluation**. Configure your pipeline to
+automatically initiate the evaluation process whenever
+there's a model update or new training data becomes
+available. This provides continuous quality assessment and
+identifies performance degradation early.
+- **Create visualization and reporting
+mechanisms**. Implement dashboards or reports that
+display model performance metrics in a straightforward
+format. Stakeholders can use visualizations to quickly
+assess model performance against business KPIs and make
+informed decisions about model deployment.
+- **Establish model approval
+workflows**. Define criteria for model approval
+based on evaluation results. Implement approval workflows in
+the SageMaker AI Model Registry that automatically promote
+models meeting performance thresholds to production, while
+flagging underperforming models for review.
+- **Implement A/B testing
+capabilities**. For production models, set up A/B
+testing infrastructure to compare performance of new models
+against baseline models using real-world data. This provides
+additional validation before fully deploying model updates.
+- **Monitor production model
+performance**. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously monitor
+deployed models for data drift, model drift, and performance
+degradation. Set up alerts when performance metrics fall
+below acceptable thresholds.
+- **Implement bias detection and
+fairness evaluation**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html) to detect bias in your models and
+check fairness across different demographic groups. Include
+bias metrics as part of your evaluation criteria.
+- **Create feedback loops for continuous
+improvement**. Design mechanisms to capture
+feedback from production model performance and incorporate
+these insights into future model iterations. This creates a
+cycle of continuous improvement based on real-world
+performance.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Define
+a pipeline](https://docs.aws.amazon.com/sagemaker/latest/dg/define-pipeline.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness
+and Explainability with SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html)
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Extend
+Amazon SageMaker AI Pipelines to include custom steps using
+callback steps](https://aws.amazon.com/blogs/machine-learning/extend-amazon-sagemaker-pipelines-to-include-custom-steps-using-callback-steps/)
+
+**Related videos:**
+
+- [Amazon SageMaker AI Pipelines](https://www.youtube.com/watch?v=Hvz2GGU3Z8g)
+- [How
+to create fully automated ML workflows with Amazon SageMaker AI
+Pipelines](https://www.youtube.com/watch?v=W7uabCTfLrg)
+
+**Related examples:**
+
+- [Orchestrate
+your build and train pipeline with SageMaker AI Pipelines](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab6-mlops/pipelines)
+- [SageMaker AI
+Model Evaluation Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-pipelines)
+- [MLOps
+with SageMaker AI Pipelines](https://github.com/aws-samples/amazon-sagemaker-mlops-workshop)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp03.html*
+
+---
+
+# MLPERF04-BP04 Establish feature statistics
+
+Establishing key statistics to measure changes in data that affect
+model outcomes is crucial for maintaining ML model performance. By
+analyzing feature importance and sensitivity, you can select the
+most critical features to monitor and detect when data drifts
+outside acceptable ranges so you can determine when model retraining
+is necessary.
+
+**Desired outcome:** You establish a
+robust monitoring system that tracks key statistics for the most
+influential features in your machine learning models. You can detect
+data drift that could impact model performance, allowing for timely
+model retraining decisions based on quantitative measures rather
+than intuition. Your monitoring system alerts you when important
+features drift outside their expected statistical ranges, providing
+continuous model reliability and performance.
+
+**Common anti-patterns:**
+
+- Monitoring features equally without considering their relative
+importance to model outcomes.
+- Failing to establish baseline statistics for important features
+before deploying models.
+- Not setting appropriate thresholds for data drift alerts.
+- Monitoring only model outputs without analyzing input feature
+distributions.
+- Neglecting to perform sensitivity analysis to understand model
+behavior at decision boundaries.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of data quality issues that could affect model
+performance.
+- Reduced model performance degradation through timely retraining.
+- Greater understanding of which features most impact model
+predictions.
+- Improved model reliability in production environments.
+- Enhanced ability to explain model behavior and decision
+boundaries to stakeholders.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing feature statistics is essential for maintaining model
+performance over time. As real-world data evolves, your model's
+predictive power can deteriorate if the data drift exceeds certain
+thresholds. By focusing on the most influential features and
+understanding your model's sensitivity to changes in these
+features, you can create an effective monitoring strategy.
+
+Start by analyzing which features have the greatest impact on your
+model's predictions through feature importance analysis. Then
+establish baseline statistics for these critical features using
+your training data. Monitor these statistics in production,
+comparing them to your baseline, and set up alerts when deviations
+occur. This approach allows you to proactively address potential
+model performance issues before they impact your business
+outcomes.
+
+### Implementation steps
+
+- **Analyze feature distributions with
+Data Wrangler**. Use
+[Amazon SageMaker AI Data Wrangler](https://docs.aws.amazon.com/sagemaker/latest/dg/data-wrangler-analyses.html) to perform exploratory data
+analysis on your dataset. Examine the distribution of each
+feature, identify outliers, and understand relationships
+between features. Data Wrangler provides visualizations such
+as histograms, scatter plots, and correlation matrices to
+understand your data's characteristics before training.
+- **Train your model with proper
+tracking**. When training your model, capture
+metadata about the training process using
+[SageMaker AI
+Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html). This can establish a baseline for
+comparison and enables reproducibility of your experiments.
+Track key metrics, parameters, and the training dataset
+version to maintain a complete record of model development.
+- **Determine feature
+importance**. After training your model, analyze
+which features have the greatest impact on predictions. Use
+built-in feature importance methods in SageMaker AI, such as
+SHAP (SHapley Additive exPlanations) values or permutation
+importance. Alternatively, use model-specific methods like
+feature importance in tree-based models or coefficient
+magnitudes in linear models.
+- **Perform sensitivity
+analysis**. Map out regions in feature space where
+predictions change abruptly or remain invariant. Focus
+particularly on features near decision boundaries where
+small changes can alter model outputs. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-data-bias.html) to analyze how variations in input
+features affect predictions and understand which features
+require the closest monitoring.
+- **Check for data bias**. Use
+Amazon SageMaker AI Clarify to analyze your dataset for
+potential biases. Imbalances or biases in your training data
+can lead to poor generalization and unfair predictions.
+Identify and address these issues before deploying your
+model to create ethical and reliable ML systems.
+- **Establish monitoring
+baseline**. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to create a baseline from
+your training data. This baseline captures the expected
+statistical properties of your features, including
+distributions, ranges, and relationships. SageMaker AI
+automatically analyzes and creates constraints for each
+feature based on the training data.
+- **Configure data quality
+monitoring**. Set up SageMaker AI Model Monitor to
+continuously evaluate production data against your
+established baseline. Configure monitoring schedules based
+on your application's requirements—hourly, daily, or weekly.
+Define thresholds for acceptable deviation from the baseline
+for each important feature.
+- **Implement data drift
+detection**. Configure alerts to notify you when
+important features drift outside their acceptable
+statistical ranges. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to set up alarms that run when drift
+metrics exceed thresholds. This enables timely intervention
+when data quality issues arise.
+- **Create model retraining
+prompts**. Establish criteria for when to retrain
+your model based on data drift metrics. For example, if
+multiple important features show drift, or if a single
+critical feature drifts beyond a certain threshold, run the
+model retraining process.
+- **Set up continuous feedback
+loop**. Implement a system to continuously gather
+new labeled data for model retraining. This verifies that
+your model can adapt to legitimate changes in data
+distribution over time. Use
+[AWS Step Functions](https://aws.amazon.com/step-functions/) to orchestrate workflows that include
+data collection, preprocessing, model training, and
+deployment.
+
+## Resources
+
+**Related documents:**
+
+- [Pre-training
+Data Bias](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-data-bias.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Data
+quality](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-data-quality.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+
+**Related videos:**
+
+- [Prepare
+data for machine learning with ease, speed, and
+accuracy](https://www.youtube.com/watch?v=Wi3eJxfX754)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Lab
+1. Feature Engineering](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab1-feature-engineering)
+- [SageMaker AI
+Model Monitor Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+- [SageMaker AI
+Clarify Explainability Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp04.html*
+
+---
+
+# MLPERF04-BP05 Perform a performance trade-off analysis
+
+Perform a trade-off analysis to identify optimal ML model
+configurations that balance competing requirements for your business
+needs. This practice enables you to maximize both model accuracy and
+overall business value.
+
+**Desired outcome:** You develop a
+structured approach to evaluate and select machine learning models
+based on multiple dimensions including accuracy, complexity, bias,
+fairness, and operational constraints. You'll be able to make
+informed decisions about model selection that align with your
+business requirements and ethical considerations.
+
+**Common anti-patterns:**
+
+- Focusing solely on model accuracy without considering other
+important factors like explainability, fairness, or inference
+speed.
+- Ignoring bias in training data that may lead to unfair model
+outcomes for certain groups.
+- Deploying overly complex models that are difficult to explain
+and maintain when simpler models could achieve adequate
+performance.
+- Not testing different model configurations against business
+requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Optimized machine learning models that balance performance with
+operational constraints.
+- Models that can be explained and trusted by stakeholders and end
+users.
+- Reduced risk of unfair or biased model outcomes.
+- Better alignment between model performance and business
+requirements.
+- More cost-effective model deployment and maintenance.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Performance trade-off analysis requires careful consideration of
+your use case and business requirements. You need to determine
+which aspects of model performance are most important for your
+application - whether that's accuracy, explainability, fairness,
+latency, or other factors. Different business contexts may
+prioritize these dimensions differently.
+
+For example, in a credit scoring application, fairness and
+explainability might be primary concerns due to regulatory
+requirements and the need to provide reasons for decisions. In
+contrast, a real-time product recommendation system might
+prioritize prediction speed and accuracy over explainability.
+Understanding these requirements upfront can guide your model
+development process.
+
+Trade-off analysis is not a one-time activity but should be
+incorporated throughout the machine learning lifecycle. As you
+gather more data, refine your models, and receive feedback from
+stakeholders, you should continually reassess these trade-offs to
+verify that your models continue to meet business needs.
+
+### Implementation steps
+
+- **Define performance metrics aligned
+with business goals**. Start by clearly defining
+what success looks like for your use case. Identify the key
+performance indicators (KPIs) that matter most to your
+business stakeholders. These might include technical metrics
+like precision, recall, or latency, as well as business
+metrics like conversion rate or cost reduction.
+- **Establish a baseline for trade-off
+analysis**. Create a simple model as a baseline to
+compare against more complex approaches. This provides a
+reference point for measuring improvements and understanding
+the minimum acceptable performance for your use case.
+Techniques like cross-validation can determine if your
+baseline is robust.
+- **Explore the accuracy versus
+complexity trade-off**. Test models with different
+levels of complexity, from simple linear models to more
+sophisticated deep learning approaches. Use
+[Amazon SageMaker AI Managed MLFlow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to track different model
+architectures and their performance characteristics.
+Remember that simpler models are often more explainable and
+simpler to deploy, even if they sacrifice some accuracy.
+- **Analyze bias and fairness
+implications**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-fairness-and-explainability.html) to detect potential bias in your
+data and models. Identify sensitive attributes that might
+lead to unfair outcomes for certain groups. Implement
+mitigation strategies such as balanced datasets,
+regularization techniques, or fairness-aware algorithms to
+reduce bias while maintaining acceptable performance.
+- **Optimize the bias versus variance
+trade-off**. Address underfitting (high bias) and
+overfitting (high variance) through systematic
+experimentation. Techniques like cross-validation can
+identify the optimal model complexity for your data.
+Consider using more training data, implementing
+regularization techniques, or simplifying your model
+architecture depending on whether bias or variance is your
+primary concern.
+- **Evaluate precision versus recall
+trade-offs**. For classification problems,
+determine whether false positives or false negatives are
+more problematic for your use case. Use tools like
+precision-recall curves to visualize this trade-off and ROC
+curves to understand the relationship between true positive
+and false positive rates. Adjust classification thresholds
+based on the relative costs of different types of errors.
+- **Consider operational
+constraints**. Evaluate how models perform under
+real-world constraints like latency requirements, memory
+limitations, or compute availability. For edge deployment
+scenarios, use
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to optimize your models for hardware
+targets while maintaining accuracy. This is particularly
+important for applications that need to run in
+resource-constrained environments.
+- **Implement explainability
+techniques**. Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) to generate feature importance
+explanations and understand how your model makes
+predictions. This builds trust with stakeholders and may be
+necessary to address regulatory adherence in some
+industries. Consider the trade-off between model complexity
+and explainability when selecting your final model.
+- **Document trade-off
+decisions**. Create comprehensive documentation of
+your trade-off analysis, including the experiments
+performed, results observed, and the rationale behind your
+final model selection. This provides transparency for
+stakeholders and provides an understanding to future teams
+on why certain decisions were made.
+- **Establish continuous
+monitoring**. After deployment, use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to track model performance
+and detect drift in data or predictions. This allows you to
+identify when your trade-off assumptions may no longer be
+valid and when retraining might be necessary.
+
+## Resources
+
+**Related documents:**
+
+- [Evaluating
+ML Models](https://docs.aws.amazon.com/machine-learning/latest/dg/evaluating_models.html)
+- [AI
+Fairness and Explainability Whitepaper](https://pages.awscloud.com/rs/112-TZM-766/images/Amazon.AI.Fairness.and.Explainability.Whitepaper.pdf)
+- [Optimize
+model performance using Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Accelerating
+generative AI development with fully managed MLflow 3.0 on
+Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+- [Amazon SageMaker AI Clarify Detects Bias and Increases the Transparency
+of Machine Learning Models](https://aws.amazon.com/blogs/aws/new-amazon-sagemaker-clarify-detects-bias-and-increases-the-transparency-of-machine-learning-models/)
+- [Unlock
+near 3x performance gains with XGBoost and Amazon SageMaker AI
+Neo](https://aws.amazon.com/blogs/machine-learning/unlock-performance-gains-with-xgboost-amazon-sagemaker-neo-and-serverless-artillery/)
+
+**Related videos:**
+
+- [Building
+explainable AI models with Amazon SageMaker AI](https://www.youtube.com/watch?v=UbeyQmY1qCw)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp05.html*
+
+---
+
+# MLPERF04-BP06 Detect performance issues when using transfer learning
+
+Transfer learning can accelerate machine learning development by
+using pre-trained models for new tasks. Monitoring the performance
+of these transferred models verifies that they yield accurate
+results in new contexts and stops inherited weaknesses from
+affecting your solutions.
+
+**Desired outcome:** You can
+effectively identify and address hidden problems in transfer
+learning applications, which improves the reliability of your model
+predictions. By implementing proper monitoring and validation
+techniques, you gain confidence that inherited prediction weights
+perform as expected for your use case while minimizing risks
+associated with using pre-trained models.
+
+**Common anti-patterns:**
+
+- Assuming a pre-trained model will automatically perform well on
+your task without validation.
+- Neglecting to monitor prediction accuracy and model behavior
+after transfer learning implementation.
+- Failing to examine model predictions for subtle but
+consequential errors.
+- Overlooking the need to validate input preprocessing techniques
+for transferred models.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of performance issues that might otherwise
+remain hidden.
+- Improved model reliability and prediction accuracy.
+- Better understanding of what capabilities are truly inherited
+from pre-trained models.
+- Reduced risk of model failures in production environments.
+- More effective fine-tuning strategies based on identified
+weaknesses.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Transfer learning can dramatically reduce the time and
+computational resources needed to develop effective machine
+learning models by leveraging knowledge gained from solving one
+problem and applying it to a different but related problem.
+However, this approach comes with unique challenges that require
+careful monitoring and validation.
+
+When using transfer learning, it's essential to understand that
+the pre-trained model's performance characteristics may not
+directly translate to your use case. The underlying patterns and
+relationships learned by the original model might not fully align
+with your target domain, leading to subtle but potentially serious
+performance issues. These problems can be especially challenging
+to identify because they often don't manifest as obvious failures
+but rather as biased or suboptimal predictions.
+
+For effective transfer learning implementations, you need
+comprehensive monitoring and debugging strategies that can detect
+these hidden issues. This involves validating not just overall
+model performance but also examining individual predictions,
+understanding the inherited capabilities, and properly
+preprocessing the inputs.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Debugger for
+monitoring**. Configure
+[Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html) to monitor your transfer learning
+model during training and inference. This service can
+identify hidden issues that might otherwise go undetected by
+automatically analyzing tensors, tracking model convergence,
+and detecting anomalies.
+- **Examine model predictions for
+errors**. Analyze the outputs of your transfer
+learning model to identify patterns in prediction errors.
+Look beyond aggregate metrics like accuracy or F1 score to
+understand what types of inputs are causing the most
+confusion. Create confusion matrices and error distribution
+reports to visualize where your model's performance deviates
+from expectations.
+- **Validate model
+robustness**. Test your model's performance under
+various input conditions to determine how much of its
+robustness comes from the pre-trained weights versus your
+fine-tuning process. Perform adversarial testing by
+introducing slight variations to inputs and measuring how
+the predictions change. Use SageMaker AI Debugger's built-in
+rules to detect training anomalies, such as vanishing
+gradients or exploding tensors.
+- **Verify input preprocessing
+methods**. Align your data preprocessing pipeline
+with the expectations of the pre-trained model.
+Inconsistencies in normalization, tokenization, or feature
+engineering can impact performance. Document and validate
+the preprocessing steps to maintain consistency between
+training and inference stages.
+- **Implement continuous performance
+monitoring**. Deploy systems to continually monitor
+your model's performance after deployment. Configure
+automated alerts for deviations in key performance metrics
+to catch potential issues early. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) in conjunction with
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to set up comprehensive monitoring
+dashboards and alerting systems.
+- **Leverage foundation models with
+fine-tuning**. When using foundation models for
+transfer learning, implement
+[Amazon SageMaker AI JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) to access pre-trained models and
+fine-tune them for your tasks. Monitor the alignment between
+generated outputs and expected results, particularly for
+tasks requiring domain-specific knowledge.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Debugger](https://docs.aws.amazon.com/sagemaker/latest/dg/train-debugger.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Detecting
+data drift using SageMaker AI](https://aws.amazon.com/blogs/architecture/detecting-data-drift-using-amazon-sagemaker/)
+- [Detecting
+hidden but non-trivial problems in transfer learning models
+using Amazon SageMaker AI Debugger](https://aws.amazon.com/blogs/machine-learning/detecting-hidden-but-non-trivial-problems-in-transfer-learning-models-using-amazon-sagemaker-debugger/)
+
+**Related videos:**
+
+- [Introduction
+to Amazon SageMaker AI Debugger](https://www.youtube.com/watch?v=MqPdTj0Znwg)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf04-bp06.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLPERF05.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLPERF05.md
@@ -1,0 +1,317 @@
+# MLPERF05
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLPERF05-BP01 Evaluate cloud versus edge options for machine learning deployment
+
+Evaluate machine learning deployment options to determine if your
+application requires near-instantaneous inference results or needs
+to operate without network connectivity. When the lowest possible
+latency is essential, deploying inference directly on edge devices
+avoids costly roundtrips to cloud API endpoints. Edge deployments
+are particularly valuable for use cases like predictive maintenance
+in factories, where immediate local responses are critical.
+
+**Desired outcome:** You can make
+informed decisions about where to deploy your machine learning
+models based on your business requirements. You understand when to
+use cloud resources for training and when to deploy optimized models
+to edge devices for low-latency inference. Your edge deployments can
+operate autonomously when needed while maintaining security,
+performance, and the ability to update models as new data becomes
+available.
+
+**Common anti-patterns:**
+
+- Defaulting to cloud-based inference without evaluating latency
+requirements.
+- Deploying models to edge devices without proper optimization,
+resulting in poor performance.
+- Neglecting to establish a strategy for model updates and
+monitoring on edge devices.
+- Overlooking security considerations for models deployed at the
+edge.
+- Failing to evaluate hardware constraints of edge devices before
+deployment.
+
+**Benefits of establishing this best
+practice:**
+
+- Dramatically reduced inference latency for time-sensitive
+applications.
+- Ability to operate ML models in environments with limited or no
+connectivity.
+- Lower operational costs by reducing network traffic and cloud
+compute usage.
+- Enhanced privacy by keeping sensitive data local to edge
+devices.
+- Improved resilience against network outages.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning deployments require careful consideration of
+where inference should take place based on your use case
+requirements. While training complex models is computationally
+intensive and best suited for the cloud, inference operations
+require less computing power and can often be performed directly
+on edge devices.
+
+Avoid defaulting to cloud-based inference without evaluating
+latency requirements. Many organizations deploy models to edge
+devices without proper optimization, resulting in poor
+performance, neglect to establish a strategy for model updates and
+monitoring on edge devices, overlook security considerations for
+models deployed at the edge, and fail to evaluate hardware
+constraints of edge devices before deployment.
+
+When evaluating cloud versus edge deployment, consider factors
+like latency requirements, connectivity constraints, data privacy
+needs, and the computational capabilities of your edge devices.
+For applications requiring real-time responses, such as autonomous
+vehicles, industrial equipment monitoring, or smart security
+systems, edge deployment reduces network latency and provides
+continuous operation even during connectivity disruptions.
+
+AWS provides comprehensive tools to optimize models for edge
+deployment while maintaining the ability to train and manage those
+models in the cloud. This hybrid approach gives you the best of
+both worlds: powerful cloud resources for development and
+optimization, with efficient edge deployment for operational
+performance.
+
+### Implementation steps
+
+- **Assess your deployment
+requirements**. Begin by clearly defining your
+application's latency, connectivity, and privacy
+requirements. Determine if your use case needs
+millisecond-level response times, must function in
+environments with unreliable connectivity, or needs to
+process sensitive data locally. These factors will guide
+your decision between cloud and edge deployment options.
+- **Optimize models for edge
+deployment**. Training and optimizing machine
+learning models require massive computing resources, making
+cloud environments ideal for this phase.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides powerful tools for building and
+training models that can later be optimized for edge
+deployment. Consider the computational constraints of your
+target edge devices and select model architectures that
+balance accuracy with efficiency.
+- **Deploy with Amazon SageMaker AI Neo for
+cross-solution compatibility**.
+[Amazon SageMaker AI Neo](https://aws.amazon.com/sagemaker/neo/) enables ML models to be trained once
+and run anywhere in the cloud or at the edge. The Neo
+compiler reads models exported from various frameworks,
+converts them to framework-agnostic representations, and
+generates optimized binary code for target hardware. This
+process makes your models run faster without accuracy loss.
+- **Implement edge ML with AWS IoT Greengrass**.
+[AWS IoT Greengrass](https://aws.amazon.com/greengrass/ml/) provides a robust solution for running
+ML inferences on edge devices using cloud-trained models.
+These models can be built using Amazon SageMaker AI,
+[AWS Deep Learning AMIss](https://aws.amazon.com/machine-learning/amis/), or
+[AWS Deep Learning Containers](https://aws.amazon.com/machine-learning/containers/). Models are stored in
+[Amazon S3](https://aws.amazon.com/s3/) before deployment to edge devices.
+
+## Resources
+
+**Related documents:**
+
+- [AWS IoT Greengrass](https://aws.amazon.com/greengrass/ml/)
+- [Set
+up Neo on Edge Devices](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-getting-started-edge.html)
+- [AWS Internet of
+Things](https://aws.amazon.com/iot/)
+- [Optimize
+image classification on AWS IoT Greengrass using ONNX
+Runtime](https://aws.amazon.com/blogs/iot/optimize-image-classification-on-aws-iot-greengrass-using-onnx-runtime/)
+
+**Related videos:**
+
+- [Machine
+Learning at the Edge](https://www.youtube.com/watch?v=EAz-qAL5z2U)
+- [Getting
+Started Using Machine Learning at the Edge](https://pages.awscloud.com/Getting-Started-Using-Machine-Learning-at-the-Edge_2020_0202-IOT_OD.html)
+- [AWS IoT Greengrass and Machine Learning at the Edge](https://www.youtube.com/watch?v=keaq6sy46ek)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf05-bp01.html*
+
+---
+
+# MLPERF05-BP02 Choose an optimal deployment option in the cloud
+
+When deploying machine learning models in the cloud, selecting the
+right deployment option is crucial for performance efficiency. By
+matching your deployment method to your use case requirements for
+request frequency, latency, and runtime, you can optimize both
+performance and cost.
+
+**Desired outcome:** You can deploy
+your machine learning models in a way that meets your application's
+needs for throughput, response time, and cost efficiency. The
+selected deployment option provides the optimal balance between
+performance and resource utilization while accommodating your
+workload patterns.
+
+**Common anti-patterns:**
+
+- Deploying models on persistent endpoints regardless of traffic
+patterns or workload spikes.
+- Overlooking payload size and processing time requirements when
+selecting deployment options.
+- Using real-time inference for batch processing use cases that
+don't require immediate responses.
+- Failing to consider cost implications of different deployment
+options.
+- Not monitoring and optimizing deployment configurations after
+initial setup.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved cost efficiency by matching resources to actual usage
+patterns.
+- Enhanced performance through selection of appropriate deployment
+methods.
+- Better scalability to handle varying workloads.
+- Reduced operational overhead with managed deployment options.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Selecting the optimal deployment option for your machine learning
+models involves understanding your use case requirements and
+matching them to the capabilities of different AWS SageMaker AI
+deployment services. Consider factors such as request frequency,
+payload size, processing time, and response latency needs.
+
+Avoid deploying models on persistent endpoints regardless of
+traffic patterns or workload spikes. Many organizations overlook
+payload size and processing time requirements when selecting a
+deployment option, use real-time inference for batch processing
+use cases that don't require immediate responses, and fail to
+consider cost implications of different deployment options.
+
+For time-sensitive applications requiring immediate responses,
+real-time inference provides persistent endpoints, while workloads
+with inconsistent traffic patterns might benefit from serverless
+options that scale automatically. For larger payloads or longer
+processing times, asynchronous inference is appropriate, and for
+non-time-sensitive bulk processing, batch transformation offers an
+efficient option.
+
+Your deployment choice should align with your application's
+operational patterns to balance performance and cost efficiency. A
+chatbot requiring immediate responses would benefit from real-time
+inference, while overnight batch processing of transactions might
+use batch transform.
+
+### Implementation steps
+
+- **Evaluate your model deployment
+requirements**. Begin by clearly defining your
+application's requirements for inference frequency, latency
+needs, payload sizes, and budget constraints. Consider how
+often model predictions will be requested, how quickly
+responses must be delivered, and what resource constraints
+you may have.
+- **Implement Amazon SageMaker AI Real-time
+Inference for continuous, low-latency needs**.
+Deploy models that require near-instantaneous responses and
+consistent availability using
+[SageMaker AI
+real-time endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html). These fully managed endpoints
+support auto-scaling and are ideal for applications like
+real-time recommendation engines, chatbots, or fraud
+detection systems where immediate response is critical.
+- **Implement Amazon SageMaker AI
+Serverless Inference for variable traffic
+patterns**. For workloads with inconsistent request
+patterns or idle periods between traffic spikes, use
+[SageMaker AI
+Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html). This option automatically
+provisions and scales compute resources based on traffic,
+avoiding the need to manage server infrastructure while
+optimizing costs during periods of low utilization.
+- **Implement Amazon SageMaker AI
+Asynchronous Inference for large payloads or long
+processing**. For use cases involving large input
+files (up to 1GB) or models requiring extended processing
+time (up to 15 minutes), deploy using
+[SageMaker AI
+Asynchronous Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html). This option queues incoming
+requests and processes them when resources are available,
+making it ideal for tasks like video processing, large
+document analysis, or complex NLP tasks.
+- **Implement Amazon SageMaker AI Batch
+Transform for scheduled bulk processing**. For
+non-time-sensitive workloads where predictions can be
+processed in batches, such as overnight processing of
+transactions or weekly sentiment analysis of customer
+feedback, use
+[SageMaker AI
+Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html). This option automatically
+distributes workloads across compute instances and shuts
+down resources when processing is complete.
+- **Monitor and optimize your
+deployment**. Once deployed, continuously monitor
+your model's performance, resource utilization, and costs.
+Use Amazon CloudWatch metrics to track invocation metrics,
+errors, latency, and resource utilization. Adjust
+auto-scaling configurations or switch deployment options if
+your usage patterns change over time.
+- **Implement security and
+governance**. Incorporate proper security controls
+in your model deployments, including IAM roles with least
+privilege access, network isolation where appropriate, and
+encryption of data in transit and at rest. Use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to create persona-based IAM
+roles for different ML user types (data scientists, MLOps
+engineers, business analysts) with preconfigured templates
+that follow least-privilege principles. For regulated
+industries, implement model governance practices to track
+model versions, approvals, and changes.
+
+## Resources
+
+**Related documents:**
+
+- [Real-time
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Batch
+transform for inference with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Deploy
+models with Amazon SageMaker AI](https://sagemaker-examples.readthedocs.io/en/latest/inference/index.html)
+- [Deploying
+ML models using SageMaker AI Serverless Inference](https://aws.amazon.com/blogs/machine-learning/deploying-ml-models-using-sagemaker-serverless-inference-preview/)
+- [Optimize
+deployment cost of Amazon SageMaker AI JumpStart foundation
+models with Amazon SageMaker AI asynchronous endpoints](https://aws.amazon.com/blogs/machine-learning/optimize-deployment-cost-of-amazon-sagemaker-jumpstart-foundation-models-with-amazon-sagemaker-asynchronous-endpoints/)
+- [Announcing
+managed inference for Hugging Face models in Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/announcing-managed-inference-for-hugging-face-models-in-amazon-sagemaker/)
+- [Run
+computer vision inference on large videos with Amazon SageMaker AI asynchronous endpoints](https://aws.amazon.com/blogs/machine-learning/run-computer-vision-inference-on-large-videos-with-amazon-sagemaker-asynchronous-endpoints/)
+
+**Related videos:**
+
+- [Achieve high
+performance and cost-effective model deployment](https://youtu.be/gWuO0gNKlm8)
+- [Amazon SageMaker AI serverless inference](https://youtu.be/KB6vLQGixjA)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf05-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLPERF06.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLPERF06.md
@@ -1,0 +1,1041 @@
+# MLPERF06
+
+**Pillar**: Unknown  
+**Best Practices**: 6
+
+---
+
+# MLPERF06-BP01 Include human-in-the-loop monitoring
+
+Including human-in-the-loop monitoring is an effective method for
+efficiently tracking and maintaining model performance. By
+incorporating human review into automated decision processes,
+organizations can establish a reliable quality assurance mechanism
+that validates model inferences and detects performance degradation
+over time.
+
+**Desired outcome:** You implement a
+robust human-in-the-loop monitoring system that enables continuous
+assessment of your machine learning models. You can compare human
+labels with model inferences to detect model drift and performance
+degradation, allowing timely mitigation through retraining or other
+remediation actions. This creates a feedback loop that maintains
+high model quality and reliability in production environments.
+
+**Common anti-patterns:**
+
+- Relying solely on automated metrics without human validation.
+- Ignoring edge cases and low-confidence predictions.
+- Not establishing a systematic review process for model outputs.
+- Failing to incorporate human feedback into model retraining
+cycles.
+- Using untrained reviewers without subject matter expertise.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model drift and performance degradation.
+- Higher quality assurance for critical model predictions.
+- Better understanding of edge cases and model limitations.
+- Continuous improvement of model performance through expert
+feedback.
+- Increased trust in AI systems through human oversight.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Human-in-the-loop monitoring provides a crucial safety net for
+your machine learning systems by adding appropriate human
+oversight to important decisions. This approach is particularly
+valuable when automated systems make predictions that impact
+critical business processes or customer experiences. By
+establishing a workflow where human experts review model outputs,
+particularly those with low confidence or selected randomly for
+quality assurance, you create a reliable mechanism to evaluate
+model performance in real-world scenarios.
+
+Avoid relying solely on automated metrics without human
+validation. Many organizations ignore edge cases and
+low-confidence predictions, don't establish a systematic review
+process for model outputs, fail to incorporate human feedback into
+model retraining cycles, and use untrained reviewers without
+subject matter expertise.
+
+This monitoring approach can identify when models begin to drift
+or perform poorly on new data. The comparison between human labels
+and model predictions serves as a key indicator of model health,
+signaling when retraining or other interventions are necessary.
+This feedback loop is essential for maintaining high-quality,
+reliable AI systems over time.
+
+### Implementation steps
+
+- **Design a quality assurance system
+for model inferences**. Create a comprehensive plan
+for how human review will integrate with your machine
+learning workflow. Determine which predictions will be sent
+for human review (low-confidence predictions, random
+samples, or high-risk categories) and establish clear
+guidelines for reviewers to follow when evaluating model
+outputs.
+- **Establish a team of subject matter
+experts**. Identify and recruit individuals with
+domain expertise who can accurately evaluate model
+inferences. These reviewers should understand both the
+technical aspects of your models and the business context in
+which they operate, allowing them to provide valuable
+feedback on model performance and identify potential issues.
+- **Implement Amazon Augmented AI for
+human review workflows**. Use
+[Amazon
+Augmented AI](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-use-augmented-ai-a2i-human-review-loops.html) (Amazon A2I) to create and manage human
+review workflows for your machine learning models. Amazon
+A2I integrates with other AWS services like
+[IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html),
+[Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html), and
+[Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) to handle the entire review process.
+- **Configure review criteria and
+thresholds**. Define the conditions that initiate
+human review, such as confidence score thresholds or types
+of predictions that require human validation. Set up rules
+in Amazon A2I to automatically route these cases to your
+human reviewers while allowing high-confidence, routine
+predictions to proceed without review.
+- **Develop feedback integration
+mechanisms**. Create systems to incorporate human
+feedback into your model improvement cycle. This includes
+storing human labels alongside model predictions, analyzing
+disagreement patterns, and using this information to
+identify areas where your model needs improvement.
+- **Monitor and analyze human-model
+agreement rates**. Track how often human reviewers
+agree with model predictions and analyze patterns in
+disagreements. This data can identify systematic issues with
+your model so that you can prioritize areas for improvement.
+- **Implement model retraining based on
+feedback**. Use the labeled data gathered through
+human review to periodically retrain your models. This
+creates a continuous improvement loop where your models
+learn from past mistakes and adapt to changing patterns in
+your data.
+- **Measure and optimize
+cost-effectiveness**. Analyze the ROI of your
+human-in-the-loop system by comparing the costs of human
+review with the benefits of improved model accuracy. Adjust
+your review sampling strategy to focus human attention where
+it provides the most value.
+
+## Resources
+
+**Related documents:**
+
+- [Using
+Amazon Augmented AI for Human Review](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-use-augmented-ai-a2i-human-review-loops.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Customized
+model monitoring for near real-time batch inference with
+Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/customized-model-monitoring-for-near-real-time-batch-inference-with-amazon-sagemaker/)-
+- [Human-in-the-loop
+review of model explanations with Amazon SageMaker AI Clarify and
+Amazon A2I](https://aws.amazon.com/blogs/machine-learning/human-in-the-loop-review-of-model-explanations-with-amazon-sagemaker-clarify-and-amazon-a2i/)
+
+**Related videos:**
+
+- [Easily
+Implement Human in the Loop into Your Machine Learning
+Predictions with Amazon A2I](https://www.youtube.com/watch?v=jNUp1SO_0YU)
+- [Accelerate
+foundation model evaluation with Amazon SageMaker AI
+Clarify](https://www.youtube.com/watch?v=9X2oDkOBYyA)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp01.html*
+
+---
+
+# MLPERF06-BP02 Evaluate model explainability
+
+Model explainability allows you to understand and interpret how your
+machine learning models arrive at their decisions. By evaluating
+model explainability, you gain insights into the factors that
+influence predictions to build trustworthy AI systems that meet
+business requirements and regulatory standards.
+
+**Desired outcome:** You can
+demonstrate why your machine learning models make predictions, which
+enables you to build trust with stakeholders, adhere to regulatory
+requirements, and identify potential biases in model outcomes. You
+have the tools to balance model complexity with explainability based
+on your business needs and can produce documentation that satisfies
+governance requirements.
+
+**Common anti-patterns:**
+
+- Treating machine learning models as unknown without
+understanding their decision-making process.
+- Ignoring explainability requirements until after model
+deployment.
+- Prioritizing model performance metrics over interpretability
+when business or regulations requires explainability.
+- Failing to document model explanations for regulatory adherence.
+- Using complex models when simpler, more interpretable
+alternatives would meet business requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Increased trust from stakeholders and end-users in AI systems.
+- Improves adherence with regulations requiring transparent AI
+decision-making.
+- Ability to detect and mitigate biases in model predictions.
+- Enhanced model debugging and performance improvement.
+- Better alignment between model behavior and business objectives.
+- More effective model governance and risk management.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model explainability is a critical aspect of responsible AI
+development. When you evaluate explainability, you assess how
+transparently your machine learning models make decisions and
+whether those decisions can be explained to stakeholders,
+regulators, and end-users. This transparency is particularly
+important in regulated industries and for applications where
+decisions impact individuals.
+
+Avoid treating machine learning models as opaque without
+understanding their decision-making process. Many organizations
+ignore explainability requirements until after model deployment,
+prioritize model performance metrics over interpretability when
+business or regulatory requirements demand explainability, and
+fail to document model explanations for regulatory adherence.
+
+The trade-off between model complexity and explainability is a key
+consideration. Complex models like deep neural networks may
+deliver higher accuracy but are often harder to interpret. Simpler
+models like decision trees or linear regression provide more
+straightforward explanations but might sacrifice some performance.
+Your choice should be guided by your business context, including
+regulatory requirements and the importance of building trust with
+end-users.
+
+For example, a credit approval system may require clear
+explanations for why applications are denied, while a
+manufacturing quality control system might prioritize accuracy
+over explainability. By evaluating these requirements early, you
+can select appropriate modeling approaches and develop the right
+metrics for assessing both performance and interpretability.
+
+### Implementation steps
+
+- **Assess explainability
+requirements**. Begin by understanding the business
+and compliance-aligned needs that drive your explainability
+requirements. Consider regulatory constraints (like GDPR,
+which includes a right to explanation), business
+transparency goals, and stakeholder expectations. Document
+these requirements clearly and prioritize them based on
+their importance to your use case.
+- **Select appropriate model
+types**. Choose model architectures that align with
+your explainability needs. If high explainability is
+required, consider inherently interpretable models like
+decision trees, rule-based systems, or linear models. For
+applications where performance takes priority, more complex
+models with post-hoc explanation techniques may be
+appropriate.
+- **Implement Amazon SageMaker AI
+Clarify**.
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html) provides tools to explain model
+predictions using feature attribution methods. It can
+identify which features contribute most to a prediction,
+enabling you to understand and communicate model behavior.
+SageMaker AI Clarify supports various model types and
+integrates seamlessly with the SageMaker AI environment.
+- **Apply feature attribution
+techniques**. Use feature attribution methods like
+[SHAP
+(SHapley Additive exPlanations) values](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html) through
+SageMaker AI Clarify to quantify the contribution of each
+feature to individual predictions. These techniques explain
+both global model behavior (which features are most
+important overall) and local explanations (why a prediction
+was made).
+- **Establish explainability
+metrics**. Define quantitative metrics to assess
+model explainability, such as feature importance stability,
+explanation fidelity, or consistency. Use these metrics to
+objectively evaluate explainability alongside traditional
+performance metrics like accuracy or F1 score. Include these
+metrics in your model evaluation framework and monitoring
+systems.
+- **Create model
+documentation**. Develop comprehensive
+documentation that describes how your model works, what
+features influence its decisions, and how explanations are
+generated. This documentation should be understandable by
+both technical and non-technical stakeholders. SageMaker AI
+Clarify can generate reports that contribute to model
+governance documentation.
+- **Implement bias detection**.
+Use
+[SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) to detect potential bias in your models
+during development and production. Configure the appropriate
+bias metrics based on your use case and sensitive
+attributes. Regularly assess these metrics to verify that
+your model remains fair across different demographic groups.
+- **Set up continuous
+monitoring**. Configure SageMaker AI Clarify to
+monitor production inferences for bias or feature
+attribution drift. This allows you to detect when model
+explanations change over time, which might indicate problems
+with the model or changes in the underlying data. Establish
+alerts for shifts in explanations or bias metrics.
+- **Integrate human review
+processes**. For high-stakes decisions, implement
+human-in-the-loop review of model explanations using Amazon SageMaker AI Clarify in combination with
+[Amazon
+Augmented AI (A2I)](https://aws.amazon.com/augmented-ai/). This provides an additional layer
+of oversight and can build confidence in the model's
+decisions.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Feature
+Attributions that Use Shapley Values](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-shapley-values.html)
+- [Run
+SageMaker AI Clarify Processing Jobs for Bias Analysis and
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [ML
+model explainability with Amazon SageMaker AI Clarify and the
+SKLearn pre-built container](https://aws.amazon.com/blogs/machine-learning/use-amazon-sagemaker-clarify-with-the-sklearn-pre-built-container/)
+- [Human-in-the-loop
+review of model explanations with Amazon SageMaker AI Clarify and
+Amazon A2I](https://aws.amazon.com/blogs/machine-learning/human-in-the-loop-review-of-model-explanations-with-amazon-sagemaker-clarify-and-amazon-a2i/)
+
+**Related examples:**
+
+- [Fairness
+and Explainability with SageMaker AI Clarify](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-experiments/sagemaker_clarify_integration/tracking_bias_explainability.html)
+- [Explainability
+with Amazon SageMaker AI Debugger](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-debugger/xgboost_census_explanations/xgboost-census-debugger-rules.html)
+- [Amazon SageMaker AI Clarify Processing GitHub Examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp02.html*
+
+---
+
+# MLPERF06-BP03 Evaluate data drift
+
+Data drift can impact the performance of your machine learning
+models, leading to inaccurate predictions and diminished business
+value. By implementing effective monitoring and detection
+strategies, you can identify when your models are no longer
+performing optimally due to changes in the underlying data patterns.
+
+**Desired outcome:** You can detect
+and mitigate data drift in your machine learning models, providing
+continued accuracy and reliability over time. By implementing model
+monitoring capabilities, you gain visibility into changes in data
+distributions and model performance, allowing for timely
+interventions and retraining when necessary.
+
+**Common anti-patterns:**
+
+- Deploying models without drift monitoring mechanisms.
+- Ignoring gradual changes in input data distribution until model
+performance deteriorates.
+- Assuming that a model trained on historical data will remain
+accurate indefinitely.
+- Manually checking model performance at arbitrary intervals
+rather than implementing continuous monitoring.
+- Retraining models on fixed schedules without considering actual
+data drift patterns.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance degradation before it
+impacts business outcomes.
+- Increased trust in ML model predictions through continuous
+quality assurance.
+- Improved model lifecycle management with data-driven retraining
+decisions.
+- Reduced operational risks associated with inaccurate
+predictions.
+- Enhanced ability to detect and mitigate bias in ML models over
+time.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data drift occurs when the statistical properties of model inputs
+change over time, causing discrepancies between training data and
+production data. This can happen gradually due to evolving user
+behaviors, market conditions, or abrupt changes like economic
+shifts. When your model encounters data drift, it's essentially
+making predictions on data distributions it wasn't trained on,
+which can lead to decreased accuracy and potentially harmful
+business decisions.
+
+Avoid deploying models without drift monitoring mechanisms. Many
+organizations ignore gradual changes in input data distribution
+until model performance deteriorates, assume that a model trained
+on historical data will remain accurate indefinitely, and manually
+check model performance at arbitrary intervals rather than
+implementing continuous monitoring.
+
+Implementing a robust data drift monitoring strategy assists you
+in maintaining high-performing models by identifying when
+retraining becomes necessary. Rather than retraining models on
+arbitrary schedules, you can make data-driven decisions based on
+actual changes in your data distributions and model performance
+metrics. This approach verifies that you're optimizing both model
+performance and resource utilization.
+
+Amazon SageMaker AI provides comprehensive tools to monitor your ML
+models in production environments, allowing you to detect data
+drift, concept drift, and bias. By setting up automated monitoring
+pipelines, you can receive alerts when your models require
+attention, enabling proactive management of your ML systems.
+
+### Implementation steps
+
+- **Set up baseline data for
+monitoring**. Establish a reference dataset that
+represents your model's expected input and output
+distributions. This baseline will be used to compare against
+your production data to detect drift. Use the training data
+or a representative subset that performed well during model
+validation.
+- **Configure SageMaker AI Model
+Monitor**. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automatically detect
+deviations in your model's data quality and performance
+metrics. SageMaker AI Model Monitor can be set up to run on a
+schedule, analyzing incoming production data and comparing
+it to your baseline.
+- **Define data quality and drift
+metrics**. Determine which statistical metrics are
+most relevant for detecting drift in your use case.
+SageMaker AI Model Monitor supports various statistical
+measures like KL divergence, Jensen-Shannon divergence, and
+population stability index to quantify differences between
+distributions.
+- **Establish threshold
+values**. Set appropriate threshold values for your
+metrics that, when exceeded, will initiate alerts. These
+thresholds should balance sensitivity to meaningful changes
+while avoiding false alarms from minor variations.
+- **Create automated monitoring
+schedules**. Configure SageMaker AI Model Monitor to
+run analysis jobs at regular intervals that match your
+business requirements. For critical models, consider more
+frequent monitoring schedules.
+- **Implement bias detection**.
+Use
+[Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-post-training-bias.html) to detect bias in your ML models
+both pre-training and during production. SageMaker AI Clarify
+can identify if your model is developing biases over time as
+the data distribution changes.
+- **Set up alert mechanisms**.
+Configure Amazon CloudWatch alarms to notify appropriate
+stakeholders when data drift exceeds your defined
+thresholds. Integrate these alerts with your team's
+communication tools for timely responses.
+- **Develop a retraining
+strategy**. Establish clear criteria for when to
+retrain models based on drift detection results. This should
+include considerations for data collection, feature
+engineering updates, and model revalidation.
+- **Implement automated retraining
+pipelines**. Create SageMaker AI pipelines that can be
+run automatically when drift exceeds critical thresholds,
+streamlining the retraining process and minimizing the time
+models operate with degraded performance.
+- **Document drift patterns and
+interventions**. Maintain records of detected drift
+incidents, their causes, and the effectiveness of
+interventions. This documentation builds institutional
+knowledge that can improve future model development and
+monitoring strategies.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Detecting
+bias after training](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-detect-post-training-bias.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Amazon SageMaker AI Clarify Detects Bias and Increases the Transparency
+of Machine Learning Models](https://aws.amazon.com/blogs/aws/new-amazon-sagemaker-clarify-detects-bias-and-increases-the-transparency-of-machine-learning-models/)
+- [Detecting
+data drift using Amazon SageMaker AI](https://aws.amazon.com/blogs/architecture/detecting-data-drift-using-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Clarify](https://github.com/aws/amazon-sagemaker-clarify)
+- [Amazon SageMaker AI Model Monitor examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp03.html*
+
+---
+
+# MLPERF06-BP04 Monitor, detect, and handle model performance degradation
+
+Model performance could degrade over time for reasons such as data
+quality, model quality, model bias, and model explainability.
+Continuously monitor the quality of the ML model in real time.
+Identify the right time and frequency to retrain and update the
+model. Configure alerts to notify and initiate actions if a drift in
+model performance is observed.
+
+**Desired outcome:** You establish a
+comprehensive monitoring system for your machine learning models
+that detects performance degradation, alerts relevant stakeholders,
+and takes appropriate remediation actions. Your ML systems maintain
+high accuracy and reliability over time through automated
+monitoring, detection, and handling of performance issues.
+
+**Common anti-patterns:**
+
+- Implementing ML models without ongoing monitoring.
+- Relying solely on periodic manual checks of model performance.
+- Ignoring data drift or concept drift until model performance
+severely degrades.
+- Not having an established retraining strategy or schedule.
+- Missing alert systems for model performance degradation.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of model performance issues.
+- Automated notifications when models start to degrade.
+- Improved model reliability and accuracy over time.
+- Reduced operational risk from poor model predictions.
+- Better understanding of model behavior in production
+environments.
+- Increased trust in ML-powered systems.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Model performance monitoring is critical for maintaining reliable
+machine learning systems in production environments. As real-world
+data changes over time, models can experience data drift (changes
+in the distribution of input data) or concept drift (changes in
+the relationship between inputs and target variables). Establish a
+robust monitoring framework to detect these issues early and take
+appropriate action.
+
+Avoid implementing ML models without ongoing monitoring. Many
+organizations rely solely on periodic manual checks of model
+performance, ignore data drift or concept drift until model
+performance severely degrades, don't have an established
+retraining strategy or schedule, and miss alert systems for model
+performance degradation.
+
+When implementing model monitoring, you should establish baseline
+performance metrics during the training and validation phases.
+These baselines serve as the foundation for comparison once the
+model is deployed. Monitor not just accuracy metrics, but also
+data statistics, feature distributions, and prediction patterns to
+identify subtle changes that might indicate underlying problems.
+
+Setting up automated alerts notifies your team when key
+performance indicators fall below acceptable thresholds. These
+alerts should be configured with appropriate severity levels to
+reflect the business impact of model degradation. Additionally,
+implement automated scaling to handle varying workloads
+efficiently, which keeps your model endpoints responsive
+regardless of demand.
+
+### Implementation steps
+
+- **Monitor model
+performance**.
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) continually monitors the
+quality of Amazon SageMaker AI machine learning models in
+production. Establish a baseline during training before
+model is in production. Collect data while in production and
+compare changes in model inferences. Observations of drifts
+in the data statistics will indicate that the model may need
+to be retrained. Use
+[SageMaker AI
+Clarify](https://aws.amazon.com/sagemaker/clarify/) to identify model bias. Configure alerting
+systems with
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to send notifications for unexpected bias
+or changes in data quality.
+- **Perform automatic
+scaling**. Amazon SageMaker AI includes automatic
+scaling capabilities for your hosted model to dynamically
+adjust underlying compute supporting an endpoint based on
+demand. This capability verifies that that your endpoint can
+dynamically support demand while reducing operational
+overhead.
+- **Monitor endpoint metrics**.
+Amazon SageMaker AI also outputs endpoint metrics for
+monitoring the usage and health of the endpoint. Amazon SageMaker AI Model Monitor provides the capability to monitor
+your ML models in production and provides alerts when data
+quality issues appear. For enhanced observability, leverage
+one-click metrics and monitoring for HyperPod training jobs,
+deployments, health, resource usage, and historical job
+traces to drive faster debugging and operational excellence
+in foundation model workflows. Create a mechanism to
+aggregate and analyze model prediction endpoint metrics
+using services, such as
+[Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/). OpenSearch Service supports
+[dashboards](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/dashboards.html)
+for visualization. Consider integrating third-party AI tools
+(Comet, Deepchecks, Fiddler AI, Lakera) for extended
+governance, bias detection, explainable AI, and vertical
+solutions. The traceability of hosting metrics back to
+versioned inputs allows for analysis of changes that could
+be impacting current operational performance.
+- **Establish data quality
+monitoring**. Configure SageMaker AI Model Monitor to
+track data quality metrics such as missing values,
+statistical outliers, and feature distribution shifts. Set
+up constraints that define acceptable ranges for these
+metrics and generate alerts when violations occur.
+- **Implement bias detection and
+tracking**. Use SageMaker AI Clarify to detect bias in
+your model predictions over time. Monitor for changes in
+fairness metrics across different segments of your data and
+create visualizations to track these metrics over time.
+- **Set up model explainability
+analysis**. Deploy SageMaker AI Clarify to track
+feature importance and SHAP values over time. These values
+can determine if the model's decision-making process is
+changing in unexpected ways that might indicate performance
+issues.
+- **Create a retraining
+pipeline**. Develop an automated pipeline that can
+retrain your models when performance degradation is
+detected. Use
+[AWS Step Functions](https://aws.amazon.com/step-functions/) to orchestrate the retraining
+workflow, including data preparation, model training,
+evaluation, and deployment.
+- **Implement A/B testing for model
+updates**. When deploying updated models, use
+SageMaker AI's
+[production
+variants](https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html) to perform A/B testing between the current
+and new model versions. This allows you to validate
+performance improvements before fully replacing the existing
+model.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness
+and Explainability with SageMaker AI Clarify](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-clarify/fairness_and_explainability/fairness_and_explainability.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Monitoring
+in-production ML models at large scale using Amazon SageMaker AI
+Model Monitor](https://aws.amazon.com/blogs/machine-learning/monitoring-in-production-ml-models-at-large-scale-using-amazon-sagemaker-model-monitor/)
+- [ML
+model explainability with Amazon SageMaker AI Clarify and the
+SKLearn pre-built container](https://aws.amazon.com/blogs/machine-learning/use-amazon-sagemaker-clarify-with-the-sklearn-pre-built-container/)
+
+**Related videos:**
+
+- [Understand
+ML model predictions & biases with Amazon SageMaker AI
+Clarify](https://www.youtube.com/watch?v=t2SJTYiTnYM)
+- [Deep
+Dive on Amazon SageMaker AI Debugger & Amazon SageMaker AI Model
+Monitor](https://www.youtube.com/watch?v=0zqoeZxakOI)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Model Monitor Examples - Github](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+- [SageMaker AI
+Clarify Examples - Github](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp04.html*
+
+---
+
+# MLPERF06-BP05 Establish an automated re-training framework
+
+Monitor data and model predictions to identify errors due to data
+and concept drift. By implementing automated model re-training at
+scheduled intervals or when performance metrics reach defined
+thresholds, you can maintain model accuracy and effectiveness over
+time. This approach keeps your machine learning models relevant as
+data patterns evolve.
+
+**Desired outcome:** You can detect
+when your deployed ML models experience data drift or performance
+degradation, and automatically run retraining processes. You
+establish mechanisms to monitor data statistics and ML inferences in
+production, allowing you to maintain high-quality predictions
+without manual intervention. Your models are consistently updated
+with new data, and model versions are properly tracked to maintain
+traceability and reproducibility.
+
+**Common anti-patterns:**
+
+- Waiting for model performance to fail catastrophically before
+initiating retraining.
+- Manually monitoring model performance without automated alerts
+or prompts.
+- Retraining on a fixed schedule regardless of model performance
+or data patterns.
+- Lacking proper version control for retrained models.
+- Not maintaining consistent evaluation metrics across model
+versions.
+
+**Benefits of establishing this best
+practice:**
+
+- Maintains model accuracy and relevance as data patterns evolve.
+- Reduces manual intervention required to keep models performing
+optimally.
+- Enables quick response to data drift and concept drift.
+- Creates a documented, repeatable process for model updates.
+- Provides consistent model quality through automated evaluation.
+- Maximizes return on investment for machine learning solutions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Establishing an automated retraining framework is crucial for
+maintaining ML model performance over time. As new data becomes
+available or as the underlying patterns in your data change, your
+models can drift and become less accurate. By implementing a
+systematic approach to model monitoring and retraining, you can
+verify that your ML solutions continue to deliver business value.
+
+Avoid waiting for model performance to fail catastrophically
+before initiating retraining. Many organizations manually monitor
+model performance without automated alerts or prompts, retrain on
+a fixed schedule regardless of model performance or data patterns,
+lack proper version control for retrained models, and don't
+maintain consistent evaluation metrics across model versions.
+
+Start by defining clear performance metrics for your models that
+align with your business objectives. These metrics should be
+continuously monitored in production to detect performance
+degradation. Additionally, monitor your input data for statistical
+changes that may indicate drift from the training distribution.
+When changes are detected, your automated framework should run
+retraining workflows.
+
+The process should include data preparation, model training with
+both existing and new data, thorough evaluation, and controlled
+deployment. Each retrained model should be versioned appropriately
+to maintain traceability and allow for rollback if needed.
+
+### Implementation steps
+
+- **Define model performance
+metrics**. Establish clear metrics that measure how
+well your model is performing relative to business
+objectives. These could include accuracy, precision, recall,
+F1 score, or custom domain-specific metrics. Verify that
+these metrics can be calculated automatically and regularly
+in your production environment.
+- **Configure monitoring
+systems**. Use
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously monitor the
+quality of your ML models in production. Set up data quality
+monitoring to detect drift in input features, model quality
+monitoring to track prediction quality, bias drift
+monitoring to detect changes in fairness metrics, and
+feature attribution drift to identify changes in feature
+importance.
+- **Establish retraining
+prompts**. Define the conditions that will initiate
+model retraining. These can include scheduled intervals
+based on business requirements, performance degradation
+beyond defined thresholds, detection of data drift above
+acceptable limits, and availability of new training data.
+Set up
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) alerts to notify or automatically run
+retraining workflows.
+- **Design retraining
+pipelines**. Create automated pipelines using
+[Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) that handle the entire retraining
+workflow, including data preparation, feature engineering,
+model training, evaluation, and deployment. For large-scale
+foundation model training or distributed workloads, leverage
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) which provides managed, resilient
+high-performance clusters with automatic health checks and
+PyTorch auto-resume capabilities for long-running training
+jobs. In your pipeline, include steps for validation against
+holdout data before deployment.
+- **Implement model
+versioning**. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to track and manage
+different versions of your models. As a result, you can
+recreate a model version if needed and provide traceability
+for your deployed models. Associate metadata with each
+version to document training data, hyperparameters, and
+performance metrics.
+- **Automate data processing for new
+training data**. Set up automated data processing
+workflows that prepare new data for training. Configure
+[Amazon S3](https://aws.amazon.com/s3/) event notifications to run Lambda functions or
+
+[AWS Step Functions](https://aws.amazon.com/step-functions/) workflows when new data becomes
+available. Use
+
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to manage features
+consistently across training and inference.
+- **Set up orchestration**. Use
+[AWS Step Functions Data Science SDK for SageMaker AI](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-python-sdk.html) to
+orchestrate complex ML workflows. Define each step in the
+workflow and configure alerts to initiate the process. For
+detecting new training data, combine
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) with Amazon CloudWatch Events to
+automatically start Step Function workflows.
+- **Implement deployment
+safeguards**. Use deployment techniques like
+blue-green deployment or canary releases to safely
+transition to new model versions. Monitor the performance of
+new models closely during initial deployment and configure
+automatic rollback if performance degrades.
+- **Create feedback loops**.
+Establish mechanisms to collect ground truth data from
+production to continually evaluate and improve your models.
+This might involve user feedback, delayed outcomes, or
+manual labeling processes for a subset of predictions.
+- **Document the retraining
+process**. Create comprehensive documentation for
+your retraining framework, including prompts, pipelines,
+evaluation criteria, and deployment strategies. This process
+fosters knowledge transfer and consistent application of the
+process.
+
+## Resources
+
+**Related documents:**
+
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html)
+- [Retraining
+Models on New Data](https://docs.aws.amazon.com/machine-learning/latest/dg/retraining-models-on-new-data.html)
+- [Data
+and model quality monitoring with SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Train
+a Machine Learning Model (using AWS Step Functions)](https://docs.aws.amazon.com/step-functions/latest/dg/sample-train-model.html)
+- [Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Best practices and design patterns for building machine learning workflows with Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/best-practices-and-design-patterns-for-building-machine-learning-workflows-with-amazon-sagemaker-pipelines/)
+- [Create SageMaker AI Pipelines for training, consuming and monitoring your batch use cases](https://aws.amazon.com/blogs/machine-learning/create-sagemaker-pipelines-for-training-consuming-and-monitoring-your-batch-use-cases/)
+- [Launch Amazon SageMaker AI Autopilot experiments directly from within Amazon SageMaker AI Pipelines to easily automate MLOps workflows](https://aws.amazon.com/blogs/machine-learning/automating-complex-deep-learning-model-training-using-amazon-sagemaker-debugger-and-aws-step-functions/)
+
+**Related videos:**
+
+- [Automating Machine Learning Workflows: Leveraging Amazon SageMaker AI Pipelines and Autopilot for Efficient Model Development and Deployment](https://aws.amazon.com/awstv/watch/f2ed03696ea/)
+
+**Related examples:**
+
+- [Amazon SageMaker AI MLOps Immersion Day](https://catalog.us-east-1.prod.workshops.aws/workshops/63069e26-921c-4ce1-9cc7-dd882ff62575/en-US/lab6-mlops)
+- [Amazon SageMaker AI MLOps](https://github.com/aws-samples/mlops-amazon-sagemaker-devops-with-ml)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp05.html*
+
+---
+
+# MLPERF06-BP06 Review for updated data and features for retraining
+
+Establishing a framework to regularly review and update your machine
+learning model's data and features is essential for maintaining
+model accuracy. As business environments evolve, new data patterns
+emerge that can impact your model's performance. By systematically
+reviewing your data and features at appropriate intervals, you can
+keep your models accurate and reliable.
+
+**Desired outcome:** You establish a
+systematic approach to monitor data changes, explore new features,
+and incorporate updated data into your models. Through regular data
+exploration and feature engineering, you maintain model accuracy
+even as underlying data patterns evolve. This creates a proactive
+rather than reactive approach to model maintenance and verifies that
+your ML solutions consistently deliver business value.
+
+**Common anti-patterns:**
+
+- Assuming that data patterns remain stable over time.
+- Retraining models only when performance degrades.
+- Failing to explore new potential features as business evolves.
+- Using the same feature engineering approach regardless of
+changing data characteristics.
+- Not establishing regular review schedules for data and feature
+updates.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model accuracy through updated training data and
+features.
+- Early detection of data drift and proactive model updates.
+- Continuous discovery of new, potentially valuable features.
+- Consistent model performance despite changing business
+conditions.
+- Extended model lifecycle and reduced need for complete rebuilds.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data is the foundation of a machine learning model, and its
+characteristics can change over time due to various factors such
+as seasonal variations, market shifts, or changes in customer
+behavior. Without a framework to regularly review and update your
+data and features, models can gradually become less accurate as
+they fail to account for these changes.
+
+Avoid assuming that data patterns remain stable over time. Many
+organizations retrain models only when performance degrades, fail
+to explore new potential features as their business evolves, and
+use the same feature engineering approach regardless of changing
+data characteristics.
+
+To implement this practice effectively, you need to understand the
+volatility of your business environment and establish appropriate
+review intervals. For example, retail businesses might need more
+frequent reviews during holiday seasons when consumer behavior
+changes rapidly. You also need tools to efficiently explore data,
+identify new patterns, and engineer features that capture these
+insights.
+
+Amazon SageMaker AI provides comprehensive capabilities for data
+preparation, feature engineering, and model monitoring. By using
+these tools, you can create an efficient pipeline for regularly
+reviewing and updating your model's data and features, providing
+continued accuracy and relevance.
+
+### Implementation steps
+
+- **Assess data volatility in your
+business environment**. Analyze how quickly your
+business data changes by examining historical data patterns
+and identifying seasonal trends, market shifts, or other
+factors that affect your data. This assessment can determine
+how frequently you need to review your model's data and
+features.
+- **Establish a review
+schedule**. Based on your data volatility
+assessment, create a calendar for regular data and feature
+reviews. For highly volatile environments, you may need
+monthly reviews, while more stable contexts might require
+quarterly or biannual reviews.
+- **Set up data monitoring**.
+Implement
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously track data
+drift by comparing production data against your model's
+training data. Configure alerts when deviations occur to run
+expedited reviews.
+- **Create a data exploration workflow
+with Amazon SageMaker AI Canvas**. Use
+[Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-data-prep.html) to build data exploration workflows.
+The unified SageMaker AI Studio environment provides seamless
+integration with S3, Redshift, and EMR for comprehensive
+data exploration, engineering, training, and deployment
+workflows. Canvas now includes enhanced no/low-code ML tools
+with templates, automation, and wizards that enable
+non-engineering users to train custom models for verticals
+like sales, fraud, and demand with minimal technical
+expertise. These workflows should include data
+visualizations, statistical analyses, and data quality
+assessments.
+- **Implement feature engineering
+processes**. Develop standardized feature
+engineering pipelines in SageMaker AI Data Wrangler that can
+transform raw data into model features. Include steps to
+identify potential new features during each review cycle.
+- **Integrate with SageMaker AI Feature
+Store**. Store engineered features in
+[Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html) to maintain feature
+consistency between training and inference. This creates a
+single source of truth for features and simplifies
+retraining with updated data.
+- **Establish an evaluation
+framework**. Create a systematic approach to
+compare model performance using original features versus
+updated or new features. This quantifies the impact of
+feature changes and supports data-driven decisions about
+model updates.
+- **Form a cross-functional review
+team**. Assemble a team including data scientists,
+domain experts, and business stakeholders who can
+collectively evaluate data changes, validate new features,
+and authorize model retraining when necessary.
+- **Document changes and maintain
+version control**. Track changes to data sources,
+feature definitions, and transformation logic using version
+control systems. This creates an audit trail and supports
+reproducibility.
+- **Automate the retraining
+pipeline**. Use
+[Amazon SageMaker AI Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html) to create automated workflows
+that can retrain models with updated data and features when
+approved by the review team.
+
+## Resources
+
+**Related documents:**
+
+- [Automate
+data preparation with Amazon SageMaker AI Canvas](https://docs.aws.amazon.com/sagemaker/latest/dg/canvas-data-export.html)
+- [Data
+and model quality monitoring with SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [No-code
+data preparation for time series forecasting using Amazon SageMaker AI Canvas](https://aws.amazon.com/blogs/machine-learning/no-code-data-preparation-for-time-series-forecasting-using-amazon-sagemaker-canvas/)
+
+**Related videos:**
+
+- [Introducing
+Amazon SageMaker AI Canvas](https://www.youtube.com/watch?v=Tb4NTq9n_Hc)
+- [Automating
+Machine Learning Workflows with SageMaker AI Pipelines](https://aws.amazon.com/awstv/watch/f2ed03696ea/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlperf06-bp06.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLREL01.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLREL01.md
@@ -1,0 +1,350 @@
+# MLREL01
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLREL01-BP01 Use APIs to abstract change from model consuming applications
+
+APIs abstract changes from model-consuming applications, keeping
+machine learning solutions flexible and resilient. Establishing an
+abstraction layer between ML models and consuming applications
+enables model updates, replacements, or enhancements without
+disrupting existing workloads.
+
+**Desired outcome:** You have a
+flexible application and API design that isolates machine learning
+model implementations from consuming applications. You make changes
+to ML models with minimal or no disruption to existing applications.
+Your ML endpoints are well-documented and accessible, and changes to
+underlying models do not require extensive modifications to
+downstream applications.
+
+**Common anti-patterns:**
+
+- Directly embedding model code within applications.
+- Hardcoding model versions or parameter specifications in client
+applications.
+- Lacking proper API documentation and version control.
+- Designing rigid interfaces that break when model inputs or
+outputs change.
+- Creating tight coupling between ML models and consuming
+applications.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces downtime when updating or replacing ML models.
+- Simplifies model deployment and versioning processes.
+- Increases agility and flexibility when evolving ML capabilities.
+- Lowers maintenance costs for applications using ML models.
+- Enhances ability to A/B test different model versions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Abstracting changes from model-consuming applications requires
+thoughtful API design and implementation. Create a well-designed
+API layer between ML models and applications so that you can make
+modifications to models without disrupting services. This approach
+involves developing stable interfaces that hide underlying
+complexity and implementation details of ML models.
+
+When designing these APIs, focus on creating contracts that are
+flexible enough to accommodate model evolution while maintaining
+backward compatibility. Document APIs thoroughly so developers
+consuming models understand how to interact with them correctly.
+Consider implementing versioning strategies that allow introducing
+new model capabilities while supporting existing clients.
+
+### Implementation steps
+
+- **Adopt best practices in API
+design**. Expose ML endpoints through APIs so
+changes to the model can be introduced without disrupting
+upstream communications. Create a well-designed API contract
+that focuses on business capabilities rather than technical
+implementation details. Document your API in a central
+repository or documentation site so calling services can
+understand API routes and flags. Communicate changes to your
+API with calling services.
+- **Implement API versioning**.
+Use versioning strategies for APIs to enable backward
+compatibility while supporting new features. Consider using
+URL path versioning (for example,
+/v1/predict), header-based versioning, or
+query parameter versioning depending on organizational
+standards. This allows introducing new model versions
+without breaking existing client applications.
+- **Deploy models in Amazon SageMaker AI**. After training your model, deploy it
+using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to get predictions. To establish a
+persistent endpoint for one prediction at a time, use
+SageMaker AI hosting services. For predictions on entire
+datasets, use SageMaker AI batch transform. SageMaker AI provides
+flexibility in deployment options, including
+[multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html),
+[serverless
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html), and
+[asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html).
+- **Use Amazon API Gateway to create
+APIs**.
+[Amazon API Gateway](https://aws.amazon.com/api-gateway/) is a fully managed service that enables
+developers to create, publish, maintain, monitor, and secure
+APIs. Using API Gateway, you can create RESTful APIs and
+WebSocket APIs that enable real-time two-way communication
+applications. API Gateway supports containerized and
+serverless workloads, as well as web applications.
+- **Implement request and response
+transformations**. Use API Gateway's mapping
+templates to transform client requests to match your model's
+input format and transform model responses to maintain a
+consistent API contract. This allows changing model
+implementations without requiring client applications to
+change how they format requests or interpret responses.
+- **Add caching and
+throttling**. Configure API Gateway's caching
+capability to improve performance and reduce costs for
+frequently accessed predictions. Implement throttling to
+protect ML endpoints from traffic spikes and provide
+consistent performance. Use
+[SageMaker AI
+Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to optimize endpoint
+configurations for optimal latency and cost performance.
+- **Monitor and analyze API
+usage**. Set up monitoring and logging for APIs to
+understand how they are being used and identify potential
+issues. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) metrics and logs to track API performance,
+errors, and usage patterns. This data can optimize ML
+endpoints and identify opportunities for improvement.
+- **Consider inference components for
+shared endpoints**. Use
+[SageMaker AI
+inference components](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-deploy-models.html) to deploy multiple models to
+shared endpoints, improving resource utilization and
+reducing costs while maintaining API abstraction.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+deployment options in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-deployment.html)
+- [What
+is Amazon API Gateway?](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html)
+- [Real-time
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Deploying
+ML models using SageMaker AI Serverless Inference](https://aws.amazon.com/blogs/machine-learning/deploying-ml-models-using-sagemaker-serverless-inference-preview/)
+- [Optimize
+deployment cost of Amazon SageMaker AI JumpStart foundation
+models with Amazon SageMaker AI asynchronous endpoints](https://aws.amazon.com/blogs/machine-learning/optimize-deployment-cost-of-amazon-sagemaker-jumpstart-foundation-models-with-amazon-sagemaker-asynchronous-endpoints/)
+
+**Related videos:**
+
+- [Amazon
+Sagemaker Serverless Inference](https://www.youtube.com/watch?v=esG_Q8egwMU)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Examples Repository](https://github.com/aws/amazon-sagemaker-examples)
+- [Amazon SageMaker AI MLOps Workshop](https://github.com/aws-samples/amazon-sagemaker-mlops-workshop)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel01-bp01.html*
+
+---
+
+# MLREL01-BP02 Adopt a machine learning microservice strategy
+
+Machine learning systems can be effectively implemented through a
+microservice architecture that breaks down complex business problems
+into smaller, loosely coupled components. This approach enables
+distributed development, improves scalability, and facilitates
+change management while reducing the impact of single failures on
+the overall workload.
+
+**Desired outcome:** You decompose
+complex business problems into manageable components with clear
+interfaces. You have a more resilient ML system architecture that
+can scale individual components independently, enable faster
+iterations, and allow specialized teams to work simultaneously on
+different parts of the solution. Your organization benefits from
+improved fault isolation, simplified testing, and greater
+flexibility to update or replace individual ML models without
+affecting the entire system.
+
+**Common anti-patterns:**
+
+- Building monolithic ML applications where functionality is
+tightly coupled in a single runtime.
+- Creating overly complex microservices that serve multiple
+purposes.
+- Implementing microservices without clear business domain
+boundaries.
+- Neglecting proper service interfaces and communication patterns
+between microservices.
+- Overlooking the operational complexity introduced by distributed
+systems.
+
+**Benefits of establishing this best
+practice:**
+
+- Improves resilience through isolation of failures to individual
+components.
+- Enhances scalability by allowing independent scaling of
+individual services.
+- Accelerates development cycles through parallel work streams.
+- Simplifies testing and deployment of individual components.
+- Provides flexibility to use different technologies for different
+ML model requirements.
+- Aligns technical components with business domains.
+- Eases integration of new ML models and capabilities.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When implementing ML systems, adopt a microservice architecture to
+break down complex problems into manageable components. Rather
+than creating one large monolithic application that handles the
+entirety of of your machine learning workflow, you can develop
+specialized services that handle specific functions like data
+preprocessing, model training, inference, and business logic
+integration. This approach is particularly valuable for machine
+learning applications where different models may have varying
+resource requirements, development cycles, and deployment
+frequencies.
+
+Microservices provide the flexibility to use different
+technologies for different parts of your ML system. For example,
+you might use Python-based services for data science tasks while
+implementing Java-based services for integration with enterprise
+systems. By establishing clear service interfaces, you verify that
+these components work together seamlessly while maintaining
+freedom.
+
+When designing your ML microservices, focus on business domains
+rather than technical functions. Instead of creating a generic
+prediction service, you might create more specific services like
+*customer churn prediction* or
+*product recommendation* that align with
+business capabilities. This domain-driven approach makes your
+architecture more intuitive and adaptable to changing business
+needs.
+
+### Implementation steps
+
+- **Adopt a microservice
+strategy**. Implement a service-oriented
+architecture (SOA) by making software components reusable
+through service interfaces. Break your monolithic
+application into separate components along business
+boundaries or logical domains. Focus on building
+single-purpose applications that can be composed in
+different ways to deliver various end-user experiences.
+Design clear APIs between services to implement proper
+isolation and communication patterns.
+- **Define domain boundaries**.
+Analyze your machine learning workflow and identify natural
+boundaries between different functional areas. Map out the
+data flow and determine where service boundaries make sense.
+Consider creating separate microservices for data ingestion,
+preprocessing, feature engineering, model training, model
+serving, and business logic integration. Verify that each
+microservice has a clear, single responsibility within your
+ML system.
+- **Choose appropriate AWS
+services**. Select AWS services that best support
+your microservice architecture.
+[AWS Lambda](https://aws.amazon.com/lambda/) provides serverless compute that scales
+automatically and charges only for the compute time
+consumed. For container-based deployments, use
+[AWS Fargate](https://aws.amazon.com/fargate/) to run containers without managing
+infrastructure. Consider
+[Amazon ECS](https://aws.amazon.com/ecs/) or
+[Amazon EKS](https://aws.amazon.com/eks/) for container orchestration needs, and
+[Amazon API Gateway](https://aws.amazon.com/api-gateway/) to manage and secure your microservice
+APIs.
+- **Implement model serving
+infrastructure**. Set up efficient model serving
+using services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) for deploying, monitoring, and scaling ML
+models. SageMaker AI endpoints provide a managed solution for
+hosting models and handling inference requests.
+Alternatively, use
+[AWS Lambda](https://aws.amazon.com/lambda/) for lightweight, event-driven inferencing or
+containers on
+[AWS Fargate](https://aws.amazon.com/fargate/) for more complex requirements.
+- **Establish communication
+patterns**. Design how your microservices will
+communicate with each other. Use synchronous REST APIs for
+direct request-response patterns, and asynchronous
+communication through
+[Amazon SNS](https://aws.amazon.com/sns/) or
+[Amazon SQS](https://aws.amazon.com/sqs/) for event-driven architectures. Implement
+[AWS EventBridge](https://aws.amazon.com/eventbridge/) to create event-driven workflows between
+your ML microservices and other AWS services.
+- **Implement monitoring and
+observability**. Set up comprehensive monitoring
+for your ML microservices using
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/). Track operational metrics like latency,
+throughput, and error rates along with ML-specific metrics
+such as prediction accuracy or drift. Implement distributed
+tracing with
+[AWS X-Ray](https://aws.amazon.com/xray/) to troubleshoot issues across service
+boundaries and identify performance bottlenecks.
+- **Automate deployments**.
+Implement CI/CD pipelines using
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) and
+[AWS CodeBuild](https://aws.amazon.com/codebuild/) to automate the testing and deployment of
+your ML microservices. Use infrastructure as code with
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to define and provision your microservice
+infrastructure consistently.
+- **Implement security best
+practices**. Secure your ML microservices by
+implementing proper authentication and authorization using
+[Amazon Cognito](https://aws.amazon.com/cognito/) or
+[AWS IAM](https://aws.amazon.com/iam/). Use
+[AWS WAF](https://aws.amazon.com/waf/) to protect your APIs from common web exploits,
+and encrypt sensitive data using
+[AWS KMS](https://aws.amazon.com/kms/) to improve data privacy and adhere to regulatory
+requirements.
+
+## Resources
+
+**Related documents:**
+
+- [Implementing
+Microservices on AWS](https://docs.aws.amazon.com/whitepapers/latest/microservices-on-aws/microservices-on-aws.html)
+- [AWS Lambda Documentation](https://docs.aws.amazon.com/lambda/index.html)
+- [Architect
+for AWS Fargate for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/what-is-fargate.html)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+- [What
+is the AWS Serverless Application Model (AWS SAM)?](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html)
+- [Build
+and deploy ML inference applications from scratch using Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/build-and-deploy-ml-inference-applications-from-scratch-using-amazon-sagemaker/)
+
+**Related examples:**
+
+- [Run
+a Serverless "Hello, World" with AWS Lambda](https://aws.amazon.com/getting-started/hands-on/run-serverless-code/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel01-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLREL02.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLREL02.md
@@ -1,0 +1,547 @@
+# MLREL02
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLREL02-BP01 Use a data catalog
+
+Process data across multiple data stores using data catalog
+technology. An advanced data catalog service can enable ETL process
+integration. This approach improves reliability and efficiency.
+
+**Desired outcome:** You establish a
+centralized system that inventories your ML data assets across the
+organization. You can track, discover, and manage data
+transformations, and your stakeholders can find and use appropriate
+datasets. With a complete data catalog in place, you gain better
+data governance, reduce duplication of effort, increase data
+quality, and accelerate ML model development through streamlined
+data preparation workflows.
+
+**Common anti-patterns:**
+
+- Maintaining separate, isolated data silos without centralized
+metadata.
+- Manual tracking of data assets using spreadsheets or wiki pages.
+- Failing to document data transformations and lineage.
+- Rebuilding ETL processes for each new ML project.
+- Relying on tribal knowledge for understanding data
+characteristics.
+
+**Benefits of establishing this best
+practice:**
+
+- Provides centralized visibility of available data assets.
+- Improves data governance.
+- Reduces time spent searching for and understanding data.
+- Enhances data quality through consistent transformation
+processes.
+- Strengthens collaboration between data engineers and data
+scientists.
+- Accelerates ML model development with faster data preparation.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+A data catalog is critical infrastructure for machine learning
+workloads to succeed. Without proper cataloging, data scientists
+spend excessive time searching for, understanding, and preparing
+data rather than analyzing it or building models. A comprehensive
+data catalog provides a centralized inventory of your data assets,
+complete with metadata, transformation history, and usage
+information.
+
+When implementing a data catalog for ML workloads, focus on
+creating a single source of truth for data discovery. The catalog
+should document where data resides, what transformations have been
+applied, and how it can be accessed. This reduces the time spent
+on data preparation, which typically consumes 60-80% of a data
+scientist's time.
+
+For AWS environments, the AWS AWS Glue Data Catalog offers a powerful
+solution as it integrates seamlessly with other AWS analytics and
+machine learning services. By implementing a data catalog as part
+of your ML infrastructure, you create a foundation for consistent,
+reliable data processing that supports both current and future ML
+initiatives.
+
+### Implementation steps
+
+- **Set up AWS AWS Glue Data Catalog**. Establish the
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html) as your central metadata
+repository. This fully managed service provides a unified
+view of your data across multiple data stores, making it
+accessible to various AWS services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/),
+[Amazon EMR](https://aws.amazon.com/emr/),
+[Amazon Athena](https://aws.amazon.com/athena/), and
+[Amazon Redshift](https://aws.amazon.com/redshift/).
+- **Define your metadata
+strategy**. Determine what metadata to capture
+about each dataset, including business definitions, data
+lineage, quality metrics, and usage patterns.
+Well-documented metadata assists data scientists in quickly
+understanding if a dataset is appropriate for their modeling
+needs.
+- **Populate the data
+catalog**. Use
+[AWS Glue crawlers](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html) to automatically discover schemas, data
+types, and statistics from your data sources. Crawlers can
+scan various data stores including Amazon S3, Amazon RDS,
+and other database systems. Systematically add your data
+sources to build comprehensive coverage.
+- **Implement ETL processes with AWS Glue**. Create ETL jobs that transform raw data
+into formats optimized for machine learning.
+[AWS Glue](https://aws.amazon.com/glue/) can automatically generate Python or Scala code
+for these transformations, reducing development time and
+improving consistency across different data processing
+pipelines.
+- **Establish data lineage
+tracking**. Configure your data catalog to track
+transformations and maintain clear lineage information. With
+data lineage tracking, data scientists can understand data
+provenance, which builds trust in the datasets used for
+model training.
+- **Integrate with ML
+workflows**. Connect your AWS AWS Glue Data Catalog
+with Amazon SageMaker AI to streamline data access for model
+training. For enterprise environments, implement
+[Amazon SageMaker AI Catalog](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects-templates-sm.html) as a central metadata hub for ML
+and data assets, enabling secure sharing and governed access
+via Amazon DataZone integration. This integration allows
+data scientists to discover and use properly prepared
+datasets directly from their modeling environments.
+- **Implement access controls and
+governance**. Configure appropriate permissions for
+your data catalog using
+[AWS IAM](https://aws.amazon.com/iam/) roles. Verify that data scientists have access to
+the metadata and datasets they need while maintaining
+security and regulatory adherence.
+- **Automate catalog
+maintenance**. Set up automated processes to keep
+your data catalog current as new data arrives and
+transformations occur. Regular updates verify that data
+scientists have access to the latest information about
+available datasets.
+- **Monitor and measure
+impact**. Track key metrics like time saved in data
+discovery, reduction in redundant data preparation work, and
+improvements in model development cycles to quantify the
+benefits of your data catalog implementation.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI and when to use Amazon SageMaker AI vs Amazon
+DataZone](https://docs.aws.amazon.com/datazone/latest/userguide/sagemaker-datazone.html)
+- [The
+lakehouse architecture of Amazon SageMaker AI](https://aws.amazon.com/sagemaker/lakehouse/)
+- [Amazon SageMaker AI Unified Studio](https://aws.amazon.com/sagemaker/unified-studio/)
+- [Catalog
+and search](https://docs.aws.amazon.com/whitepapers/latest/building-data-lakes/data-cataloging.html)
+- [Getting
+started with serverless ETL on AWS Glue](https://docs.aws.amazon.com/prescriptive-guidance/latest/serverless-etl-aws-glue/metadata-management.html)
+- [Using
+crawlers to populate the Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html)
+- [AWS modern data architecture](https://docs.aws.amazon.com/prescriptive-guidance/latest/strategy-aws-data/aws-architecture.html)
+- [Moving
+from development to automated ML pipelines using Amazon SageMaker AI and AWS Glue](https://aws.amazon.com/blogs/machine-learning/moving-from-notebooks-to-automated-ml-pipelines-using-amazon-sagemaker-and-aws-glue/)
+- [How
+Genworth built a serverless ML pipeline on AWS using Amazon SageMaker AI and AWS Glue](https://aws.amazon.com/blogs/machine-learning/how-genworth-built-a-serverless-ml-pipeline-on-aws-using-amazon-sagemaker-and-aws-glue/)
+- [How
+to build and automate a serverless data lake using AWS Glue](https://aws.amazon.com/blogs/big-data/build-and-automate-a-serverless-data-lake-using-an-aws-glue-trigger-for-the-data-catalog-and-etl-jobs/)
+
+**Related videos:**
+
+- [Amazon SageMaker AI Lakehouse - Unified, open, and secure data
+lakehouse](https://www.youtube.com/watch?v=wH0dZLtS88Y)
+- [Understanding
+Amazon S3 Tables: Architecture, performance, and
+integration](https://www.youtube.com/watch?v=e1ypMWSHgsM)
+- [Accelerate
+your Analytics and AI with Amazon SageMaker AI LakeHouse](https://www.youtube.com/watch?v=qZTbS0xPN-U)
+- [Unifying
+data governance with Immuta and AWS Lake Formation](https://www.youtube.com/watch?v=X09-n2jJZKw)
+
+**Related examples:**
+
+- [Explaining
+Credit Decisions with Amazon SageMaker AI](https://github.com/awslabs/sagemaker-explaining-credit-decisions)
+- [How
+to build an end-to-end Machine Learning pipeline using AWS Glue, Amazon S3, Amazon SageMaker AI and Amazon Athena](https://github.com/aws-samples/amazon-sagemaker-predict-accessibility)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel02-bp01.html*
+
+---
+
+# MLREL02-BP02 Use a data pipeline
+
+Automate the processing, movement, and transformation of data
+between different compute and storage services. This automation
+enables data processing that is fault tolerant, repeatable, and
+highly available.
+
+**Desired outcome:** You achieve
+streamlined and consistent data processing workflows that
+automatically handle data movement and transformations. You can
+process your machine learning data with increased reliability,
+repeatability, and availability, while reducing manual effort and
+potential errors. Your data processing becomes more efficient and
+scalable, enabling you to focus on deriving insights rather than
+managing data logistics.
+
+**Common anti-patterns:**
+
+- Manually moving and transforming data between systems.
+- Creating one-off scripts for data processing tasks.
+- Inconsistent data transformation processes across teams.
+- Neglecting error handling and recovery mechanisms in data
+workflows.
+- Not versioning data processing code or configurations.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces manual errors and inconsistencies in data processing.
+- Increases repeatability and reliability of data transformations.
+- Enables fault tolerance and automatic recovery mechanisms.
+- Improves scalability of data processing workflows.
+- Facilitates collaboration through standardized data processing
+patterns.
+- Enhances traceability and governance of data transformations.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data is the foundation of a machine learning workload, and how you
+handle this data directly impacts the quality of your ML models.
+Data pipelines automate and standardize the process of collecting,
+cleaning, transforming, and delivering data to your ML workflows.
+Without proper data pipelines, your ML initiatives can suffer from
+inconsistent data quality, limited reproducibility, and
+operational inefficiencies.
+
+Creating effective data pipelines requires careful planning around
+data sources, transformation logic, error handling, and monitoring
+capabilities. By implementing automated data pipelines, you verify
+that your data preparation follows a consistent, repeatable
+process that can scale with your ML workload demands. This
+approach leads to more reliable models and faster deployment
+cycles.
+
+AWS provides a comprehensive set of tools specifically designed to
+build robust ML data pipelines, with Amazon SageMaker AI offering
+integrated capabilities for the entire ML lifecycle. These tools
+enable you to focus on deriving insights from your data rather
+than managing infrastructure.
+
+### Implementation steps
+
+- **Assess your data processing
+requirements**. Begin by identifying your data
+sources, required transformations, and destination systems.
+Document the flow of data from source to consumption, noting
+data quality requirements, validation rules, or business
+logic that must be applied during processing.
+- **Implement data preparation and
+wrangling processes**. Establish comprehensive data
+preparation workflows that transform raw data into ML-ready
+formats. Use a combination of AWS services and tools to:
+
+Connect to data sources including
+[Amazon S3](https://aws.amazon.com/s3/),
+[Amazon Athena](https://aws.amazon.com/athena/),
+[Amazon Redshift](https://aws.amazon.com/redshift/), and other databases using appropriate
+connectors
+- Explore and profile your data using
+[Amazon EMR](https://aws.amazon.com/emr/) with Apache Spark or
+[AWS Glue](https://aws.amazon.com/glue/) interactive sessions to identify patterns,
+anomalies, and data quality issues
+- Transform your data using
+[AWS Glue ETL jobs](https://docs.aws.amazon.com/glue/latest/dg/author-job.html),
+[Amazon EMR](https://aws.amazon.com/emr/) clusters, or
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) jobs with custom transformation
+scripts
+- Generate data quality reports and validation checks
+using
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) or custom validation scripts to
+identify issues before model training
+- Create reusable data preparation workflows using
+[AWS Glue workflows](https://docs.aws.amazon.com/glue/latest/dg/workflows_overview.html) or
+[SageMaker AI
+Pipelines](https://aws.amazon.com/sagemaker/pipelines/) that verify consistency across
+different datasets and projects
+
+- **Build automated ML workflows with
+SageMaker AI Pipelines**. After creating your data
+preparation workflow, export it to
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) to automate your entire ML
+workflow. SageMaker AI Pipelines helps you:
+
+Create end-to-end ML workflows that combine data
+preparation, model training, evaluation, and deployment
+- Automate pipeline execution on a schedule or
+trigger-based approach
+- Track lineage of ML artifacts for governance
+- Implement quality gates to verify that models meet
+performance criteria
+- Version control your pipelines for reproducibility
+
+- **Implement error handling and
+monitoring**. Configure your pipelines to handle
+errors gracefully and provide visibility into pipeline
+performance:
+
+Set up retry mechanisms for transient failures
+- Create notification systems for critical pipeline
+failures
+- Implement logging throughout your pipeline steps
+- Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor pipeline metrics and set up
+alerts
+
+- **Version and store your data
+artifacts**. Maintain traceability of your data
+processing:
+
+Store processed datasets in Amazon S3 with appropriate
+versioning
+- Use
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to create reusable
+feature repositories
+- Document data transformations and their business logic
+- Implement data lineage tracking to understand data
+provenance
+
+- **Integrate with your existing ML
+workflow**. Connect your data pipelines to other
+components of your ML environment:
+
+Feed processed data directly into model training jobs
+- Integrate with model registries and deployment pipelines
+- Establish feedback loops from model performance back to
+data preparation
+
+- **Scale your data processing as
+needed**. Configure your pipelines to handle
+growing data volumes:
+
+Use distributed processing for large datasets with
+services like
+[Amazon EMR](https://aws.amazon.com/emr/)
+- Implement incremental processing patterns for streaming
+data
+- Configure compute resources appropriately for each
+pipeline stage
+
+## Resources
+
+**Related documents:**
+
+- [Data
+transformation workloads with SageMaker AI Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)
+- [Pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Get
+started with Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-getting-started.html)
+- [Data
+preparation and cleaning](https://docs.aws.amazon.com/prescriptive-guidance/latest/modern-data-centric-use-cases/data-preparation-cleaning.html)
+- [Run
+secure processing jobs using PySpark in Amazon SageMaker AI
+Pipelines](https://aws.amazon.com/blogs/machine-learning/run-secure-processing-jobs-using-pyspark-in-amazon-sagemaker-pipelines/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+
+**Related videos:**
+
+- [AWS Glue and Amazon SageMaker AI Studio Integration](https://aws.amazon.com/awstv/watch/5d00e03ffe3/)
+- [Build,
+automate, manage, and scale ML workflows using Amazon SageMaker AI Pipelines](https://www.youtube.com/watch?v=Hvz2GGU3Z8g)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Examples GitHub Repository](https://github.com/aws/amazon-sagemaker-examples)
+- [MLOps
+Workshop with Amazon SageMaker AI Pipelines](https://catalog.us-east-1.prod.workshops.aws/workshops/741835d3-a2bf-4cb6-81f0-d0bb4a62edca/en-US)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel02-bp02.html*
+
+---
+
+# MLREL02-BP03 Automate managing data changes
+
+Effective management of machine learning training data changes is
+crucial for maintaining model reproducibility and providing
+consistent performance over time. By implementing automated version
+control for training data, you can precisely recreate a model
+version when needed and maintain a clear audit trail of data
+transformations.
+
+**Desired outcome:** You establish
+automated processes for tracking and managing changes to your
+training data using version control technology. You gain the ability
+to reproduce model versions exactly as they were originally created,
+track data lineage through your ML pipeline, and maintain consistent
+model performance across deployments. Your ML operations become more
+reliable, transparent, and compatible with governance requirements.
+
+**Common anti-patterns:**
+
+- Manually tracking data versions in spreadsheets or
+documentation.
+- Storing multiple versions of datasets with inconsistent naming
+conventions.
+- Neglecting to record relationships between datasets and
+resulting models.
+- Not preserving feature engineering transformations applied to
+training data.
+- Relying on ad-hoc backup processes instead of systematic version
+control.
+
+**Benefits of establishing this best
+practice:**
+
+- Enables reproducible machine learning by maintaining exact data
+version history.
+- Improves troubleshooting by allowing precise recreation of model
+versions.
+- Enhances collaboration among data scientists through shared
+version control.
+- Provides audit trail for governance requirements.
+- Reduces errors in model deployment by providing consistent
+training data.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Managing changes to training data is fundamental to maintaining
+reproducible machine learning models. As your data evolves through
+acquisition, cleaning, and feature engineering, implementing
+automated version control allows you to track these changes
+systematically. This provides confidence that you can recreate any
+model version precisely when needed, which is essential for
+troubleshooting, compliance alignment, and proviidng consistent
+performance.
+
+By implementing automated data versioning, you create a traceable
+history of your training data that integrates seamlessly with your
+ML pipeline. This approach mirrors software development best
+practices by treating data as a critical asset requiring the same
+level of version control as code. When data changes occur, whether
+through new acquisitions or transformations, your versioning
+system automatically captures these changes, making it possible to
+track model lineage from training data to deployment.
+
+### Implementation steps
+
+- **Implement a data version control
+system**. Begin by setting up a data version
+control system that can handle ML datasets efficiently.
+Tools like Git LFS, DVC (Data Version Control), or AWS
+solutions can be used to track changes in your training
+datasets. These tools provide mechanisms to capture dataset
+metadata and references without storing the entire dataset
+in the version control repository.
+- **Establish a data management
+strategy**. Define clear workflows for how data
+should be versioned, including naming conventions, branching
+strategies, and metadata requirements. Document how data
+should flow through your ML pipeline and how versions will
+be tracked at each stage.
+- **Use AWS MLOps Framework**.
+Implement the
+[AWS MLOps Framework](https://aws.amazon.com/sagemaker/ai/mlops/) to establish a standardized interface
+for managing ML pipelines. This framework works with both
+Amazon Machine Learning services and third-party services,
+providing a comprehensive solution for ML operations. The
+framework allows you to upload trained models (bring your
+own model), configure pipeline orchestration, and monitor
+operations—all while maintaining version control of data
+assets.
+- **Integrate with SageMaker AI Model
+Registry**. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to track model versions and
+their associated artifacts. Model Registry maintains
+comprehensive records of model lineage, including which
+datasets were used for training and validation, preserving
+the connection between models and their source data.
+- **Establish CI/CD for ML
+pipelines**. Set up continuous integration and
+continuous deployment (CI/CD) pipelines specifically
+designed for ML workflows using
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/). This assists you to version and
+test changes to both code and data properly before moving to
+production.
+- **Create reproducible training
+environments**. Use container technology to package
+your training environment along with references to specific
+data versions.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides mechanisms to create reproducible
+training jobs that can reference specific versions of your
+datasets stored in
+[Amazon S3](https://aws.amazon.com/s3/).
+- **Implement data quality
+monitoring**. Set up automated monitoring of data
+quality metrics to detect drift or anomalies in incoming
+data. Tools like
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) can identify when new data
+differs from the baseline training data, allowing you to
+make informed decisions about model retraining.
+- **Configure automated
+testing**. Implement automated tests that validate
+data consistency and model performance when data versions
+change. This verifies that new data meets quality standards
+before being used in training or inference.
+- **Document data versioning
+procedures**. Create comprehensive documentation
+that describes your data versioning strategy, including how
+to retrieve specific versions of datasets and how to match
+models with their corresponding training data versions.
+
+## Resources
+
+**Related documents:**
+
+- [Implement
+MLOps](https://docs.aws.amazon.com/sagemaker/latest/dg/mlops.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Pipelines Brings DevOps Capabilities to your Machine
+Learning Projects](https://aws.amazon.com/blogs/machine-learning/promote-pipelines-in-a-multi-environment-setup-using-amazon-sagemaker-model-registry-hashicorp-terraform-github-and-jenkins-ci-cd/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Fully
+managed MLflow 3.0 on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+
+**Related videos:**
+
+- [Implementing
+End-to-End MLOps Solutions with Amazon SageMaker AI](https://aws.amazon.com/awstv/watch/5057107a7fc/)
+- [Accelerate
+production for gen AI using Amazon SageMaker AI MLOps &
+FMOps](https://www.youtube.com/watch?v=-3Otl7GVeCc)
+- [Deliver
+high-performance ML models faster with MLOps tools](https://www.youtube.com/watch?v=T9llSCYJXxc)
+
+**Related examples:**
+
+- [Amazon SageMaker AI secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+- [ML
+Pipelines using Amazon SageMaker AI](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops/sm-mlflow_pipelines)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel02-bp03.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLREL03.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLREL03.md
@@ -1,0 +1,679 @@
+# MLREL03
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLREL03-BP01 Enable CI/CD/CT automation with traceability
+
+Enable source code, data, and artifact version control of ML
+workloads to enable roll back to a specific version. Incorporate
+continuous integration (CI), continuous delivery (CD), and
+continuous training (CT) practices to ML workload operations,
+providing automation with added traceability.
+
+**Desired outcome:** You establish
+automated pipelines that handle the entire machine learning
+lifecycle from development to deployment and continuous training.
+You gain the ability to track every artifact, model version,
+dataset, and code change throughout the ML workflow, enabling
+transparent auditing, reproducibility of experiments, and the
+capability to quickly roll back to previous versions when needed.
+
+**Common anti-patterns:**
+
+- Manual deployment and training processes without version
+control.
+- Lack of documentation on model lineage and data provenance.
+- Inability to reproduce ML experiments due to missing environment
+configurations.
+- Performing model training only when necessary without automated
+testing and validation.
+- Siloed development and operations teams working separately on ML
+workflows.
+
+**Benefits of establishing this best
+practice:**
+
+- Increases productivity through automation of repetitive ML
+development tasks.
+- Improves reproducibility of ML experiments and model training.
+- Enhances collaboration between data scientists and operations
+teams.
+- Accelerates time-to-market for ML-powered features and
+applications.
+- Reduces risk through ability to quickly roll back problematic
+deployments.
+- Improves adherence to audit requirements through comprehensive
+traceability.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Implementing CI/CD/CT for machine learning workloads requires a
+different approach than traditional software development due to
+the data-centric nature of ML systems. While software CI/CD
+focuses primarily on code, ML pipelines must also track data,
+model artifacts, and training environments for full
+reproducibility.
+
+MLOps combines DevOps practices with machine learning to automate
+and streamline the entire lifecycle of ML systems. By implementing
+MLOps with traceability, you create a foundation that supports
+reproducible science, auditability, and operational excellence.
+This allows your organization to deploy ML models with confidence
+while maintaining the ability to understand exactly how each model
+was created and what data influenced its behavior.
+
+Amazon SageMaker AI provides a comprehensive solution to implement
+MLOps practices with built-in version control, lineage tracking,
+and pipeline automation. By using SageMaker AI and complementary AWS
+services, you can establish a robust MLOps framework that makes
+your ML workflows reproducible, traceable, and maintainable.
+
+### Implementation steps
+
+- **Implement version control for ML
+artifacts**. Set up repositories for code, data,
+models, and configurations using version control systems.
+Use
+[AWS CodeCommit](https://aws.amazon.com/codecommit/) or integrate with GitHub to version your
+ML code and configurations. For data and models, use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to version and catalog your
+models, creating a system of record that tracks the lineage
+of each model.
+- **Set up data versioning and lineage
+tracking**. Implement data version control to track
+changes in your datasets over time. Use
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to store, share, and manage
+features for ML development, which you can use to track and
+version feature values. Implement Lineage Tracking to track
+the relationships between ML artifacts including data,
+models, training jobs, and deployments.
+- **Establish continuous integration
+practices**. Configure automated tests that verify
+both code quality and model performance. Set up CI pipelines
+using
+[AWS CodeBuild](https://aws.amazon.com/codebuild/) that run unit tests, integration tests, and
+model quality tests when changes are pushed to your
+repositories. Implement automated code review practices to
+maintain quality standards across your ML codebase.
+- **Build continuous delivery pipelines
+for models**. Create automated deployment pipelines
+for ML models using
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) or
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/). Configure pipelines to include stages
+for data preparation, model training, evaluation, and
+deployment. Implement approval gates for human validation
+before models are deployed to production environments.
+- **Implement continuous training
+mechanisms**. Set up automated retraining pipelines
+that can be triggered by data drift, scheduled intervals, or
+on-demand. Use Amazon SageMaker AI Pipelines to create
+end-to-end workflows for model retraining. Implement
+monitoring for model drift using
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) and trigger retraining when performance
+degrades below thresholds.
+- **Establish model governance and
+approval workflows**. Create a governance framework
+that requires appropriate reviews and approvals before
+models move to production. Use SageMaker AI Model Registry to
+implement model approval workflows with different approval
+stages. Configure integration with notification services
+like [Amazon SNS](https://aws.amazon.com/sns/) to alert stakeholders when models need review.
+- **Implement immutable infrastructure
+for reproducibility**. Use infrastructure as code
+(IaC) to define your ML environments consistently. Leverage
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to define your SageMaker AI environments,
+maintaining consistency across development, testing, and
+production. Create standardized container images for
+training and inference to improve environment
+reproducibility.
+- **Set up comprehensive monitoring and
+logging**. Implement monitoring for your ML
+pipelines and deployed models. Use
+[CloudWatch](https://aws.amazon.com/cloudwatch/)
+to track operational metrics of your pipeline runs and model
+endpoints. Configure SageMaker AI Model Monitor to track data
+drift, model drift, and prediction quality over time.
+- **Create rollback mechanisms for
+models and pipelines**. Establish automated
+rollback procedures that can quickly revert to previous
+model versions when issues are detected. Configure SageMaker AI
+endpoints with production variants to support blue/green
+deployments and canary testing, enabling safe rollbacks when
+needed.
+
+## Resources
+
+**Related documents:**
+
+- [Implement
+MLOps](https://docs.aws.amazon.com/sagemaker/latest/dg/mlops.html)
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [AWS DevOps Guidance](https://docs.aws.amazon.com/wellarchitected/latest/devops-guidance/devops-guidance.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Create
+Amazon SageMaker AI projects with image building CI/CD
+pipelines](https://aws.amazon.com/blogs/machine-learning/create-amazon-sagemaker-projects-with-image-building-ci-cd-pipelines/)
+
+**Related videos:**
+
+- [Deliver
+high-performance ML models faster with MLOps tools](https://www.youtube.com/watch?v=T9llSCYJXxc)
+- [Accelerate
+production for gen AI using Amazon SageMaker AI MLOps &
+FMOps](https://www.youtube.com/watch?v=-3Otl7GVeCc)
+
+**Related examples:**
+
+- [Amazon
+Sagemaker MLOps](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+- [Amazon SageMaker AI secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp01.html*
+
+---
+
+# MLREL03-BP02 Verify feature consistency across training and inference
+
+Provide consistent, scalable, and highly available features between
+training and inference using a feature storage. This results in
+reducing the training-serving skew by keeping feature consistency
+between training and inference.
+
+**Desired outcome:** You create a
+centralized feature repository where feature definitions are stored,
+versioned, and shared across your organization. This makes the same
+features used during model training consistently available during
+inference, which reduces training-serving skew. You can discover,
+reuse, and share features across different ML projects, reducing
+duplicate work and standardizing feature engineering practices.
+
+**Common anti-patterns:**
+
+- Recreating feature transformations separately for training and
+inference pipelines.
+- Storing features in different formats or locations for training
+versus production.
+- Lack of versioning for features, leading to inconsistencies when
+models are updated.
+- Duplicating feature engineering work across different teams or
+projects.
+- Using non-standardized approaches to feature storage and
+retrieval.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces training-serving skew, leading to more reliable model
+performance in production.
+- Increases developer productivity through feature reusability.
+- Standardizes feature definitions across the organization.
+- Improves model governance and auditability through feature
+versioning.
+- Saves costs by avoiding redundant feature computation and
+storage.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Feature consistency between training and inference is critical for
+machine learning system reliability. When the features used to
+train a model differ from those used during inference, model
+performance can degrade, a problem known as training-serving skew.
+To avoid this issue, you need a centralized feature repository
+that provides consistent access to the same feature definitions
+and transformations across both training and inference
+environments.
+
+A feature store serves as this centralized repository, enabling
+you to define, store, and retrieve features consistently. It
+provides mechanisms for versioning features, which verifies that
+you can maintain compatibility between models and the features
+they expect as your data and feature engineering processes evolve.
+Additionally, a feature store allows for the sharing and reuse of
+features across multiple ML projects, increasing efficiency and
+standardizing feature engineering practices across your
+organization.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI Feature
+Store**. Create and configure a
+[SageMaker AI
+Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to serve as your centralized repository
+for ML features. SageMaker AI Feature Store provides both
+online and offline storage capabilities: the online store
+supports low-latency, real-time inference use cases, while
+the offline store supports training and batch inference
+processes. Create a feature group that defines your feature
+structure, data types, and storage configurations using the
+SageMaker AI SDK or console.
+- **Define feature groups and
+schemas**. Organize your features into logical
+groups based on business domains, data sources, or ML use
+cases. Define schemas for your features, including data
+types, descriptions, and metadata. This organization makes
+features more discoverable and more straightforward to
+manage across your organization.
+- **Implement feature ingestion
+pipelines**. Build automated pipelines to ingest
+and process raw data into features. Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html),
+[AWS Glue](https://aws.amazon.com/glue/), or
+[Amazon EMR](https://aws.amazon.com/emr/) to transform raw data into feature values.
+Configure both batch ingestion for historical data and
+streaming ingestion for real-time updates using services
+like
+[Amazon Kinesis](https://aws.amazon.com/kinesis/) with SageMaker AI Feature Store.
+- **Develop feature retrieval
+mechanisms**. Create standardized ways to retrieve
+features for both training and inference. For training
+datasets, implement code that pulls features from the
+offline store, while for inference, develop services that
+query the online store. Verify that both paths use the same
+feature definitions and transformations.
+- **Integrate with ML
+workflows**. Connect your feature store to your ML
+pipelines by integrating it with
+[SageMaker AI
+Pipelines](https://aws.amazon.com/sagemaker/pipelines/) or your custom ML workflows. This makes
+feature retrieval consistent throughout the ML lifecycle,
+from experimentation to production deployment.
+- **Monitor and validate
+features**. Implement monitoring for your feature
+store to detect data drift, missing values, or other quality
+issues. Use
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) or custom validation scripts for
+feature consistency and quality over time. Set up alerts for
+deviations in feature distributions.
+- **Enable feature discovery and
+sharing**. Document your features with metadata and
+descriptions to make them discoverable across your
+organization. Integrate with data catalogs like
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html) to enhance discoverability and
+governance of features.
+
+## Resources
+
+**Related documents:**
+
+- [Get
+started with Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-getting-started.html)
+- [Feature
+Store concepts](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-concepts.html)
+- [Store,
+Discover, and Share Machine Learning Features with Amazon SageMaker AI Feature Store](https://aws.amazon.com/blogs/machine-learning/unlock-ml-insights-using-the-amazon-sagemaker-feature-store-feature-processor/)
+- [Unlock
+ML insights using the Amazon SageMaker AI Feature Store Feature
+Processor](https://aws.amazon.com/blogs/machine-learning/unlock-ml-insights-using-the-amazon-sagemaker-feature-store-feature-processor/)
+
+**Related videos:**
+
+- [Amazon SageMaker AI Feature Store: Store, discover, & share features
+for ML apps](https://www.youtube.com/watch?v=pEg5c6d4etI)
+- [Deep
+dive on Amazon SageMaker AI Feature Store](https://www.youtube.com/watch?v=mHEUlPFT6xg)
+
+**Related examples:**
+
+- [Introduction
+to Feature Store](https://sagemaker-examples.readthedocs.io/en/latest/sagemaker-featurestore/feature_store_introduction.html)
+- [Amazon SageMaker AI Feature Store SageMaker AI Examples](https://github.com/aws/amazon-sagemaker-examples/tree/master/sagemaker-featurestore)
+- [Amazon SageMaker AI Feature Store: Streaming Aggregation](https://github.com/aws-samples/amazon-sagemaker-feature-store-streaming-aggregation)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp02.html*
+
+---
+
+# MLREL03-BP03 Validate models with relevant data
+
+Testing and validating machine learning models with appropriate data
+is essential for reliable performance in production. Use real and
+representative data that covers many possible patterns and scenarios
+to avoid model failures when deployed in real-world environments.
+
+**Desired outcome:** You establish
+processes that validate your machine learning models with
+real-world, representative data before deployment. You can identify
+distribution mismatches between training, validation, test, and
+inference data early, allowing you to address issues before they
+impact production performance. Your validation approach includes
+both real-world and engineered data to account for the scenarios
+your model might encounter.
+
+**Common anti-patterns:**
+
+- Testing models with only synthetic data that doesn't represent
+real-world conditions.
+- Failing to check for distribution mismatch between training and
+production data.
+- Ignoring edge cases and rare scenarios in validation datasets.
+- Using validation data that lacks diversity or has sampling
+biases.
+- Neglecting periodic revalidation after models are deployed.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces risk of model failures in production environments.
+- Enables early detection of data drift and model quality
+degradation.
+- Creates more robust models that perform well across expected
+scenarios.
+- Increases trust in model predictions from stakeholders.
+- Improves alignment between model performance in testing and
+production.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Validating your machine learning models with relevant data is a
+critical step in the ML development lifecycle. Data that fails to
+represent the full range of scenarios your model will encounter in
+production can lead to poor performance, biased outputs, or
+complete failures when deployed. The key challenge lies in
+obtaining and using data that accurately mirrors your production
+environment.
+
+Begin by analyzing your data sources to capture the breadth and
+depth of real-world scenarios. This includes common cases as well
+as edge cases that might be rare but important. For example, a
+model designed to detect fraudulent transactions needs exposure to
+both typical and unusual fraud patterns. Missing these edge cases
+can create vulnerabilities in your deployed model.
+
+Pay particular attention to distribution mismatches, where the
+statistical properties of your training, validation, test, and
+eventual inference data differ. These mismatches often lead to
+degraded model performance in production. For instance, if you
+train a product recommendation model on data from one demographic
+group but deploy it for a different group, the model may make
+irrelevant recommendations.
+
+Implement continuous monitoring after deployment to detect when
+the data distribution shifts over time, which is common in
+real-world applications. This allows you to retrain models before
+performance degradation impacts business outcomes.
+
+### Implementation steps
+
+- **Establish data quality
+criteria**. Define what constitutes representative
+data for your use case. Include requirements for data
+completeness, diversity, and coverage of edge cases.
+Document these criteria as part of your ML development
+process to create consistency across projects.
+- **Implement cross-validation
+techniques**. Use techniques like k-fold
+cross-validation to verify that your model generalizes well
+across different subsets of your data. This can identify
+potential overfitting issues before deployment and provides
+a more robust estimate of how your model will perform in
+production.
+- **Use Amazon SageMaker AI MLFlow
+Tracking**. Set up experiments to track and compare
+different training runs with various data configurations.
+[SageMaker AI
+MLFlow Tracking](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html) allows you to organize, monitor, and
+evaluate your machine learning experiments systematically.
+This can identify which data configurations lead to the best
+performance and provides a historical record for future
+reference.
+- **Create engineered test
+data**. Generate synthetic data to supplement
+real-world data, especially for rare but important edge
+cases. Verify that this synthetic data maintains the
+statistical properties of real data while providing coverage
+for scenarios that might be underrepresented in your
+original dataset.
+- **Implement data drift
+detection**. Set up processes to continuously
+compare the distribution of inference data with your
+baseline training data. Use this comparison to identify when
+the real-world data begins to diverge from what the model
+was trained on, which can signal the need for retraining.
+- **Use Amazon SageMaker AI Model
+Monitor**. Deploy
+[Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to automatically track and analyze model
+behavior in production. Configure alerts for deviations in
+model quality, data quality, bias drift, and feature
+attribution drift. SageMaker AI Model Monitor continuously
+evaluates your deployed models and notifies you when action
+is needed.
+- **Establish a regular validation
+cadence**. Schedule periodic evaluations of your
+model using fresh data, even if drift hasn't been detected.
+This can catch subtle changes that might not trigger
+automated alerts but could still affect model performance
+over time.
+- **Document validation
+results**. Create detailed reports of validation
+processes and outcomes for each model version. Include
+metrics on data representativeness, performance across
+different data segments, and identified gaps or biases.
+
+## Resources
+
+**Related documents:**
+
+- [Evaluating
+ML Models](https://docs.aws.amazon.com/machine-learning/latest/dg/evaluating_models.html)
+- [Cross-Validation](https://docs.aws.amazon.com/machine-learning/latest/dg/cross-validation.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/)
+- [Detect
+data drift using Amazon SageMaker AI Model Monitor](https://aws.amazon.com/blogs/architecture/detecting-data-drift-using-amazon-sagemaker/)
+- [Monitoring
+in-production ML models at large scale using Amazon SageMaker AI
+Model Monitor](https://aws.amazon.com/blogs/machine-learning/monitoring-in-production-ml-models-at-large-scale-using-amazon-sagemaker-model-monitor/)
+
+**Related videos:**
+
+- [How
+To Efficiently Manage ML experiments using Amazon SageMaker AI ML
+Flow](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Model Monitor](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker_model_monitor)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp03.html*
+
+---
+
+# MLREL03-BP04 Establish data bias detection and mitigation
+
+Detect and mitigate bias to avoid inaccurate model results.
+Establish bias detection methodologies at data preparation stage
+before training starts. Monitor, detect, and mitigate bias after the
+model is in production. Establish feedback loops to track the drift
+over time and initiate a re-training.
+
+**Desired outcome:** You can identify
+and address biases in your machine learning data and models,
+providing fair and accurate predictions. You have established
+systematic approaches for detecting bias before training and
+continuously monitoring bias in production. Your AI systems produce
+more reliable, fair, and trustworthy results through automated
+detection and mitigation processes.
+
+**Common anti-patterns:**
+
+- Waiting until after model deployment to consider bias detection.
+- Using a single bias metric for each use case without
+understanding context-specific requirements.
+- Focusing only on training data bias and ignoring bias that may
+emerge in production.
+- Failing to establish feedback mechanisms to monitor and address
+drift over time.
+- Treating bias detection as a one-time activity rather than an
+ongoing process.
+
+**Benefits of establishing this best
+practice:**
+
+- Improves model accuracy and fairness across different
+demographic groups.
+- Reduces risk of deploying models with harmful or discriminatory
+outcomes.
+- Enhances transparency and explainability for model predictions.
+- Increases trust from users and stakeholders in AI systems.
+- Improves adherence to emerging AI regulations and ethical
+guidelines.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Bias in machine learning models can lead to unfair or inaccurate
+outcomes that disproportionately impact certain groups. You need a
+systematic approach to detect and mitigate bias throughout the
+machine learning lifecycle. This begins with careful analysis of
+your training data to identify potential imbalances or historical
+biases that could be propagated by your models. By implementing
+bias detection methodologies before training, you can address
+issues early in the development process.
+
+Once your models are in production, ongoing monitoring is
+essential as new data patterns may introduce unexpected biases
+over time. Setting up automated detection systems allows you to
+continuously evaluate model fairness and take corrective actions
+when necessary. Building feedback loops provides the data needed
+to understand how bias manifests in real-world applications and
+informs model retraining strategies.
+
+Amazon SageMaker AI provides comprehensive tools like SageMaker AI
+Clarify to implement bias detection and mitigation strategies
+throughout the ML lifecycle. These tools offer quantitative
+metrics to measure different types of bias and provide
+explanations for model predictions to understand and address the
+root causes of unfairness.
+
+### Implementation steps
+
+- **Understand different types of
+bias**. Begin by educating your team about various
+forms of bias that can affect machine learning models,
+including selection bias, measurement bias, aggregation
+bias, and evaluation bias. Educate your team members on how
+bias can be introduced at different stages of the ML
+lifecycle and the potential impacts on model predictions.
+- **Analyze your training
+data**. Use
+[Amazon SageMaker AI Clarify](https://aws.amazon.com/sagemaker/clarify/) to examine your training data for
+potential bias before model development. Analyze the
+distribution of sensitive attributes and identify imbalances
+or correlations that could lead to unfair outcomes. Address
+data imbalances through techniques like resampling,
+weighting, or generating synthetic data for underrepresented
+groups.
+- **Select appropriate bias
+metrics**. Choose bias metrics that align with your
+specific use case and fairness requirements. SageMaker AI
+Clarify provides multiple pre-training bias metrics
+including class imbalance, difference in proportions of
+labels, and conditional demographic disparity. For
+post-training, metrics like disparate impact, difference in
+positive proportions across predicted labels, and accuracy
+difference can evaluate model fairness.
+- **Run SageMaker AI Clarify processing
+jobs**. Integrate
+[SageMaker AI
+Clarify processing jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html) into your ML pipeline to
+analyze bias and provide explainability. Configure these
+jobs to calculate bias metrics on your training data and
+model predictions, identifying potential issues before
+deployment.
+- **Implement bias mitigation
+strategies**. Address identified biases using
+techniques like preprocessing (modifying training data),
+in-processing (incorporating fairness constraints during
+training), or post-processing (adjusting model outputs).
+Experiment with different approaches and measure their
+impact on both fairness metrics and model performance.
+- **Set up production
+monitoring**. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously track bias
+metrics on production data. Create alerts that alarm when
+bias metrics exceed predefined thresholds, enabling prompt
+investigation and remediation of emerging issues.
+- **Establish feedback loops**.
+Implement mechanisms to collect and analyze feedback on
+model predictions, particularly focusing on cases where bias
+may be present. Use this feedback to improve your
+understanding of real-world bias patterns and inform model
+retraining strategies.
+- **Generate model governance
+reports**. Use SageMaker AI Clarify to create
+comprehensive reports on model fairness and explainability
+for stakeholders, including risk and compliance-aligned
+teams and external regulators. These reports should document
+your bias detection and mitigation efforts, providing
+transparency into your responsible AI practices.
+- **Conduct regular model
+reviews**. Schedule periodic reviews of your
+models' fairness performance, bringing together
+cross-functional teams to evaluate bias metrics, examine
+challenging cases, and decide on necessary interventions or
+improvements.
+
+## Resources
+
+**Related documents:**
+
+- [Run
+SageMaker AI Clarify Processing Jobs for Bias Analysis and
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-processing-job-run.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Fairness,
+model explainability and bias detection with SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Amazon SageMaker AI Clarify Detects Bias and Increases the Transparency
+of Machine Learning Models](https://aws.amazon.com/blogs/aws/new-amazon-sagemaker-clarify-detects-bias-and-increases-the-transparency-of-machine-learning-models/)
+- [Build
+a secure enterprise machine learning platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.html)
+
+**Related videos:**
+
+- [Introducing
+Amazon SageMaker AI Clarify, part 1 - Bias detection](https://www.youtube.com/watch?v=jvcPZmnXaxo)
+- [Introducing
+Amazon SageMaker AI Clarify, part 2 - Model explainability](https://www.youtube.com/watch?v=1IGMG_c280E)
+- [Responsible
+use of artificial intelligence and machine learning](https://pages.awscloud.com/Responsible-Use-of-Artificial-Intelligence-and-Machine-Learning_2022_1007-MCL_OD.html)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Clarify: ML Bias Detection and Explainability](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-clarify)
+- [Amazon SageMaker AI Model Monitoring](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel03-bp04.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLREL04.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLREL04.md
@@ -1,0 +1,320 @@
+# MLREL04
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLREL04-BP01 Automate endpoint changes through a pipeline
+
+Manual change management can be error prone and potentially incur a
+high effort cost. Use automated pipelines (that integrate with a
+change management tracking system) to deploy changes to your model
+endpoints. Versioned pipeline inputs and artifacts allow you to
+track the changes and automatically rollback after a failed change.
+
+**Desired outcome:** You establish a
+reliable and consistent deployment process for your machine learning
+models. You gain the ability to track changes, perform automatic
+rollbacks when needed, and improve adherence to change management
+policies. This approach reduces manual errors, increases operational
+efficiency, and provides you with better visibility into your ML
+deployment lifecycle.
+
+**Common anti-patterns:**
+
+- Making manual updates directly to production endpoints.
+- Using different deployment processes across teams or
+environments.
+- Lacking proper version control for model artifacts.
+- Not having clear rollback mechanisms for failed deployments.
+- Bypassing change management tracking systems.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces human error during deployments.
+- Increases deployment speed and reliability.
+- Improves traceability and auditability of changes.
+- Enables rollback to previous versions.
+- Improves adherence to change management policies.
+- Supports scalable ML operations across multiple models.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Implementing automated pipelines for model endpoint changes brings
+consistency and reliability to your ML operations. By using a
+standardized deployment approach, you can verify that that changes
+to production endpoints follow the same validated process. This
+reduces the risk of deployment errors and improves overall
+operational efficiency.
+
+The pipeline should include steps for testing, validation, and
+approval of model changes before they reach production.
+Integration with your existing change management system allows for
+proper tracking and documentation of changes. The pipeline should
+also maintain versioned artifacts of models deployed, enabling
+rollback if issues arise in production.
+
+### Implementation steps
+
+- **Set up a CI/CD pipeline for ML
+workloads**. Establish a continuous integration and
+continuous delivery pipeline specifically designed for
+machine learning workloads.
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) provides a purpose-built solution
+for creating end-to-end ML workflows at scale.
+- **Integrate with change management
+systems**. Connect your pipeline to existing change
+management tracking systems to document endpoint changes.
+This improves adherence with your organization's governance
+requirements and provides a full audit trail of deployment
+activity.
+- **Implement artifact
+versioning**. Store model artifacts, code, and
+configuration files in version control. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog and version your
+models, making it straightforward to track which model
+versions are deployed to which endpoints.
+- **Define automated testing and
+validation**. Include automated testing steps in
+your pipeline to validate model performance before
+deployment. This should include unit tests, integration
+tests, and model quality evaluations using metrics specific
+to your use case.
+- **Establish approval gates**.
+Configure approval checkpoints in your pipeline where
+stakeholders can review changes before they are promoted to
+production. These gates maintain quality control and improve
+adherence to business requirements.
+- **Implement automated rollback
+mechanisms**. Create automated procedures to roll
+back to the previous stable version if a deployment fails or
+if issues are detected after deployment. This minimizes
+downtime and impact on users.
+- **Monitor deployment
+metrics**. Track the success rate of deployments
+and time-to-deployment metrics to continuously improve your
+pipeline. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor these operational metrics.
+
+## Resources
+
+**Related documents:**
+
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Build
+a CI/CD pipeline for deploying custom machine learning models
+using AWS services](https://aws.amazon.com/blogs/machine-learning/build-a-ci-cd-pipeline-for-deploying-custom-machine-learning-models-using-aws-services/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+
+**Related videos:**
+
+- [Implementing
+MLOps practices with Amazon SageMaker AI](https://youtu.be/fuXUi_hoK78)
+
+**Related examples:**
+
+- [SageMaker AI
+Pipelines and SageMaker AI Model Registry](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel04-bp01.html*
+
+---
+
+# MLREL04-BP02 Use an appropriate deployment and testing strategy
+
+Select the right deployment and testing strategy for your machine
+learning models to create smoother transitions to production,
+minimize disruption, and allow for careful evaluation of model
+performance before full implementation.
+
+**Desired outcome:** You can
+confidently deploy machine learning models to production using
+strategies that minimize risk and maximize availability. You have
+established processes to monitor model performance, allowing you to
+make data-driven decisions about when to roll back to previous
+versions or roll forward with new updates. Your deployment pipelines
+include appropriate testing, validation, and metrics collection to
+improve model quality and performance in production environments.
+
+**Common anti-patterns:**
+
+- Deploying new models directly to production without testing
+strategies.
+- Lacking version control for model artifacts.
+- Not implementing monitoring metrics to evaluate model
+performance.
+- Using the same deployment strategy for models without
+considering specific use case requirements.
+- Failing to plan for rollbacks when model performance degrades.
+
+**Benefits of establishing this best
+practice:**
+
+- Minimizes disruption to production services during model
+updates.
+- Enables testing models with real production traffic before full
+deployment.
+- Reduces risk through controlled deployment strategies.
+- Improves visibility into model performance.
+- Provides better mechanisms for recovering from poor-performing
+model deployments.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning models require special consideration when
+deploying to production environments because their behavior can be
+complex and sometimes unpredictable. Unlike traditional software
+where functionality is explicitly coded, ML models learn patterns
+from data, making it crucial to validate their performance with
+production data before full deployment.
+
+Different deployment strategies provide varying levels of risk
+mitigation and testing capabilities. Blue/green deployments allow
+for instantaneous rollback by maintaining two identical
+environments. Canary deployments reduce risk by exposing only a
+small portion of traffic to new models. A/B testing enables you to
+compare performance metrics between model versions. Shadow
+deployments let you test new models without affecting user
+experience by running them alongside the production model but not
+using their predictions.
+
+Your choice of deployment strategy should be guided by your
+specific requirements for availability, risk tolerance, and the
+criticality of the ML application. For high-stakes applications
+like fraud detection or medical diagnostics, more cautious
+approaches like canary or shadow deployments may be appropriate.
+For less critical applications, simpler strategies might suffice.
+
+### Implementation steps
+
+- **Perform a deployment strategy
+trade-off analysis**. Evaluate your business
+requirements and risk tolerance to determine which
+deployment strategies are most appropriate for your ML
+models. Consider factors like required availability,
+acceptable downtime, criticality of predictions, and
+monitoring capabilities. Document your analysis and
+selection criteria for each model deployment.
+- **Implement robust model
+versioning**. Establish a system to version model
+artifacts, including the model itself, preprocessing
+components, and associated configurations. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog models and track
+their lineage, approval status, and deployment history.
+Then, you can quickly identify what model version is running
+and roll back if needed.
+- **Set up blue/green deployments with
+SageMaker AI**. Implement blue/green deployments for
+your real-time inference endpoints to maximize availability
+during updates. SageMaker AI automatically provisions new
+infrastructure (green fleet) before transitioning traffic
+from the old infrastructure (blue fleet), providing nearly
+continuous service. Configure the appropriate
+[traffic
+shifting mode](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green.html) based on your risk tolerance.
+- **Configure canary deployments for
+higher-risk updates**. For model updates where you
+want additional safety, implement canary deployments that
+route a small percentage of traffic to the new model version
+first. Use
+[SageMaker AI
+deployment guardrails](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green-canary.html) to set up canary testing with
+baking periods to monitor model performance before shifting
+the remaining traffic.
+- **Establish linear traffic shifting
+for granular control**. For the most controlled
+deployments, set up
+[linear
+traffic shifting](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green-linear.html) in SageMaker AI to gradually move
+traffic from the blue fleet to the green fleet in multiple
+steps. Define appropriate step sizes and baking periods
+between shifts to carefully monitor model behavior at each
+stage.
+- **Implement A/B testing for model
+comparison**. When you need to validate that a new
+model performs better than the existing one, set up A/B
+testing to compare metrics between versions with real
+production traffic. Use
+[SageMaker AI
+A/B testing](https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html) to route defined percentages of traffic
+to different model variants and collect performance data.
+- **Deploy shadow models to reduce the
+risk of testing**. For high-risk applications,
+consider implementing shadow deployments where the new model
+runs alongside the production model but doesn't affect
+customer-facing decisions. This allows you to compare how
+the new model would have performed using real production
+data while minimizing the risk.
+- **Define and implement model
+performance metrics**. Establish clear metrics to
+evaluate model performance in production, such as prediction
+accuracy, latency, throughput, and business KPIs. Set up
+monitoring with
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track these metrics and create alarms
+that can run automatic or manual interventions when
+performance degrades.
+- **Create automatic rollback
+mechanisms**. Implement automated procedures to
+roll back to previous model versions when performance
+metrics indicate problems. Define specific thresholds for
+metrics that would trigger a rollback, and establish the
+process for rolling back with minimal disruption.
+- **Build comprehensive CI/CD
+pipelines**. Integrate your deployment strategies
+into complete CI/CD pipelines that automate the testing,
+deployment, and monitoring of models. Use
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) and
+[AWS CodeDeploy](https://aws.amazon.com/codedeploy/) in conjunction with SageMaker AI to create
+reliable deployment workflows.
+
+## Resources
+
+**Related documents:**
+
+- [Deployment
+guardrails for updating models in production](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails.html)
+- [Blue/Green
+Deployments](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails-blue-green.html)
+- [Testing
+models with production variants](https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Take
+advantage of advanced deployment strategies using Amazon SageMaker AI deployment guardrails](https://aws.amazon.com/blogs/machine-learning/take-advantage-of-advanced-deployment-strategies-using-amazon-sagemaker-deployment-guardrails/)
+- [A/B
+Testing ML models in production using Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/a-b-testing-ml-models-in-production-using-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Deliver
+high-performance ML models faster with MLOps tools](https://www.youtube.com/watch?v=T9llSCYJXxc)
+- [Canaries
+in the code mines: Monitoring deployment pipelines](https://www.youtube.com/watch?v=IHbY897uEbQ)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Inference Deployment Guardrails](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-inference-deployment-guardrails)
+- [Amazon SageMaker AI A/B Testing Pipeline](https://github.com/aws-samples/amazon-sagemaker-ab-testing-pipeline)
+- [Amazon SageMaker AI Safe Deployment Pipeline](https://github.com/aws-samples/amazon-sagemaker-safe-deployment-pipeline)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel04-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLREL05.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLREL05.md
@@ -1,0 +1,290 @@
+# MLREL05
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLREL05-BP01 Allow automatic scaling of the model endpoint
+
+Implement capabilities that allow the automatic scaling of model
+endpoints. This improves the reliable processing of predictions to
+meet changing workload demands. Include monitoring on endpoints to
+identify a threshold that initiates the addition or removal of
+resources to support current demand.
+
+**Desired outcome:** You can
+efficiently handle varying workload demands by implementing
+automatic scaling for your model endpoints. Your endpoints
+dynamically adjust resources based on real-time needs, providing
+consistent performance and availability without manual intervention.
+This results in reliable prediction processing, optimal resource
+utilization, and cost-effective operations.
+
+**Common anti-patterns:**
+
+- Manually scaling endpoints in response to traffic changes.
+- Over-provisioning resources to handle peak loads at non-peak
+times.
+- Neglecting to set up monitoring for endpoint performance.
+- Ignoring traffic patterns when configuring scaling policies.
+- Using fixed infrastructure that can't adapt to changing
+workloads.
+
+**Benefits of establishing this best
+practice:**
+
+- Improves reliability and availability of prediction services.
+- Optimizes costs through dynamic resource allocation.
+- Enhances user experience with consistent response times.
+- Reduces operational overhead through automation.
+- Strengthens ability to handle unexpected traffic spikes.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Automatic scaling of model endpoints is critical for maintaining
+reliable machine learning services in production. By implementing
+auto scaling, your endpoints can handle varying loads efficiently
+without manual intervention. This capability is especially
+important for applications with fluctuating traffic patterns or
+those that experience periodic spikes in demand.
+
+When setting up automatic scaling, you need to consider
+appropriate metrics that trigger scaling actions, such as CPU
+utilization, memory usage, or request latency. Define appropriate
+thresholds for these metrics so that your system scale at the
+right time - not too early (which wastes resources) or too late
+(which impacts performance).
+
+Monitoring is an essential component of an auto scaling solution.
+By implementing comprehensive monitoring, you gain visibility into
+endpoint performance and scaling operations, allowing you to
+optimize your configuration over time based on real usage
+patterns.
+
+### Implementation steps
+
+- **Configure automatic scaling for
+Amazon SageMaker AI endpoints**. Amazon SageMaker AI
+supports
+[automatic
+scaling (auto scaling)](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html) for your hosted models.
+SageMaker AI endpoints can be configured with auto scaling to
+maintain service availability as traffic increases.
+Automatic scaling automatically provisions new resources
+horizontally to handle increased user demand or system load.
+- **Set up appropriate scaling
+policies**. Define target metrics for scaling such
+as CPU utilization, memory usage, or request count.
+Configure appropriate minimum and maximum instance counts
+based on your expected traffic patterns and performance
+requirements. Consider implementing both scale-out policies
+(adding capacity when load increases) and scale-in policies
+(removing capacity when load decreases) to optimize resource
+utilization.
+- **Implement comprehensive
+monitoring**. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor the performance of your
+endpoint and collect metrics that can inform scaling
+decisions. Create dashboards to visualize endpoint
+performance and scaling activities. Set up alerts to notify
+you of issues or anomalies with your endpoints.
+- **Leverage SageMaker AI Serverless
+Inference**. For workloads with intermittent or
+unpredictable traffic patterns, consider using
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html), which automatically
+scales compute capacity up and down based on traffic,
+avoiding the need to choose instance types or manage scaling
+policies.
+- **Utilize SageMaker AI Inference
+Recommender**. Before deploying models to
+production, use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to get
+recommendations on instance types and configurations that
+will best meet your performance and cost requirements,
+assisting you in optimizing your scaling policies.
+- **Implement load testing**.
+Perform load testing on your endpoints to understand how
+they behave under different traffic conditions. This
+information can fine-tune your scaling policies so that
+they're effective when real traffic increases occur.
+
+## Resources
+
+**Related documents:**
+
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Configuring
+autoscaling inference endpoints in Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/configuring-autoscaling-inference-endpoints-in-amazon-sagemaker/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel05-bp01.html*
+
+---
+
+# MLREL05-BP02 Create a recoverable endpoint with a managed version control strategy
+
+Establish a fully recoverable system for model prediction endpoints
+by implementing proper version control and lineage tracking for
+components that generate these endpoints.
+
+**Desired outcome:** You have a
+robust infrastructure where components related to model deployment,
+including model artifacts, container images, and endpoint
+configurations, are version controlled and traceable. You can
+recover quickly from issues by identifying and reverting to previous
+stable versions, and you can audit the full lineage of model
+deployments for governance and regulatory requirements.
+
+**Common anti-patterns:**
+
+- Storing model artifacts without proper versioning.
+- Using deployment processes only when needed without
+infrastructure as code.
+- Failing to track dependencies between model artifacts,
+containers, and configurations.
+- Not maintaining a centralized registry for models.
+- Relying on manual processes for endpoint recovery.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces recovery time when endpoint issues occur.
+- Improves auditability and adherence through comprehensive
+lineage tracking.
+- Enhances collaboration between data scientists and operations
+teams.
+- Improves the consistency and reliability of model deployments.
+- Enables reproduction of model endpoints exactly as they were at
+specific points in time.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Machine learning model endpoints represent the interface where
+your business delivers value from AI/ML investments. Verifying
+that these endpoints are recoverable is critical for business
+continuity. Recoverability depends on having comprehensive version
+control for components involved in creating the endpoint.
+
+A properly implemented MLOps framework for endpoint recoverability
+tracks not just the model artifacts, but components that influence
+the prediction service—training data, feature transformations,
+container definitions, and infrastructure configurations. When
+incidents occur, you need to understand the complete lineage of
+your model endpoint, including which data trained the model, which
+code created the container, and which configurations defined the
+infrastructure.
+
+By implementing proper version control and lineage tracking, you
+create a system that is both resilient to failures and compatible
+with governance requirements. You can trace exactly how each
+endpoint was created and recreate it precisely when needed.
+
+### Implementation steps
+
+- **Implement MLOps with Amazon SageMaker AI Pipelines and Projects**.
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) automates ML workflows by
+providing a service for building, running, and managing ML
+pipelines. It handles every step from data preparation to
+model deployment in a versioned, predictable manner.
+- **Implement a model registry
+system**. Use
+[Amazon SageMaker AI Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html) to catalog your models for
+production. The registry tracks model versions and their
+approval status, creating a system of record for models in
+your organization. Define a clear approval workflow for
+moving models from development to production for proper
+governance at each stage. For each model, register metadata
+including performance metrics, training datasets, and
+intended use cases.
+- **Track experiments with SageMaker AI
+MLflow**. MLflow in SageMaker AI allows you to create,
+manage, analyze, and compare experiments. This way, data
+scientists can view and track the experiments for the
+current project. Each experiment logs every metric and
+hyperparameter automatically, along with model artifacts and
+dataset information.
+- **Use infrastructure as code (IaC)
+tools**. Define and build your infrastructure,
+including model endpoints, using
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/). IaC makes your infrastructure version
+controlled, repeatable, and able to be reverted to previous
+states if needed. Store your infrastructure code in git
+repositories alongside your model code, creating a unified
+version history. This approach reduces configuration drift
+between environments and verifies that your production
+deployment exactly matches your tested configuration.
+- **Store containers in Amazon Elastic Container Registry**. Use
+[Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html) to version and store the Docker containers that
+serve your models. Amazon ECR automatically creates version
+hashes for containers as you update them, enabling rollbacks
+to previous versions. Implement image scanning to detect
+security vulnerabilities, and apply lifecycle policies to
+manage older versions of your containers.
+- **Implement automated testing and
+deployment pipelines**. Create CI/CD pipelines
+using
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) to automate the testing and deployment
+of your models. These pipelines should validate models
+before deployment, deploy infrastructure changes through
+CloudFormation, and update model endpoints with minimal
+downtime. Integrate automated quality checks to avoid
+problematic models from reaching production.
+- **Configure automated backups and
+recovery processes**. Establish automated backup
+procedures for your model artifacts, container images, and
+endpoint configurations. Use
+[Amazon S3 versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html) for model artifacts and
+[AWS Backup](https://aws.amazon.com/backup/) to protect configuration data. Document and
+test recovery procedures regularly to verify that they work
+when needed.
+
+## Resources
+
+**Related documents:**
+
+- [AWS CloudFormation Documentation](https://docs.aws.amazon.com/cloudformation/index.html)
+- [Infrastructure
+as code](https://docs.aws.amazon.com/whitepapers/latest/introduction-devops-aws/infrastructure-as-code.html)
+- [Pipelines
+overview](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines-sdk.html)
+- [What
+is Amazon Elastic Container Registry?](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Fully
+managed MLflow 3.0 on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+- [Multi-account
+model deployment with Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/multi-account-model-deployment-with-amazon-sagemaker-pipelines/)
+- [Automate
+feature engineering pipelines with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/automate-feature-engineering-pipelines-with-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Next-generation
+CDK development with Amazon Q Developer](https://www.youtube.com/watch?v=WEYuvh3YqkI)
+- [Infrastructure
+as Code on AWS - AWS Online Tech Talks](https://www.youtube.com/watch?v=cKQtPZwf97s)
+- [How
+to create fully automated ML workflows with Amazon SageMaker AI
+Pipelines](https://www.youtube.com/watch?v=W7uabCTfLrg)
+
+**Related examples:**
+
+- [Amazon SageMaker AI MLOps](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlrel05-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSEC01.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSEC01.md
@@ -1,0 +1,190 @@
+# MLSEC01
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSEC01-BP01 Validate ML data permissions, privacy, software, and license terms
+
+Machine learning implementations require careful consideration of
+data permissions, privacy, and software licensing to adhere to
+organizational and legal requirements. Validating these elements
+throughout the ML lifecycle builds trusted ML systems that respect
+data rights while delivering business value.
+
+**Desired outcome:** Establish a
+robust governance process that verifies that ML data usage and
+software implementations meets your organization's requirements.
+Maintain clear documentation of data permissions, approved software
+packages, and license adherence. Operate ML implementations within a
+framework that respects data subject rights, follows privacy
+regulations, and avoids legal complications related to software
+licensing.
+
+**Common anti-patterns:**
+
+- Assuming data collected for one purpose can automatically be
+used for ML training without additional consent.
+- Installing ML libraries and packages without reviewing their
+license terms or data collection practices.
+- Failing to document data permissions and consent mechanisms for
+adherence verification.
+- Ignoring the need for a process to handle withdrawn consent from
+data subjects.
+- Using third-party ML models without understanding their privacy
+implications or license restrictions.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduces legal and regulatory risks related to data privacy and
+software licensing.
+- Enhances trust from data subjects and stakeholders through
+ethical data handling.
+- Avoids unexpected limitations on business plans due to
+restrictive license terms.
+- Improves documentation for audits and regulatory requirements.
+- Streamlines deployment through pre-validated software and
+container solutions.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+ML libraries and packages handle various aspects of the machine
+learning lifecycle, from data processing and model development to
+training and hosting. Each component may come with specific
+license terms, privacy considerations, and data handling
+requirements. Validating these elements verifies your
+organization's ML initiatives adhere to regulatory requirements
+and don't introduce unexpected limitations.
+
+When implementing ML systems, verify that data being used has
+proper permissions for ML applications specifically. This often
+means going beyond general data collection consent to verify
+explicit permission for ML usage. For example, if you collected
+customer data for service delivery, you may need additional
+consent to use that data for training ML models.
+
+Understanding license implications is critical for software
+components. Some open-source ML libraries may have restrictions
+that could affect your ability to commercialize models trained
+with them. Similarly, third-party models or APIs might include
+terms that grant the provider certain rights to your data or
+restrict how you can deploy solutions.
+
+Privacy considerations extend beyond initial data collection to
+the entire ML lifecycle. Establish mechanisms to handle data
+subject requests, including the right to withdraw consent or be
+forgotten. Your ML implementation should respect these requests
+without compromising the entire system.
+
+### Implementation steps
+
+- **Attain data permissions for
+ML**. Verify whether your intended data can be used
+for machine learning specifically. Document the legitimate
+business purpose for using the data, and determine whether
+you need additional consent from data owners or subjects.
+Implement a process to handle data subjects who withdraw
+their consent, including the ability to remove their data
+from training sets or models when required. Maintain
+comprehensive documentation of data permissions for
+compliance-aligned purposes and potential audits.
+- **Create a software license
+inventory**. Develop and maintain an inventory of
+ML libraries, packages, and dependencies used in your ML
+pipeline. For each component, document the license type, key
+terms, restrictions, and implications for your business
+model. Use tools like
+[AWS License Manager](https://aws.amazon.com/license-manager/) to track and manage software licenses
+across your ML environments, improving adherence to
+licensing agreements and optimizing license usage.
+- **Bootstrap instances with lifecycle
+management policies**. Create lifecycle
+configurations with references to your approved package
+repositories and scripts to install required packages. This
+improves consistency across development environments and
+avoids the introduction of unauthorized packages. Implement
+[Amazon SageMaker AI Lifecycle Configurations](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lifecycle-configurations.html) to automate the
+setup of development environments with pre-approved software
+packages and configurations.
+- **Evaluate package integrations that
+require external lookup services**. Based on your
+data privacy requirements, opt out of data collection
+features when necessary. Minimize data exposure by
+establishing trusted relationships with service providers
+and understanding their data handling practices. Evaluate
+privacy policies and license terms for ML packages that
+might collect telemetry or other data. For sensitive
+implementations, consider creating private mirrors of
+required packages to maintain control over external
+connections.
+- **Use prebuilt containers**.
+Start with pre-packaged and verified containers to quickly
+provide support for commonly used dependencies while
+improving license adherence.
+[AWS Deep Learning Containers](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html) contain several deep
+learning framework libraries and tools including TensorFlow,
+PyTorch, and Apache MXNet with pre-validated license terms.
+These containers maintain consistency while reducing the
+risk of introducing unauthorized or incompatible packages.
+- **Establish a privacy-preserving ML
+workflow**. Implement data minimization principles
+by using only the data necessary for your ML tasks. Apply
+anonymization or pseudonymization techniques to sensitive
+data before using it for training. Consider using
+privacy-preserving ML techniques such as differential
+privacy or federated learning for highly sensitive
+applications. Document your privacy-preserving measures for
+compliance-aligned purposes and to build trust with
+stakeholders.
+- **Monitor for license and privacy
+adherence**. Implement continuous monitoring of
+your ML environments to detect potential license violations
+or privacy issues. Create automated checks for package
+versions and license changes during CI/CD processes.
+Regularly audit data access patterns to verify that they
+comply with documented permissions and privacy requirements.
+Establish a process for addressing issues when they arise.
+- **Consider synthetic data for training
+and testing**. Create synthetic datasets that
+preserve the statistical properties of real data while
+avoiding privacy concerns.
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides capabilities for generating
+synthetic data for training and testing ML models when using
+real data presents privacy or licensing challenges. Document
+the use of synthetic data in your ML pipelines to
+demonstrate privacy-preserving practices.
+
+## Resources
+
+**Related documents:**
+
+- [Protecting
+compute](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-compute.html)
+- [What
+is AWS Deep Learning Containers?](https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/what-is-dlc.html)
+- [AWS License Manager](https://aws.amazon.com/license-manager/)
+- [Lifecycle
+configurations within Amazon SageMaker AI Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-lifecycle-configurations.html)
+- [Data
+Privacy in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/data-privacy.html)
+- [Best
+practices for endpoint security and health with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/best-practice-endpoint-security.html)
+- [Private
+package installation in Amazon SageMaker AI running in
+internet-free mode](https://aws.amazon.com/blogs/machine-learning/private-package-installation-in-amazon-sagemaker-running-in-internet-free-mode/)
+- [Machine
+Learning Best Practices in Financial Services](https://aws.amazon.com/blogs/machine-learning/machine-learning-best-practices-in-financial-services/)
+
+**Related videos:**
+
+- [Machine
+Learning Best Practices in Financial Services](https://youtu.be/HlSEUvApDZE?t=578)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec01-bp01.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSEC02.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSEC02.md
@@ -1,0 +1,165 @@
+# MLSEC02
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSEC02-BP01 Design data encryption and obfuscation
+
+Consider how to protect personal data. Use field level encryption or
+obfuscation to protect personally identifiable data.
+
+**Desired outcome:** You establish
+robust protection for sensitive information by implementing data
+encryption and obfuscation techniques in your machine learning
+workflows. You identify and secure personally identifiable
+information (PII) through field-level encryption and data masking,
+which improves your adherence to privacy regulations while
+maintaining data utility for ML models.
+
+**Common anti-patterns:**
+
+- Storing personally identifiable information in plain text
+format.
+- Using the same encryption keys across different environments.
+- Implementing inconsistent data protection policies across ML
+pipelines.
+- Overlooking data protection requirements during the design
+phase.
+- Failing to audit data for attributes requiring special
+treatment.
+
+**Benefits of establishing this best
+practice:**
+
+- Enhanced protection of sensitive and personally identifiable
+data.
+- Improves adherence to data privacy regulations.
+- Reduced risk of data breaches and unauthorized access.
+- Improved trust from users and stakeholders.
+- Ability to utilize sensitive data for ML training while
+maintaining privacy.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+When designing machine learning workflows, protect personal and
+sensitive data throughout the entire data lifecycle. You should
+evaluate your data early in the process to identify fields
+containing PII or other sensitive information requiring
+protection. Implementing field-level encryption or data
+obfuscation techniques maintains data utility for machine learning
+while safeguarding individual privacy.
+
+AWS provides multiple services to identify, classify, and protect
+sensitive data within your ML workflows. Services like
+[AWS Glue](https://aws.amazon.com/glue/)
+can automatically detect PII, while
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) and
+[AWS CloudHSM](https://aws.amazon.com/cloudhsm/) support robust encryption strategies. You should
+establish consistent policies for handling sensitive data across
+your organization and regularly audit your data protection
+measures to improve your adherence to privacy regulations.
+
+### Implementation steps
+
+- **Audit data for attributes requiring
+special treatment**. Identify fields containing
+data requiring special treatment, such as field-level
+encryption, data masking, or obfuscation. Use automated
+tools like
+[AWS Glue](https://aws.amazon.com/glue/) to identify PII and sensitive data patterns
+within your datasets.
+- **Establish a data classification
+framework**. Develop a systematic approach to
+categorize data based on sensitivity levels. Define which
+categories require encryption, masking, or other protection
+techniques, and document these requirements in your
+organization's security policies.
+- **Implement field-level
+encryption**. Apply encryption selectively to
+sensitive fields rather than entire datasets. Use
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to manage encryption keys
+and integrate with services like
+[Amazon S3](https://aws.amazon.com/s3/) or
+[Amazon DynamoDB](https://aws.amazon.com/dynamodb/) for transparent encryption of selected
+fields.
+- **Apply data obfuscation
+techniques**. Use methods such as tokenization,
+data masking, or anonymization to protect sensitive
+information while preserving data utility for machine
+learning. Consider using services like
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) for data transformation and masking
+operations.
+- **Establish key rotation
+policies**. Implement regular rotation of
+encryption keys to minimize the impact of potential key
+compromises. Configure
+[AWS KMS](https://aws.amazon.com/kms/) to automate key rotation according to your
+security policies and regulatory requirements.
+- **Secure ML model
+artifacts**. Verify that trained models and their
+associated metadata do not inadvertently expose sensitive
+information. Use
+[Amazon SageMaker AI's](https://aws.amazon.com/sagemaker/) security features to encrypt model
+artifacts and secure API endpoints that serve predictions.
+- **Implement access
+controls**. Restrict access to sensitive data and
+encryption keys using
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) policies. Apply the
+principle of least privilege to verify that only authorized
+personnel can access protected information.
+- **Monitor and audit access
+patterns**. Implement continuous monitoring to
+detect unauthorized access attempts or unusual patterns that
+might indicate a security breach. Configure
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) and
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track and alert on suspicious
+activities.
+- **Implement differential privacy
+techniques**. When working with AI models, consider
+implementing differential privacy techniques to add
+statistical noise to training data, protecting individual
+privacy while maintaining overall data utility.
+- **Establish mechanisms to stop model
+memorization**. Implement safeguards to block AI
+models from memorizing and potentially reproducing sensitive
+information from training data, especially when using large
+language models.
+
+## Resources
+
+**Related documents:**
+
+- [Detect
+and process sensitive data](https://docs.aws.amazon.com/glue/latest/dg/detect-PII.html)
+- [Security
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Data
+protection in Amazon SageMaker AI Unified Studio](https://docs.aws.amazon.com/sagemaker-unified-studio/latest/adminguide/data-protection.html)
+- [Data
+Privacy in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/data-privacy.html)
+- [Data
+Encryption](https://docs.aws.amazon.com/whitepapers/latest/introduction-aws-security/data-encryption.html)
+- [Introducing
+PII Data Identification and Handling Using AWS Glue
+DataBrew](https://aws.amazon.com/blogs/big-data/introducing-pii-data-identification-and-handling-using-aws-glue-databrew/)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Secure
+deployment of Amazon SageMaker AI resources](https://aws.amazon.com/blogs/security/secure-deployment-of-amazon-sagemaker-resources/)
+
+**Related videos:**
+
+- [Privacy-preserving
+machine learning](https://www.youtube.com/watch?v=ZQkB9XRqdnc)
+- [Data
+Protection Best Practices in Machine Learning](https://www.youtube.com/watch?v=1iZYmtFFLnw)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec02-bp01.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSEC03.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSEC03.md
@@ -1,0 +1,974 @@
+# MLSEC03
+
+**Pillar**: Unknown  
+**Best Practices**: 5
+
+---
+
+# MLSEC03-BP01 Provide least privilege access
+
+Protect resources across various phases of the ML lifecycle using
+the principle of least privilege. These resources include: data,
+algorithms, code, hyperparameters, trained model artifacts, and
+infrastructure. Provide dedicated network environments with
+dedicated resources and services to operate individual projects.
+
+**Desired outcome:** You establish a
+secure machine learning environment by implementing the principle of
+least privilege for resources involved in your ML workflows. Your
+organization controls access to sensitive data, models, and
+infrastructure based on business roles, maintains clear separation
+between development, test, and production environments, and uses
+appropriate governance mechanisms to enforce security policies. This
+approach minimizes your attack surface and protects valuable ML
+assets.
+
+**Common anti-patterns:**
+
+- Granting excessive permissions to data scientists or developers
+beyond what they need.
+- Using a single AWS account for ML workloads without proper
+separation.
+- Not tagging sensitive data and resources for access control
+purposes.
+- Failing to isolate ML environments based on data sensitivity
+requirements.
+- Relying solely on manual access management without proper
+governance structures.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of unauthorized access to sensitive data and ML
+assets.
+- Clear segregation of duties based on business roles.
+- Improves adherence to regulatory requirements for data
+protection.
+- Simplified governance through standardized access patterns.
+- Minimized potential impact of security breaches.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Protecting machine learning workflows requires a comprehensive
+security approach that applies the principle of least privilege to
+resources involved. By carefully controlling who has access to
+data, code, and infrastructure, you can reduce the risk of
+unauthorized access or data breaches.
+
+When implementing least privilege for ML resources, consider the
+different phases of the ML lifecycle and the types of access
+needed by various roles. For example, data scientists might need
+read access to training data but not production systems, while ML
+engineers may need deployment permissions but limited access to
+raw data.
+
+Setting up a multi-account architecture with
+[AWS Organizations](https://aws.amazon.com/organizations/) provides strong isolation between
+environments with different security requirements. This allows you
+to maintain separate development, testing, and production
+environments with appropriate controls for each.
+
+### Implementation steps
+
+- **Define role-based access control for
+ML teams**. Identify the distinct roles within your
+ML workflow, such as data scientists, ML engineers, and
+operations teams. Map these roles to specific access
+patterns required for their daily tasks. Use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to quickly create
+persona-based IAM roles with preconfigured templates for
+common ML roles including data scientists, MLOps engineers,
+and business analysts. This reduces manual permissions
+management and facilitates least privilege access by
+default. Complement with
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) for custom role-based
+policies. Implement regular access reviews to verify that
+permissions remain appropriate as responsibilities change.
+- **Implement account separation with
+AWS Organizations**. Create a multi-account
+architecture that segregates workloads between development,
+test, and production environments. Use
+[AWS Organizations](https://aws.amazon.com/organizations/) to centrally manage accounts and apply
+consistent policies. Establish tagging strategies to
+identify data sensitivity levels and resource ownership.
+Apply these tags to relevant resources like S3 buckets
+containing training data or SageMaker AI instances. Use
+[Service
+Catalog](https://aws.amazon.com/servicecatalog/) to create pre-provisioned environments that
+align with security requirements.
+- **Organize ML workloads by access
+patterns**. Group ML workloads based on common
+access requirements and security profiles. Create
+organizational units (OUs) in AWS Organizations that reflect
+these groupings. Delegate specific access permissions to
+each group according to their needs. Apply service control
+policies (SCPs) to enforce security guardrails at the
+organizational unit level. Limit administrative access to
+infrastructure to designated administrators only.
+- **Isolate sensitive data
+environments**. Create dedicated, isolated
+environments for working with sensitive data. Implement
+network controls such as security groups and network ACLs to
+restrict data flow between environments. Use
+[Amazon VPC](https://aws.amazon.com/vpc/) endpoints to provide private connectivity to AWS
+services without traversing the public internet. Configure
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) for secure access to SageMaker AI endpoints
+from within your VPC.
+- **Implement automated security
+controls**. Deploy
+[AWS Config](https://aws.amazon.com/config/) rules to continuously monitor resource
+configurations for adherence to security policies. Use
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) for threat detection across your ML
+infrastructure. Implement
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to log and monitor API calls related to ML
+resources. Consider using
+[Amazon Macie](https://aws.amazon.com/macie/) to automatically discover and protect sensitive
+data stored in Amazon S3.
+- **Use secure ML development
+practices**. Implement code repositories with
+appropriate access controls for ML code and models. Use
+version control for artifacts including data, code, and
+model parameters. Apply the principle of least privilege to
+CI/CD pipelines that deploy ML models. Implement model
+governance processes that include security reviews before
+deployment to production.
+- **Deploy ML guardrails with service
+control policies**. Create SCPs that enforce
+requirements across your ML environments. Define policies
+that block storage of sensitive data in unencrypted formats.
+Restrict network egress from environments containing
+sensitive data. Limit which AWS Regions can be used for
+specific types of ML workloads based on requirements.
+- **Implement safeguards for AI
+systems**. For AI workloads, implement additional
+security controls to protect against input injection
+attacks. Implement built-in guardrails for responsible AI
+use. Apply input validation for user inputs to AI systems.
+Implement output filtering to avoid inadvertent disclosure
+of sensitive information. Consider using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) with governance features to enforce
+compliance-aligned and responsible AI practices.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Service Catalog](https://aws.amazon.com/servicecatalog/)
+- [Build
+a Secure Enterprise Machine Learning Platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.pdf)
+- [Protecting
+data at rest](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-data-at-rest.html)
+- [Security
+best practices in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
+- [Building
+secure Amazon SageMaker AI access URLs with Service
+Catalog](https://aws.amazon.com/blogs/mt/building-secure-amazon-sagemaker-access-urls-with-aws-service-catalog/)
+- [Setting
+up secure, well-governed machine learning environments on
+AWS](https://aws.amazon.com/blogs/mt/setting-up-machine-learning-environments-aws/)
+- [ML
+security: Using Amazon SageMaker AI with AWS PrivateLink](https://aws.amazon.com/blogs/machine-learning/connect-to-amazon-services-using-aws-privatelink-in-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Architectural
+best practices for machine learning applications](https://www.youtube.com/watch?v=fBytsYBVgbo)
+- [Secure
+and compliant machine learning for regulated industries](https://www.youtube.com/watch?v=8p-B3sTLmFg)
+- [Amazon SageMaker AI Model Development in a Highly Regulated
+Environment (SDD315)](https://youtu.be/cSYFqKRQ0j0?t=1051)
+
+**Related examples:**
+
+- [Build
+your own Anomaly Detection ML Pipeline](https://d1.awsstatic.com/architecture-diagrams/ArchitectureDiagrams/build-your-own-anomaly-detection-ml-pipeline-ra.pdf?did=wp_card&trk=wp_card)
+- [AWS MLOps Framework](https://d1.awsstatic.com/architecture-diagrams/ArchitectureDiagrams/aws-mlops-framework-sol.pdf?did=wp_card&trk=wp_card)
+- [Secure
+ML deployment architecture reference](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/deploy-ml-models-securely-on-aws.html)
+- [Secure
+Data Science Reference Architecture](https://github.com/aws-samples/secure-data-science-reference-architecture)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp01.html*
+
+---
+
+# MLSEC03-BP02 Secure data and modeling environment
+
+Secure your machine learning data and development environments to
+protect valuable information assets throughout the ML lifecycle. By
+implementing proper security measures for storage, compute, and
+network resources, you can maintain data integrity and
+confidentiality while enabling data scientists to work effectively.
+
+**Desired outcome:** You have a
+secure foundation for storing, processing, and utilizing data for
+machine learning workloads. Your data is encrypted at rest and in
+transit, with access tightly controlled through identity management,
+infrastructure isolation, and secure coding practices. Your
+development environments are protected from unauthorized access
+while providing the necessary tools for your ML practitioners.
+
+**Common anti-patterns:**
+
+- Storing unencrypted training data in publicly accessible
+storage.
+- Using default security configurations for ML environments.
+- Allowing unrestricted internet access from ML environments.
+- Using hard-coded credentials in ML code and notebooks.
+- Installing ML packages from untrusted sources without
+validation.
+- Granting excessive permissions to development environments.
+
+**Benefits of establishing this best
+practice:**
+
+- Protection of sensitive training data from unauthorized access
+or exfiltration.
+- Reduced risk of compromised ML models and systems.
+- Improves adherence to regulatory requirements for data handling.
+- Improved governance of ML development environments.
+- Enhanced ability to detect and respond to security events.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Securing your ML environments requires a comprehensive approach
+addressing data storage, compute resources, network isolation, and
+access controls. The ML lifecycle involves multiple stages where
+data could be exposed if proper security measures aren't
+implemented. By establishing secure foundations for your ML
+infrastructure, you can protect valuable intellectual property
+while still enabling productivity.
+
+Start by securing your data repositories with encryption and
+access controls. Then build secure compute environments for model
+development that maintain isolation through private networking.
+Implement proper credential management to avoid exposure of
+secrets. Finally, verify that your package management practices
+block the introduction of malicious code into your ML pipeline.
+
+Modern ML workloads often involve large datasets and complex
+algorithms, making security even more critical as the impact of a
+breach could be substantial. By implementing the measures in this
+best practice, you create a secure foundation for your ML
+initiatives.
+
+### Implementation steps
+
+- **Build a secure analysis
+environment**. During the data preparation and
+feature engineering phases, leverage secure data exploration
+options on AWS. Use
+[Amazon SageMaker AI Studio](https://aws.amazon.com/sagemaker/studio/) managed environments or
+[Amazon EMR](https://aws.amazon.com/emr/) for data processing. Alternatively, use managed
+services like
+[Amazon Athena](https://aws.amazon.com/athena/) and
+[AWS Glue](https://aws.amazon.com/glue/) to explore data without moving it from your data
+lake. For smaller datasets, use Amazon SageMaker AI Studio to
+explore, visualize, and engineer features, then scale up
+your feature engineering using managed ETL services like
+Amazon EMR or AWS Glue.
+- **Create dedicated IAM and KMS
+resources**. Limit the scope and impact of
+credentials and keys by creating dedicated
+[AWS IAM](https://aws.amazon.com/iam/) roles and
+[AWS KMS](https://aws.amazon.com/kms/) keys for ML workloads. Create private
+[Amazon S3](https://aws.amazon.com/s3/) buckets with versioning enabled to protect your
+data and intellectual property. Implement a centralized data
+lake using
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) on Amazon S3. Secure your data lake
+using a combination of services to encrypt data in transit
+and at rest. Monitor access with granular
+[AWS IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html),
+[S3
+bucket policies](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-bucket-policy.html),
+[S3
+Access Logs](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html),
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/), and
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/).
+- **Use Secrets Manager and Parameter
+Store to protect credentials**. Replace hard-coded
+secrets in your code with API calls to programmatically
+retrieve and decrypt secrets using
+[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/). Use
+[AWS Systems Manager Parameter Store](https://aws.amazon.com/systems-manager/features/#Parameter_Store) to store application
+configuration variables such as AMI IDs or license keys.
+Grant permissions to your SageMaker AI IAM role to access these
+services from your ML environments.
+- **Automate managing
+configuration**. Use lifecycle configuration
+scripts to manage ML environments. These scripts run when
+environments are created or restarted, allowing you to
+install custom packages, preload datasets, and set up source
+code repositories. Lifecycle configurations can be reused
+across multiple environments and updated centrally. Use
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) infrastructure as code and
+[Service Catalog](https://aws.amazon.com/servicecatalog/) to simplify configuration for end
+users while maintaining security standards.
+- **Create private, isolated, network
+environments**. Use
+[Amazon Virtual Private Cloud](https://aws.amazon.com/vpc/) (Amazon VPC) to limit
+connectivity to only essential services and users. Deploy
+Amazon SageMaker AI resources in a VPC to enable network-level
+controls and capture network activity in
+[VPC
+Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html). For distributed training workloads, use
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html) which provides managed, resilient
+clusters with built-in VPC integration and multi-AZ
+deployment for enhanced security and availability. This
+deployment model also enables secure queries to data sources
+within your VPC, such as
+[Amazon RDS](https://aws.amazon.com/rds/) databases or
+[Amazon Redshift](https://aws.amazon.com/redshift/) data warehouses. Use IAM to restrict access
+to ML environment web UIs so they can only be accessed from
+within your VPC. Implement
+[AWS PrivateLink](https://docs.aws.amazon.com/whitepapers/latest/aws-vpc-connectivity-options/aws-privatelink.html) to privately connect your SageMaker AI
+resources with supported AWS services, facilitating secure
+communication within the AWS network. Use
+[AWS KMS](https://aws.amazon.com/kms/) to encrypt data on the
+[Amazon EBS](https://aws.amazon.com/ebs/) volumes attached to SageMaker AI resources.
+- **Restrict access**. ML
+development environments provide web-based access to the
+underlying compute resources, typically with elevated
+privileges. Restrict this access to remove the ability to
+assume root permissions while still allowing users to
+control their local environment. Implement least privilege
+access controls for ML resources.
+- **Secure ML algorithms**.
+Amazon SageMaker AI uses container technology to train and host
+algorithms and models. When creating custom containers,
+publish them to a private container registry hosted on
+[Amazon
+Elastic Container Repository (Amazon ECR)](https://aws.amazon.com/ecr/). Encrypt
+containers hosted on Amazon ECR at rest using AWS KMS.
+Regularly scan containers for vulnerabilities and implement
+a secure container update process.
+- **Enforce code best
+practices**. Use secure git repositories for
+storing code. Implement code reviews, automated security
+scanning, and version control for ML code. Integrate
+security checks into your ML CI/CD pipeline to detect
+potential security issues early in the development process.
+- **Implement a package mirror for
+consuming approved packages**. Evaluate license
+terms to determine appropriate ML packages for your business
+across the ML lifecycle phases. Common ML Python packages
+include Pandas, PyTorch, Keras, NumPy, and Scikit-learn.
+Build an automated validation mechanism to check packages
+for security issues. Only download packages from approved
+and private repos. Validate package contents before
+importing. SageMaker AI supports
+[modifying
+package channel paths to a private repository](https://aws.amazon.com/blogs/machine-learning/private-package-installation-in-amazon-sagemaker-running-in-internet-free-mode/). When
+appropriate, use an internal repository as a proxy for
+public repositories to minimize network traffic and reduce
+overhead.
+- **Implement model security
+monitoring**. Deploy continuous monitoring
+solutions to detect unauthorized access attempts, unusual
+data access patterns, and potential data exfiltration from
+your ML environments. Use
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/),
+[AWS Security Hub CSPM](https://aws.amazon.com/security-hub/), and
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) to create a comprehensive security
+monitoring solution for ML resources.
+- **Implement additional security
+controls for AI workloads**. For AI workloads,
+implement additional security controls around input
+validation and data leakage prevention. Implement
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to detect drift in production
+AI systems. Consider using
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model security
+characteristics and limitations.
+
+## Resources
+
+**Related documents:**
+
+- [Prerequisites
+for using SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html)
+- [Storage
+Best Practices for Data and Analytics Applications](https://docs.aws.amazon.com/whitepapers/latest/building-data-lakes/building-data-lake-aws.html)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Protecting
+compute](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-compute.html)
+- [Protecting
+data in transit](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-data-in-transit.html)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Building
+secure machine learning environments with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/building-secure-machine-learning-environments-with-amazon-sagemaker/)
+- [Setting
+up secure, well-governed machine learning environments on
+AWS](https://aws.amazon.com/blogs/mt/setting-up-machine-learning-environments-aws/)
+- [Private
+package installation in Amazon SageMaker AI running internet-free
+mode](https://aws.amazon.com/blogs/machine-learning/private-package-installation-in-amazon-sagemaker-running-in-internet-free-mode/)
+- [Secure
+Deployment of Amazon SageMaker AI resources](https://aws.amazon.com/blogs/security/secure-deployment-of-amazon-sagemaker-resources/)
+- [Apply
+fine-grained data access controls with AWS Lake Formation and
+Amazon EMR from Amazon SageMaker AI Studio](https://aws.amazon.com/blogs/machine-learning/apply-fine-grained-data-access-controls-with-aws-lake-formation-and-amazon-emr-from-amazon-sagemaker-studio/)
+
+**Related videos:**
+
+- [Security
+for AI/ML Models in AWS](https://www.youtube.com/watch?v=toDQL_c8Zug)
+- [Security
+best practices the AWS Well-Architected way](https://www.youtube.com/watch?v=wfIVI-M7lbQ)
+
+**Related examples:**
+
+- [Secure
+Data Science Reference Architecture](https://github.com/aws-samples/secure-data-science-reference-architecture)
+- [Amazon SageMaker AI Secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp02.html*
+
+---
+
+# MLSEC03-BP03 Protect sensitive data privacy
+
+Protect sensitive data used in training against unintended
+disclosure by implementing appropriate identification,
+classification, and handling strategies. This practice improves data
+privacy while maintaining model utility through techniques such as
+data removal, masking, tokenization, and principal component
+analysis (PCA).
+
+**Desired outcome:** You establish
+effective protocols to identify, classify, and protect sensitive
+data throughout your machine learning workflows. Your sensitive data
+is appropriately secured with encryption, access controls, and data
+minimization techniques. Your organization maintains clear
+documentation of governance practices for consistent application
+across projects.
+
+**Common anti-patterns:**
+
+- Failing to identify sensitive data before using it for model
+training.
+- Using raw PII or other sensitive data when anonymized data would
+suffice.
+- Not implementing proper encryption for sensitive training data.
+- Assuming cloud services automatically protect sensitive data
+without proper configuration.
+- Neglecting to document data handling processes for future
+reference.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of data breaches and privacy violations.
+- Improves adherence to data protection regulations.
+- Increased trust from customers and stakeholders.
+- Improved ability to use sensitive data for legitimate machine
+learning purposes.
+- Better governance through documented protocols.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Protecting sensitive data privacy in machine learning workflows
+requires a systematic approach that begins with data
+identification and classification. You need to understand what
+data you have and its sensitivity levels before determining
+appropriate protection mechanisms. Different types of sensitive
+data may require different handling strategies—some might need
+complete removal, while others can be effectively masked or
+tokenized.
+
+When working with sensitive data in ML workflows, you should adopt
+a defense-in-depth approach. This means implementing multiple
+layers of protection, including access controls, encryption, data
+minimization techniques, and monitoring systems. For example, you
+might use [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to encrypt your training data,
+implement role-based access controls, and use
+[Amazon Macie](https://aws.amazon.com/macie/) to continuously monitor for sensitive data exposure.
+
+Privacy-preserving machine learning techniques are increasingly
+important as models become more sophisticated. Techniques like
+differential privacy, federated learning, and secure multi-party
+computation can allow you to train effective models while
+minimizing exposure of sensitive data. These approaches maintain
+privacy while still extracting valuable insights from your data.
+
+### Implementation steps
+
+- **Implement automated data discovery
+and classification**. Use automated sensitive data
+discovery in
+[Amazon Macie](https://aws.amazon.com/macie/) to gain continuous, cost-efficient,
+organization-wide visibility into where sensitive data
+resides across your Amazon S3 environment. Macie
+automatically inspects your S3 buckets for sensitive data
+such as personally identifiable information (PII), financial
+data, and AWS credentials, then builds and maintains an
+interactive data map of sensitive data locations and
+provides sensitivity scores for each bucket.
+- **Apply resource tagging for sensitive
+data tracking**. Tag resources and models that
+contain or are derived from sensitive elements to quickly
+differentiate between resources requiring protection and
+those that do not. Use
+[AWS resource tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) to systematically identify and
+manage resources containing sensitive data throughout their
+lifecycle.
+- **Implement comprehensive encryption
+strategies**. Encrypt sensitive data using services
+such as [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/), the
+[AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/getting-started.html), or client-side encryption. Apply
+encryption consistently across data at rest and in transit,
+with appropriate key management practices.
+- **Implement data minimization
+techniques**. Evaluate and identify data for
+anonymization or de-identification to reduce sensitivity.
+Use techniques such as masking, tokenization, or principal
+component analysis to reduce the risk associated with using
+sensitive data for training. Consider using
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) with appropriate
+transformation techniques to create privacy-preserving
+feature representations.
+- **Establish governance documentation
+and processes**. Create comprehensive documentation
+of your sensitive data handling practices, including
+classification schemes, protection mechanisms, access
+control policies, and incident response procedures.
+Regularly review and update these documents to reflect
+changes in regulations, technologies, and organizational
+practices.
+- **Implement differential privacy
+techniques**. Apply differential privacy methods to
+add controlled noise to your data or models to block the
+extraction of individual data points while maintaining
+overall statistical validity.
+[AWS Clean Rooms](https://aws.amazon.com/clean-rooms/) assist organizations with collaborating
+on sensitive data while maintaining privacy and adherence to
+regulations.
+- **Perform regular privacy impact
+assessments**. Conduct systematic evaluations of
+how your ML workflows collect, use, and protect sensitive
+data. Use the results to identify areas for improvement in
+your privacy protection mechanisms and adhere to relevant
+regulations.
+- **Implement safeguards for large
+language models**. When using large language
+models, implement safeguards to block memorization and
+exposure of sensitive training data. Use
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) with appropriate
+privacy-preserving configurations and implement proper data
+filtering and anonymization techniques during model training
+and fine-tuning.
+
+## Resources
+
+**Related documents:**
+
+- [Running
+sensitive data discovery jobs in Amazon Macie](https://docs.aws.amazon.com/macie/latest/user/discovery-jobs.html)
+- [Categorizing
+your storage using tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html)
+- [AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html)
+- [Using
+the AWS Encryption SDK with AWS KMS](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/getting-started.html)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Use
+Macie to discover sensitive data as part of automated data
+pipelines](https://aws.amazon.com/blogs/security/use-macie-to-discover-sensitive-data-as-part-of-automated-data-pipelines/)
+- [Building
+a Serverless Tokenization Solution to Mask Sensitive
+Data](https://aws.amazon.com/blogs/compute/building-a-serverless-tokenization-solution-to-mask-sensitive-data/)
+
+**Related videos:**
+
+- [Security
+for AI/ML Models in AWS](https://www.youtube.com/watch?v=toDQL_c8Zug)
+- [Security
+best practices the AWS Well-Architected way](https://www.youtube.com/watch?v=wfIVI-M7lbQ)
+
+**Related examples:**
+
+- [Secure
+Data Science Reference Architecture](https://github.com/aws-samples/secure-data-science-reference-architecture)
+- [Amazon SageMaker AI Secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp03.html*
+
+---
+
+# MLSEC03-BP04 Enforce data lineage
+
+Data lineage tracking allows you to monitor and track data origins
+and transformations over time, enabling better visibility into your
+machine learning workflows. By enforcing data lineage, you can trace
+the root cause of data processing errors and and protect the
+integrity of your ML models.
+
+**Desired outcome:** You can trace a
+data element back to its source, verify the transformations it
+underwent, and verify data integrity throughout the ML lifecycle.
+You have visibility into your entire ML workflow from data
+preparation to model deployment, enabling you to reproduce
+workflows, establish model governance standards, and demonstrate
+audit adherence.
+
+**Common anti-patterns:**
+
+- Treating data lineage as an afterthought rather than a core
+requirement.
+- Failing to maintain records of data transformations during
+preprocessing.
+- Not implementing integrity checks for detecting data
+manipulation or corruption.
+- Neglecting to document code and infrastructure changes that
+affect the ML pipeline.
+- Relying on manual tracking methods that are prone to errors and
+inconsistencies.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved troubleshooting through the ability to trace issues
+back to their source.
+- Improves adherence to regulatory requirements through
+comprehensive audit trails.
+- Greater confidence in model outputs by understanding the
+provenance of training data.
+- Faster iteration cycles by being able to reproduce workflows
+efficiently.
+- Better governance and risk management across ML operations.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Data lineage is a critical component of responsible ML operations.
+By tracking the journey of your data from its source through
+various transformations to model deployment, you create
+accountability and transparency in your ML systems. Enforcing data
+lineage involves implementing mechanisms to record metadata about
+data origins, transformations, and access controls throughout the
+ML lifecycle.
+
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) provides built-in capabilities to track and
+maintain data lineage through its MLflow tracking capabilities.
+This system allows you to record the relationships between various
+ML artifacts such as datasets, algorithms, hyperparameters, and
+model artifacts. By utilizing these tracking capabilities, you can
+establish a clear audit trail that assists with reproducibility,
+governance, and troubleshooting.
+
+Proper data lineage implementation also requires strict access
+controls to block unauthorized data manipulation. Your tracking
+system should record who accessed the data, what changes were
+made, and when those changes occurred. Additionally, implement
+integrity checks against your training data to detect unexpected
+deviations caused by data corruption or malicious manipulation.
+
+### Implementation steps
+
+- **Set up Amazon SageMaker AI MLflow
+Tracking**. Enable tracking capabilities in your
+SageMaker AI environment to automatically capture metadata
+about your ML workflows. Configure SageMaker AI to track
+artifacts, associations, and context information using
+[Amazon SageMaker AI MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html). MLflow in SageMaker AI allows you to
+create, manage, analyze, and compare experiments, providing
+comprehensive tracking of training runs, model versions, and
+associated metadata.
+- **Implement automated metadata
+collection**. Configure your ML pipelines to
+automatically record metadata at each stage of processing.
+Use
+[SageMaker AI
+Processing](https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html) jobs to track data transformations and
+record preprocessing steps. Apply
+[SageMaker AI
+Pipeline](https://aws.amazon.com/sagemaker/pipelines/) steps to document the flow of data from one
+stage to another, creating a complete record of the data
+journey.
+- **Establish data access
+controls**. Implement strict access controls to
+protect data integrity. Use
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) roles and policies to
+restrict access to specific datasets and models. Configure
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect unauthorized access
+or changes to your data.
+- **Create integrity verification
+mechanisms**. Implement data validation steps in
+your pipeline to detect anomalies or unexpected changes. Use
+checksums, statistical analysis, or machine learning-based
+anomaly detection to identify potential data corruption.
+Store integrity verification results as part of your lineage
+tracking records.
+- **Document code and infrastructure
+changes**. Track changes to your code repositories
+and infrastructure configurations that affect the ML
+workflow. Use version control systems like Git integrated
+with
+[AWS CodeCommit](https://aws.amazon.com/codecommit/) to maintain a history of code changes, and
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to version your infrastructure as code.
+- **Implement end-to-end
+traceability**. Verify that your lineage tracking
+system can trace model predictions back to the original data
+sources used for training. Use
+[SageMaker AI
+MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to catalog your models and
+associate them with their training data lineage. This
+enables you to understand exactly which data influenced
+specific model behaviors.
+- **Establish audit and
+compliance-aligned reporting**. Create automated
+reports that demonstrate data lineage for compliance-aligned
+purposes. Use
+[Quick](https://aws.amazon.com/quicksight/) to visualize data lineage graphs and
+[Amazon Athena](https://aws.amazon.com/athena/) to query lineage metadata for audit reports.
+Regularly review these reports to improve your adherence to
+your governance requirements.
+- **Implement foundation model
+tracking**. For foundation model workflows, track
+not only the data but also the foundation models used, their
+versions, and fine-tuning parameters. Use
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model
+characteristics and
+[Amazon SageMaker AI Model Dashboard](https://docs.aws.amazon.com/sagemaker/latest/dg/model-dashboard.html) to monitor model
+performance. Implement comprehensive traceability features
+to document model provenance and usage.
+- **Track model input
+variations**. Maintain a record of input variations
+used with models, as these influence model outputs. Use
+[Amazon SageMaker AI MLflow tracking server](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html) with enhanced MLflow
+3.0 capabilities to track different input variations and
+their effectiveness, treating inputs as critical components
+of your data lineage system. The managed MLflow service
+provides robust experiment management at scale for ML
+projects with comprehensive tracking of training runs, model
+versions, and associated metadata.
+
+## Resources
+
+**Related documents:**
+
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [SageMaker AI
+MLflow Tracking Server](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server.html)
+- [Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/)
+- [Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html)
+- [Accelerating
+generative AI development with fully managed MLflow 3.0 on
+Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/accelerating-generative-ai-development-with-fully-managed-mlflow-3-0-on-amazon-sagemaker-ai/)
+- [Building,
+automating, managing, and scaling ML workflows using Amazon SageMaker AI Pipelines](https://aws.amazon.com/blogs/machine-learning/building-automating-managing-and-scaling-ml-workflows-using-amazon-sagemaker-pipelines/)
+
+**Related videos:**
+
+- [How
+To Efficiently Manage ML experiments using Amazon SageMaker AI ML
+Flow](https://www.youtube.com/watch?v=3xkz_5HOP6k)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp04.html*
+
+---
+
+# MLSEC03-BP05 Keep only relevant data
+
+Reduce data exposure risks by preserving only use-case relevant data
+across computing environments. Implementing data lifecycle
+management and privacy-preserving techniques maintains data security
+while enabling effective machine learning workflows.
+
+**Desired outcome:** You maintain a
+streamlined dataset across development, staging, and production
+environments that contains only the data elements needed for your
+machine learning use cases. You have implemented automated data
+lifecycle management processes that properly identify data, redact
+it when necessary, and remove it when no longer needed. This
+approach reduces your security risk exposure while maintaining data
+usability for ML operations.
+
+**Common anti-patterns:**
+
+- Keeping collected data indefinitely in case it might be useful
+later.
+- Failing to implement data redaction for personally identifiable
+information (PII) in ML datasets.
+- Using production data with sensitive information in development
+environments.
+- Not establishing clear timelines for data retention and removal.
+- Ignoring privacy regulations when designing ML workflows.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of data breaches and privacy violations.
+- Lower storage and computational costs from processing only
+necessary data.
+- Improved adherence to data privacy regulations.
+- Enhanced ML model performance through focus on relevant
+features.
+- Streamlined data management processes across environments.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Managing data exposure is crucial for machine learning security.
+The more data you collect and store, the greater your attack
+surface and potential for data breaches. By focusing on data
+minimization principles, you can reduce these risks while still
+achieving your ML objectives.
+
+Your data lifecycle management strategy should begin with a
+thorough assessment of what data is truly needed for your ML use
+cases. This requires close collaboration between data scientists,
+security professionals, and business stakeholders to identify
+essential features and acceptable levels of data granularity. Once
+identified, implement mechanisms to maintain only the necessary
+data elements across environments.
+
+When working with potentially sensitive information, apply
+privacy-preserving techniques like anonymization,
+pseudonymization, or redaction of PII. AWS services like
+[Amazon Comprehend](https://aws.amazon.com/comprehend/) and
+[Amazon Macie](https://aws.amazon.com/macie/) can identify sensitive data automatically, while
+[Amazon Transcribe](https://aws.amazon.com/transcribe/) offers automatic redaction capabilities. For
+more advanced scenarios, consider techniques like differential
+privacy or federated learning that allow you to derive insights
+from sensitive data without exposing the raw information.
+
+Regular data audits and automated cleanup processes are essential
+components of an effective data lifecycle management strategy. By
+implementing automated policies for data retention and deletion,
+you can verify that data doesn't linger unnecessarily in your
+systems after its useful life has ended.
+
+### Implementation steps
+
+- **Assess data requirements**.
+Begin by thoroughly analyzing your ML use case to determine
+exactly which data elements are required for model training,
+validation, and inference. Document the minimum data
+requirements for each stage of your ML pipeline and justify
+the need for each attribute. Consider using techniques like
+feature importance analysis to identify which data elements
+contribute most to model performance.
+- **Develop a comprehensive data
+lifecycle plan**. Create a documented plan that
+defines how data will flow through your ML pipeline,
+including data collection, processing, storage, usage, and
+eventual deletion. Identify usage patterns and requirements
+for debugging and operational tasks. Specify retention
+periods based on business needs, regulatory requirements,
+and the purpose of the data.
+- **Implement data minimization
+techniques**. Design your data collection and
+preprocessing pipelines to capture only the necessary data
+attributes identified in your assessment. Use
+[AWS Glue](https://aws.amazon.com/glue/) or similar ETL services to filter out
+unnecessary fields before storage. Consider implementing
+record-level filtering in addition to column-level
+filtering.
+- **Set up automated PII detection and
+redaction**. Deploy solutions to automatically
+identify and redact sensitive information. Use
+[Amazon Comprehend](https://aws.amazon.com/comprehend/) for detecting PII in text data and
+[Amazon Rekognition](https://aws.amazon.com/rekognition/) for identifying sensitive elements in
+images. Implement
+[Amazon Transcribe's automatic redaction feature](https://aws.amazon.com/blogs/aws/now-available-in-amazon-transcribe-automatic-redaction-of-personally-identifiable-information/) for audio
+transcriptions.
+- **Establish data governance
+controls**. Implement access controls and
+encryption mechanisms using
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) and
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/). Use
+[Amazon Macie](https://aws.amazon.com/macie/) to automatically discover, classify, and
+protect sensitive data in AWS. Apply data classification
+tags to facilitate appropriate handling of different data
+types.
+- **Configure automated data lifecycle
+policies**. Set up
+[S3
+Lifecycle configurations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) to automatically transition
+or expire data based on your retention policies. Implement
+similar mechanisms for other storage systems used in your ML
+pipeline. Create automated jobs to periodically review and
+remove stale data from environments.
+- **Implement privacy-preserving ML
+techniques**. Where possible, use privacy-enhancing
+technologies like differential privacy, federated learning,
+or encrypted computation. Consider using
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) to centrally define and enforce
+fine-grained access controls. For sensitive use cases,
+explore options for machine learning on encrypted data.
+- **Monitor and audit data
+usage**. Set up logging and monitoring using
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) and
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track data access patterns.
+Periodically audit data usage against documented
+requirements to identify and avoid unnecessary data
+collection. Use
+[Amazon Athena with user-defined functions](https://aws.amazon.com/blogs/big-data/redacting-sensitive-information-with-user-defined-functions-in-amazon-athena/) for analyzing and
+redacting sensitive information in logs and audit trails.
+- **Implement responsible data practices
+for AI models**. When using AI models, be
+especially careful with training data to block memorization
+of sensitive information. Utilize
+[Amazon SageMaker AI's feature store](https://aws.amazon.com/sagemaker/feature-store/) for centralized feature
+management with built-in security controls. Consider data
+poisoning risks and implement appropriate data validation
+before model training.
+
+## Resources
+
+**Related documents:**
+
+- [Reference
+Guide: Extract More Value from your Data](https://pages.awscloud.com/data-lifecycle-reference-guide.html?sc_channel=bl&sc_campaign=datalifecycleandanalyticsintheawscloud&sc_geo=mult&sc_country=global&sc_outcome=multi)
+- [Data
+Privacy Center](https://aws.amazon.com/compliance/data-privacy/)
+- [Building
+a data analytics practice across the data lifecycle](https://aws.amazon.com/blogs/publicsector/building-a-data-analytics-practice-across-the-data-lifecycle/)
+- [Detecting
+and redacting PII using Amazon Comprehend](https://aws.amazon.com/blogs/machine-learning/detecting-and-redacting-pii-using-amazon-comprehend/)
+- [Now
+available in Amazon Transcribe: Automatic Redaction of
+Personally Identifiable Information](https://aws.amazon.com/blogs/aws/now-available-in-amazon-transcribe-automatic-redaction-of-personally-identifiable-information/)
+- [Redacting
+sensitive information with user-defined functions in Amazon Athena](https://aws.amazon.com/blogs/big-data/redacting-sensitive-information-with-user-defined-functions-in-amazon-athena/)
+
+**Related videos:**
+
+- [Privacy-preserving
+machine learning](https://www.youtube.com/watch?v=ZQkB9XRqdnc)
+- [Best
+practices for Amazon S3](https://youtu.be/HT3QiuzgjZg?t=524)
+
+**Related examples:**
+
+- [Field
+Notes: Redacting Personal Data from Connected Cars Using
+Amazon Rekognition](https://aws.amazon.com/blogs/architecture/field-notes-redacting-personal-data-from-connected-cars-using-amazon-rekognition/)
+- [How
+to Create a Modern CPG Data Architecture with Data Mesh](https://aws.amazon.com/blogs/industries/how-to-create-a-modern-cpg-data-architecture-with-data-mesh/)
+- [Building
+a secure enterprise machine learning platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec03-bp05.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSEC04.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSEC04.md
@@ -1,0 +1,581 @@
+# MLSEC04
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLSEC04-BP01 Secure governed ML environment
+
+Creating a secure and governed ML environment allows you to protect
+valuable data and models while enabling teams to innovate
+efficiently. By implementing proper guardrails, monitoring, and
+security practices, you maintain control while providing the
+flexibility ML practitioners need to deliver business value.
+
+**Desired outcome:** You establish a
+secure ML operational environment using AWS managed services that
+incorporates best practices for security, governance, and
+monitoring. You create development environments that allow data
+scientists to explore data safely while maintaining organizational
+security standards. Your ML environments are centrally managed with
+proper access controls, yet offer self-service capabilities to
+improve productivity. This balance between security and flexibility
+enables your organization to innovate while protecting sensitive
+assets.
+
+**Common anti-patterns:**
+
+- Using a single shared account for ML workloads regardless of
+sensitivity or access requirements.
+- Allowing unrestricted access to ML infrastructure and production
+environments.
+- Implementing manual provisioning processes that create
+bottlenecks for data scientists.
+- Neglecting to isolate environments containing sensitive data.
+- Failing to implement continuous monitoring and detection
+controls for ML operations.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced security risks through proper isolation and access
+controls.
+- Improved governance with enforced security guardrails.
+- Enhanced productivity through self-service capabilities.
+- Improves adherence to regulatory requirements.
+- Simplified management of ML environments.
+- Faster time-to-market for ML initiatives.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Securing your ML environment requires thoughtful architecture that
+balances security with productivity. You need to consider how
+different teams interact with ML resources and implement controls
+appropriate to their roles and the sensitivity of data being
+processed. AWS provides managed services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) that can be configured with security best
+practices in mind.
+
+Begin by understanding your organization's access patterns and
+data sensitivity levels. This knowledge assists you when
+determining how to structure your AWS accounts and implementing
+appropriate security controls. For example, you might separate
+development, testing, and production environments across different
+accounts with increasing security restrictions. This multi-account
+strategy allows you to implement tailored security controls for
+each environment while maintaining proper isolation.
+
+Once you've established your account structure, implement
+preventive guardrails using
+[AWS Organizations](https://aws.amazon.com/organizations/) and service control policies (SCPs) to
+enforce security boundaries. Detective controls using services
+like [AWS Config](https://aws.amazon.com/config/) and
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) provide continuous monitoring to identify
+potential security issues. By combining preventive and detective
+controls, you create defense-in-depth protection for your ML
+environments.
+
+For environments handling sensitive data, implement additional
+security measures like network isolation, encryption, and
+fine-grained access controls. Amazon SageMaker AI can be deployed
+within a VPC to limit network access, while
+[AWS KMS](https://aws.amazon.com/kms/)
+provides robust encryption capabilities for data at rest and in
+transit. These measures protect sensitive information throughout
+the ML lifecycle.
+
+### Implementation steps
+
+- **Break out ML workloads by
+organizational unit access patterns**. Create a
+multi-account strategy that aligns with your organization's
+structure and security requirements. For example, create
+separate accounts for data science development, model
+training, and production model deployment. This separation
+allows you to implement role-based access control (RBAC)
+with appropriate permissions for each team. Use
+[Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html) to quickly define
+persona-based IAM roles for different user types (data
+scientists, MLOps engineers, business analysts) with
+preconfigured templates that provide least privilege access.
+Use
+[AWS Organizations](https://aws.amazon.com/organizations/) to manage your multi-account
+environment efficiently.
+- **Use guardrails and service control
+policies (SCPs) to enforce best practices**.
+Implement SCPs through
+[AWS Organizations](https://aws.amazon.com/organizations/) to establish preventive guardrails that
+restrict actions across accounts. For example, create
+policies that block the disabling of security services,
+limit the AWS regions that can be used, or restrict the
+creation of public resources. Complement SCPs with
+[AWS Config](https://aws.amazon.com/config/) rules to detect non-compatible resources and
+automatically remediate issues. Limit infrastructure
+management access to administrators while allowing data
+scientists to focus on model development.
+- **Verify that sensitive data has
+access through restricted, isolated environments**.
+Implement
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) within a private VPC to control network
+traffic to and from your ML environment. Configure security
+groups and network ACLs to restrict access to authorized
+sources. Use
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) to access AWS services without traversing
+the public internet. Enable encryption for sensitive data
+using [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) for both data at rest and in
+transit. Review service dependencies to verify that they
+meet your security requirements.
+- **Secure ML algorithm implementation
+using a restricted development environment**.
+Deploy
+[Amazon SageMaker AI Studio](https://aws.amazon.com/sagemaker/studio/) with appropriate security controls
+to provide data scientists with a secure development
+environment. Implement
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) roles with least
+privilege permissions for each development environment. Use
+[Amazon SageMaker AI Domain](https://docs.aws.amazon.com/sagemaker/latest/dg/gs-studio-onboard.html) configurations to manage user access
+to resources. Scan container images for vulnerabilities
+before deploying them for model training or hosting using
+[Amazon ECR image scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html).
+- **Implement centralized management and
+monitoring**. Use
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to track API activity across your ML
+environments. Deploy
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) for operational monitoring of your ML
+resources. Implement
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) to detect suspicious activity. Centralize
+logs in a dedicated security account for comprehensive
+visibility across your ML environments. Create automated
+alerts for security-related events that require
+investigation.
+- **Enable self-service provisioning
+with guardrails**. Implement
+[Service Catalog](https://aws.amazon.com/servicecatalog/) to provide pre-approved, secure
+templates for ML resources like SageMaker AI environments.
+Configure lifecycle policies to automatically shut down idle
+resources and reduce costs. Use
+[AWS CloudFormation](https://aws.amazon.com/cloudformation/) or
+[AWS CDK](https://aws.amazon.com/cdk/) to define infrastructure as code with security
+best practices built in. This allows data scientists to
+provision resources quickly while maintaining adherence to
+organizational standards.
+- **Secure model artifacts and ML
+pipelines**. Implement version control for models
+and code using
+[Amazon SageMaker AI MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html). Configure
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/) with appropriate access controls
+to automate the ML lifecycle. Use
+[AWS CodePipeline](https://aws.amazon.com/codepipeline/) and
+[AWS CodeBuild](https://aws.amazon.com/codebuild/) to implement CI/CD for ML applications with
+security checks built into the deployment process.
+- **Implement foundation model security
+controls**. When using large language models (LLMs)
+or other foundation models, implement guardrails to block
+the generation of harmful content. Implement content
+filtering to verify responsible AI usage. For enterprise
+governance of foundation models, implement
+[SageMaker AI
+JumpStart Private Model Hub](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html) to create curated
+repositories of approved models with centralized access
+controls and version management. Use
+[SageMaker AI
+Catalog](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-projects-templates-custom.html) as a central metadata hub for secure sharing
+and governed access to ML assets across business units.
+Implement
+[Amazon SageMaker AI Model Cards](https://docs.aws.amazon.com/sagemaker/latest/dg/model-cards.html) to document model limitations,
+ethical considerations, and intended uses. Monitor model
+outputs for drift and bias using
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html).
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Role Manager](https://docs.aws.amazon.com/sagemaker/latest/dg/role-manager.html)
+- [Private
+curated hubs for foundation model access control in
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs.html)
+- [Admin
+guide for private model hubs in Amazon SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-curated-hubs-admin-guide.html)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Build
+a secure enterprise machine learning platform on AWS](https://docs.aws.amazon.com/whitepapers/latest/build-secure-enterprise-ml-platform/build-secure-enterprise-ml-platform.html)
+- [Security
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Model
+governance to manage permissions and track model
+performance](https://docs.aws.amazon.com/sagemaker/latest/dg/governance.html)
+- [Setting
+up secure, well-governed machine learning environments on
+AWS](https://aws.amazon.com/blogs/mt/setting-up-machine-learning-environments-aws)
+- [Securing
+Amazon SageMaker AI Studio connectivity using a private
+VPC](https://aws.amazon.com/blogs/machine-learning/securing-amazon-sagemaker-studio-connectivity-using-a-private-vpc/)
+- [Enable
+self-service, secured data science using Amazon SageMaker AI and
+Service Catalog](https://aws.amazon.com/blogs/mt/enable-self-service-secured-data-science-using-amazon-sagemaker-notebooks-and-aws-service-catalog/)
+- [Accelerating
+Machine Learning Development with Data Science as a Service
+from Change Healthcare](https://aws.amazon.com/blogs/apn/accelerating-machine-learning-development-with-data-science-as-a-service-from-change-healthcare/)
+
+**Related videos:**
+
+- [Architectural
+best practices for machine learning applications](https://www.youtube.com/watch?v=fBytsYBVgbo)
+- [Secure
+and compliant machine learning for regulated industries](https://www.youtube.com/watch?v=8p-B3sTLmFg)
+- [Amazon SageMaker AI Model Development in a Highly Regulated
+Environment (SDD315)](https://youtu.be/cSYFqKRQ0j0?t=1051)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec04-bp01.html*
+
+---
+
+# MLSEC04-BP02 Secure inter-node cluster communications
+
+Machine learning frameworks require secure communications between
+computational nodes to maintain data integrity and protect sensitive
+information during model training. By implementing encryption for
+inter-node communications, you safeguard coefficient exchanges and
+protect synchronized information across distributed environments.
+
+**Desired outcome:** You establish
+encrypted communication channels between computational nodes in your
+machine learning clusters, protecting sensitive model data,
+parameters, and training information as it traverses networks. This
+improves data integrity and confidentiality during distributed
+training operations while maintaining the performance requirements
+of your machine learning workloads.
+
+**Common anti-patterns:**
+
+- Assuming internal network communications are inherently secure
+and don't require encryption.
+- Implementing encryption only for external communications but
+neglecting inter-node traffic.
+- Using outdated or weak encryption protocols for performance
+reasons.
+- Neglecting to rotate encryption certificates and credentials
+regularly.
+
+**Benefits of establishing this best
+practice:**
+
+- Protection of proprietary algorithms and model parameters during
+training.
+- Prevention of data leakage and unauthorized access to training
+data.
+- Improves adherence to data protection regulations and security
+requirements.
+- Consistent security posture across your ML infrastructure.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+For machine learning frameworks like TensorFlow that rely on
+distributed computing, secure inter-node communication is
+essential to protect the integrity and confidentiality of the
+training process. During distributed training, nodes exchange
+critical information like model coefficients, gradients, and
+parameter updates. This information contains valuable intellectual
+property about your models and potentially sensitive insights
+derived from your training data.
+
+When implementing distributed machine learning workloads, encrypt
+that data transmitted between computational nodes using
+industry-standard protocols. This is particularly important when
+your infrastructure spans across different networks, availability
+zones, or even Regions. Encryption in transit stops unauthorized
+parties from intercepting or tampering with model data as it moves
+between nodes.
+
+AWS services like
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) and
+[Amazon EMR](https://aws.amazon.com/emr/)
+provide built-in capabilities to secure inter-node communications,
+making it more straightforward to implement this best practice
+without extensive custom configuration.
+
+### Implementation steps
+
+- **Enable inter-node encryption in
+Amazon SageMaker AI**. Amazon SageMaker AI provides
+automatic encryption for inter-container communication
+during training jobs. When configuring your training job,
+enable encryption to verify that data passed between
+containers traverses over an encrypted tunnel. For
+large-scale distributed training, use
+[Amazon SageMaker AI HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html) which provides managed, resilient
+clusters with built-in security features including VPC
+integration, automatic health checks, and secure
+node-to-node communication for foundation model training.
+This protects your model parameters and gradients during the
+training process without requiring additional configuration.
+- **Configure TLS for distributed
+TensorFlow workloads**. For TensorFlow-based
+distributed training, implement Transport Layer Security
+(TLS) to secure communications between worker nodes.
+TensorFlow supports TLS configuration through environment
+variables and configuration parameters. Use properly signed
+certificates and configure both client and server-side
+authentication for maximum security.
+- **Enable encryption in transit in
+Amazon EMR**. When using
+[Amazon EMR](https://aws.amazon.com/emr/) for machine learning workloads, implement
+security configurations that enable encryption in transit.
+Amazon EMR makes it simple to create security configurations
+that specify the use of Transport Layer Security (TLS)
+certificates for encrypting data in transit between cluster
+nodes. This protects data whether it's stored locally on the
+cluster or in Amazon S3.
+- **Implement secure key
+management**. Use
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to manage the encryption
+keys used for securing inter-node communications. This
+provides centralized control, auditing, and automatic key
+rotation, enhancing your security posture while simplifying
+key management operations.
+- **Configure secure cluster
+authentication**. Implement strong authentication
+mechanisms to verify that only authorized nodes can join
+your cluster and participate in the distributed training
+process. Use certificate-based authentication where possible
+and implement node identity verification as part of your
+security configuration.
+- **Regularly rotate security
+credentials**. Establish a process for regularly
+rotating TLS certificates, encryption keys, and other
+security credentials used in your distributed training
+environment. This limits the potential impact of compromised
+credentials and aligns with security best practices.
+- **Monitor encrypted
+communications**. Implement logging and monitoring
+for your encrypted communications channels to detect
+potential security issues. Configure alerts for unusual
+traffic patterns or authentication failures that might
+indicate attempted security breaches.
+- **Secure foundation model
+communication**. When using distributed training
+for large language models or other foundation models,
+encrypt parameter server communications, as these contain
+valuable intellectual property. For AI workloads on Amazon SageMaker AI, enable inter-container encryption to protect
+model weights and gradients during the training process.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI HyperPod Prerequisites](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod-prerequisites.html)
+- [Protect
+Communications Between ML Compute Instances in a Distributed
+Training Job](https://docs.aws.amazon.com/sagemaker/latest/dg/train-encrypt.html)
+- [Encryption
+options for Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-data-encryption-options.html)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Security
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Encrypt
+data in transit using a TLS custom certificate provider with
+Amazon EMR](https://aws.amazon.com/blogs/big-data/encrypt-data-in-transit-using-a-tls-custom-certificate-provider-with-amazon-emr/)
+- [Building
+secure machine learning environments with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/building-secure-machine-learning-environments-with-amazon-sagemaker/)
+- [Amazon SageMaker AI Studio Admin Best Practices](https://docs.aws.amazon.com/whitepapers/latest/sagemaker-studio-admin-best-practices/data-protection.html)
+
+**Related videos:**
+
+- [Architectural
+best practices for machine learning applications](https://www.youtube.com/watch?v=fBytsYBVgbo)
+- [Secure
+and compliant machine learning for regulated industries](https://www.youtube.com/watch?v=8p-B3sTLmFg)
+
+**Related examples:**
+
+- [Amazon SageMaker AI secure distributed training examples](https://github.com/aws/amazon-sagemaker-examples/tree/main/sagemaker-python-sdk)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec04-bp02.html*
+
+---
+
+# MLSEC04-BP03 Protect against data poisoning threats
+
+Protect your machine learning models and data by implementing
+security measures against data poisoning attacks, which can
+compromise model performance and accuracy. Data poisoning occurs
+through data injection (adding corrupt training data) or data
+manipulation (changing existing data like labels), resulting in
+inaccurate and weakened predictive capabilities. By identifying and
+addressing corrupt data using security methods and anomaly detection
+algorithms, you can maintain data integrity and protect against
+threats including ransomware and malicious code in third-party
+packages.
+
+**Desired outcome:** You have
+implemented robust protection mechanisms for your machine learning
+training data and models. These protections include data validation
+procedures, monitoring for data drift, version control for both data
+and models, and rollback capabilities. Your ML systems can detect
+potential poisoning attempts and maintain model performance
+integrity through security best practices that protect data
+throughout its lifecycle.
+
+**Common anti-patterns:**
+
+- Collecting training data from untrusted or unverified sources
+without validation.
+- Neglecting to monitor data distributions for unexpected shifts.
+- Deploying updated models without thorough testing against
+baseline performance.
+- Failing to implement version control for both training data and
+models.
+- Not having a rollback strategy for compromised models.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model reliability and accuracy through clean, trusted
+data.
+- Early detection of potential security breaches targeting
+training data.
+- Reduced risk of deploying compromised models to production.
+- Ability to quickly recover from poisoning incidents through
+rollback mechanisms.
+- Enhanced overall ML system security and resilience.
+
+**Risk level for not implementing this
+practice:** High
+
+## Implementation guidance
+
+Data poisoning represents a security threat to machine learning
+systems. When malicious actors manipulate training data, they can
+compromise model integrity and cause downstream impacts on
+decisions or predictions made by those models. You need to
+implement comprehensive protections throughout your ML pipeline,
+from data collection to model deployment and monitoring.
+
+Start by establishing strict controls over data sources and
+implementing validation procedures to detect anomalies before
+training. During model development, implement monitoring for data
+drift that could indicate poisoning attempts. Before deployment,
+thoroughly compare new models against previous versions to
+identify unexpected behavior changes. Finally, maintain versioned
+copies of both training data and models to enable rapid recovery
+from compromise.
+
+By combining these defensive approaches, you create multiple
+layers of protection that make your ML systems resilient against
+data poisoning attempts.
+
+### Implementation steps
+
+- **Use only trusted data sources for
+training data**. Verify the provenance of data used
+for training and implement audit controls that allow you to
+track changes to training data. This includes recording who
+made changes, what changes were made, and when they
+occurred. Before using data for training, validate its
+quality to identify potential outliers and incorrectly
+labeled samples that could indicate poisoning attempts.
+- **Look for underlying shifts in the
+patterns and distributions in training data**.
+Implement continuous monitoring for data drift to detect
+unexpected changes in data distributions. Use tools like
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to track these changes
+automatically. Deviations from established patterns can
+serve as early warning signs of unauthorized access or
+manipulation targeting training data.
+- **Identify model updates that
+negatively impact the results before moving them to
+production**. Compare newly trained models against
+previous versions using consistent test datasets. Look for
+unexpected performance changes, especially degradations in
+specific areas that weren't present in earlier model
+iterations. Use
+[Amazon SageMaker AI MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to track model
+versions and their performance metrics.
+- **Have a rollback plan**.
+Implement versioning for both training data and models to
+enable quick recovery from compromised states. Use
+[Amazon SageMaker AI Feature Store](https://aws.amazon.com/sagemaker/feature-store/) to maintain secure, versioned
+features for your ML models. The Feature Store provides a
+centralized repository for features with built-in security
+controls. Configure Amazon SageMaker AI MLflow Model Registry
+to support rollback capabilities so you can quickly revert
+to a known good model version if issues are detected with a
+newly deployed model.
+- **Use low-entropy classification
+cases**. Establish performance thresholds and
+monitor for unexpected classification patterns. Define
+boundaries for acceptable model behavior and create alerts
+when outputs deviate from expected patterns. This can
+identify subtle poisoning attempts that might otherwise go
+undetected through conventional testing.
+- **Implement end-to-end encryption for
+ML data**. Secure your training data, feature sets,
+and models using encryption both at rest and in transit. Use
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/) to manage encryption keys
+and apply them consistently across your ML pipeline.
+Encryption protects against unauthorized access that could
+lead to data poisoning.
+- **Regularly scan for vulnerabilities
+in ML dependencies**. Use tools like
+[Amazon Inspector](https://aws.amazon.com/inspector/) to detect vulnerabilities in the software
+packages and dependencies used in your ML environment. Data
+poisoning can occur through compromised third-party
+libraries, so regular scanning can identify potential entry
+points for bad actors.
+- **Implement input validation for AI
+systems**. For AI models, validate inputs for
+potential poisoning attempts. Implement filtering and
+sanitization of inputs to block adversarial inputs that
+could manipulate model behavior or extract sensitive
+information.
+
+## Resources
+
+**Related documents:**
+
+- [Bias
+drift for models in production](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-monitor-bias-drift.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Create,
+store, and share features with Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Automated
+monitoring of your machine learning models with Amazon SageMaker AI Model Monitor and sending predictions to human
+review workflows using Amazon A2I](https://aws.amazon.com/blogs/machine-learning/automated-monitoring-of-your-machine-learning-models-with-amazon-sagemaker-model-monitor-and-sending-predictions-to-human-review-workflows-using-amazon-a2i/)
+- [Amazon SageMaker AI Model Monitor– Fully Managed Automatic Monitoring
+for Your Machine Learning Models](https://aws.amazon.com/blogs/aws/amazon-sagemaker-model-monitor-fully-managed-automatic-monitoring-for-your-machine-learning-models/)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Building
+secure machine learning environments with Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/building-secure-machine-learning-environments-with-amazon-sagemaker/)
+
+**Related videos:**
+
+- [Detect
+machine learning (ML) model drift in production](https://www.youtube.com/watch?v=J9T0X9Jxl_w)
+- [Inawisdom:
+Machine Learning and Automated Model Retraining with SageMaker AI](https://www.youtube.com/watch?v=1kbWvlHBYLk&t=7s)
+
+**Related examples:**
+
+- [Amazon SageMaker AI Model Monitor Examples](https://github.com/aws/amazon-sagemaker-examples/tree/default/%20%20%20ml_ops)
+- [Amazon SageMaker AI Feature Store Examples](https://github.com/aws-samples/amazon-sagemaker-feature-store-examples)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec04-bp03.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSEC05.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSEC05.md
@@ -1,0 +1,180 @@
+# MLSEC05
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSEC05-BP01 Protect against adversarial and malicious activities
+
+Machine learning systems must be robust against adversarial inputs
+designed to manipulate their behavior. Implementing protection
+mechanisms both inside and outside of your deployed models can
+detect malicious inputs that could lead to incorrect predictions,
+allowing you to automatically identify unauthorized changes, repair
+compromised inputs, and validate data before it's used for further
+training.
+
+**Desired outcome:** You can detect,
+mitigate, and protect your ML models from adversarial exploits that
+attempt to manipulate inputs, preserving model integrity and
+providing reliable predictions. Your ML systems incorporate robust
+validation processes, ensemble approaches, and monitoring
+capabilities that maintain consistent performance even when faced
+with deliberately perturbed or malicious inputs.
+
+**Common anti-patterns:**
+
+- Implementing ML models without considering potential adversarial
+threats.
+- Focusing solely on model performance metrics without evaluating
+robustness.
+- Using single model architectures that are vulnerable to targeted
+threats.
+- Retraining models with unvalidated inputs that may contain
+adversarial examples.
+- Exposing ML models through unsecured endpoints without
+monitoring capabilities.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved model robustness against input manipulation attempts.
+- Enhanced detection of potential security threats targeting ML
+systems.
+- Greater reliability in model predictions even under adversarial
+conditions.
+- Protection against data poisoning during model retraining.
+- Reduced vulnerability to model extraction and inference threats.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Adversarial threats against machine learning models involve
+deliberately crafting inputs to cause incorrect predictions or
+undesirable behaviors. These threats can range from subtle
+perturbations that are imperceptible to humans but cause model
+errors, to more sophisticated techniques that exploit model
+vulnerabilities. Building protection against adversarial
+activities requires a multi-layered approach combining robust
+model design, comprehensive monitoring, and secure deployment
+strategies.
+
+When implementing defenses, you need to understand the specific
+vulnerabilities in your models and the potential impact of
+adversarial threats on your business outcomes. This requires
+conducting thorough evaluations of model behavior under different
+threats scenarios and implementing appropriate countermeasures
+based on your risk profile. Both pre-deployment testing and
+continuous monitoring during production are essential components
+of a comprehensive protection strategy.
+
+Adversarial robustness should be considered from the beginning of
+your ML development process rather than as an afterthought. By
+incorporating adversarial training, ensemble methods, and input
+validation techniques during model development, you can create
+systems that are inherently more resistant to threats.
+Additionally, implementing proper access controls, monitoring
+systems, and incident response procedures can establish a secure
+operational environment for your ML models.
+
+### Implementation steps
+
+- **Evaluate the robustness of your
+algorithm**. Conduct sensitivity analysis to
+understand how your model responds to perturbed inputs. Test
+your model with increasingly modified data points to
+identify decision boundaries that might be vulnerable to
+manipulation. Use adversarial testing frameworks to simulate
+potential threats and measure their impact on model
+performance. Document the types of perturbations that cause
+incorrect predictions to inform your defense strategy.
+- **Build for robustness from the
+start**. Select diverse features during model
+design to improve resilience against outliers and
+adversarial examples. Implement ensemble methods by
+combining multiple models with different architectures or
+training approaches to increase decision diversity. Consider
+techniques like adversarial training where you intentionally
+incorporate adversarial examples into your training data to
+make your models more resistant to threats.
+- **Identify repeats and suspicious
+patterns**. Deploy
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to continuously analyze
+inference data and detect unusual patterns such as repeated
+similar inputs that may indicate probing threats. Set up
+alerts for anomalous input distributions that differ from
+training data. Monitor for evidence of model brute-forcing,
+where bad actors systematically vary limited sets of input
+features to determine decision boundaries and derive feature
+importance.
+- **Implement experiment and model
+tracking**. Maintain comprehensive records of data
+provenance and model versions to trace model skew back to
+potentially compromised data sources. Before retraining
+models with new data, implement validation processes to
+identify and remove adversarial examples. Use
+[Amazon SageMaker AI MLflow](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to document relationships between
+datasets, algorithms, and model artifacts throughout the ML
+lifecycle.
+- **Use secure inference API
+endpoints**. Host models behind properly secured
+API endpoints that implement authentication, authorization,
+and input validation. Configure
+[Amazon SageMaker AI endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-manage.html) with appropriate security
+controls including VPC isolation,
+[AWS IAM](https://aws.amazon.com/iam/) roles with least privilege, and encryption for
+data in transit and at rest. Implement rate limiting and
+request validation to block abuse of model APIs. Monitor API
+usage patterns to detect potential exploitation attempts.
+- **Implement continuous model
+monitoring**. Set up
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to track data and concept
+drift that may indicate adversarial manipulation. Configure
+automatic alerts when inference data patterns deviate from
+training baselines. Periodically reevaluate model robustness
+as new threat techniques emerge in the security landscape.
+- **Establish incident response
+procedures**. Develop clear protocols for
+responding to detected adversarial threats against your ML
+systems. Define procedures for model rollback, data
+quarantine, and forensic analysis when suspicious activities
+are identified. Document lessons learned from security
+incidents to continuously improve protection strategies.
+- **Apply input validation
+guardrails**. For AI models, implement robust input
+validation and filtering mechanisms to block injection
+exploits. Implement custom guardrails to protect against
+harmful inputs that may manipulate model behavior. Monitor
+input patterns and responses to detect attempts to bypass
+security controls.
+
+## Resources
+
+**Related documents:**
+
+- [Deep
+ensembles](https://docs.aws.amazon.com/prescriptive-guidance/latest/ml-quantifying-uncertainty/deep-ensembles.html)
+- [Empirical
+demonstration of deterministic overconfidence](https://docs.aws.amazon.com/prescriptive-guidance/latest/ml-quantifying-uncertainty/app-b.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Security
+and compliance](https://docs.aws.amazon.com/whitepapers/latest/ml-best-practices-public-sector-organizations/security-and-compliance.html)
+- [7
+ways to improve security of your machine learning
+workflows](https://aws.amazon.com/blogs/security/7-ways-to-improve-security-of-your-machine-learning-workflows/)
+- [Run
+ensemble ML models on Amazon SageMaker AI](https://aws.amazon.com/blogs/machine-learning/part-7-model-hosting-patterns-in-amazon-sagemaker-run-ensemble-ml-models-on-amazon-sagemaker/)
+- [Securing
+Amazon SageMaker AI Studio connectivity using a private
+VPC](https://aws.amazon.com/blogs/machine-learning/securing-amazon-sagemaker-studio-connectivity-using-a-private-vpc/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec05-bp01.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSEC06.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSEC06.md
@@ -1,0 +1,381 @@
+# MLSEC06
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLSEC06-BP01 Restrict access to intended legitimate consumers
+
+Use least privilege permissions to invoke the deployed model
+endpoint. For consumers who are external to the workload
+environment, provide access using a secure API.
+
+**Desired outcome:** You establish
+secure inference API endpoints that allow only authorized parties to
+access your ML models. You create a controlled environment where
+model access is restricted based on legitimate business needs, while
+maintaining monitoring capabilities to track interactions with your
+models. Your ML endpoints are protected using the same security
+principles applied to other HTTPS APIs, providing data protection in
+transit and proper authentication.
+
+**Common anti-patterns:**
+
+- Allowing public access to model endpoints without proper
+authentication.
+- Using overly permissive IAM roles for model endpoint access.
+- Failing to implement network controls for inference endpoints.
+- Not monitoring or logging model inference activities.
+- Using the same credentials for development and production model
+access.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced risk of unauthorized model access and potential data
+exfiltration.
+- Enhanced control over who can use your ML models and when.
+- Improved monitoring and auditability of model usage.
+- Protection of intellectual property embedded in models.
+- Improves adherence to regulatory requirements for data security.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Securing your ML model endpoints is critical to protect both your
+intellectual property and the data processed by these models. By
+treating ML inference endpoints with the same security rigor as
+other HTTPS APIs, you can maintain a strong security posture while
+enabling legitimate business use. You need to implement proper
+authentication, network controls, and monitoring to verify that
+only authorized parties can access your models.
+
+When deploying machine learning models in production, you should
+consider the model as a valuable asset that requires protection.
+This means implementing layers of security controls including
+network isolation through VPC configuration, strong authentication
+mechanisms, and continuous monitoring of inference activities. For
+external consumers, create a dedicated API layer that enforces
+security policies and controls access.
+
+### Implementation steps
+
+- **Plan your access control
+strategy**. Define which users or applications need
+access to your model endpoints and what specific permissions
+they require. Follow the principle of least privilege,
+granting only the minimum permissions necessary for each
+consumer to perform their required tasks.
+- **Set up secure inference API
+endpoints**. Host your ML models so that consumers
+can perform inference against them securely. Use
+[Amazon SageMaker AI endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-manage.html) with proper authentication and
+authorization controls. Use
+[Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html) to automatically
+benchmark and optimize your model deployments for the best
+security-performance balance, and select optimal compute
+instances and configurations while maintaining security
+controls. This approach defines the relationship between the
+model and its consumers, restricts access to the base model,
+and provides monitoring capabilities for model interactions.
+- **Implement network security
+controls**. Configure your SageMaker AI inference
+endpoints within a VPC to isolate network traffic. Use
+security groups to define inbound and outbound traffic
+rules, and consider using
+[AWS PrivateLink](https://aws.amazon.com/privatelink/) for private connectivity to your
+endpoints. Follow guidance from the
+[AWS Well-Architected Framework](https://aws.amazon.com/architecture/well-architected/) to implement proper
+network controls, such as restricting access to specific IP
+ranges and implementing bot protection.
+- **Configure authentication and
+authorization**. Sign HTTPS requests for API calls
+so that requester identity can be verified. Use
+[AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) to control who has access
+to your SageMaker AI resources and what actions they can
+perform. Consider using
+[Amazon Cognito](https://aws.amazon.com/cognito/) for managing user identities if your API is
+accessed by external users.
+- **Deploy endpoints in a secure VPC
+configuration**. Use
+[VPC
+endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html) to privately connect your VPC to supported
+AWS services without requiring an internet gateway. Follow
+the guidance in
+[Give
+SageMaker AI Hosted Endpoints Access to Resources in Your
+Amazon VPC](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html) to configure your endpoint for VPC access.
+- **Implement encryption for data in
+transit and at rest**. Configure your endpoints to
+use HTTPS for API calls. Encrypt model artifacts and data at
+rest using
+[AWS Key Management Service (KMS)](https://aws.amazon.com/kms/). Use client-side encryption
+for sensitive data when appropriate.
+- **Set up monitoring and
+logging**. Configure
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor your endpoints and
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to log API calls. Implement
+[SageMaker AI
+Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect drift and data quality issues
+in your production models.
+- **Use model registry for
+governance**. Implement
+[SageMaker AI
+MLflow Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to catalog and manage versions
+of your models, control which model versions are deployed,
+and maintain an audit trail of model approvals and
+deployments.
+- **Implement proper API design
+patterns**. Design your inference API following
+REST best practices. Include proper input validation, error
+handling, and rate limiting to protect against abuse.
+Consider implementing an
+[API Gateway](https://aws.amazon.com/api-gateway/) in front of your SageMaker AI endpoint for
+additional controls.
+- **Conduct regular security
+reviews**. Periodically review the security
+configuration of your endpoints, check for over-permissive
+policies, and validate that access logs show only expected
+patterns of usage.
+- **Implement guardrails for AI
+models**. For AI endpoints, implement content
+filtering and validation controls to provide responsible
+outputs, stop harmful content generation, and maintain
+appropriate use of the models.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Real-time
+Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints.html)
+- [Give
+SageMaker AI Hosted Endpoints Access to Resources in Your Amazon VPC](https://docs.aws.amazon.com/sagemaker/latest/dg/host-vpc.html)
+- [Accelerate
+generative AI development using managed MLflow on Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html)
+- [Integrating
+machine learning models into your Java-based
+microservices](https://aws.amazon.com/blogs/awsmarketplace/integrating-machine-learning-models-into-your-java-based-microservices/)
+- [How
+Financial Institutions can use AWS to Address Regulatory
+Reporting](https://aws.amazon.com/blogs/architecture/how-banks-can-use-aws-to-meet-compliance/)
+- [Secure
+deployment of Amazon SageMaker AI resources](https://aws.amazon.com/blogs/security/secure-deployment-of-amazon-sagemaker-resources/)
+- [Accelerating
+Machine Learning Development with Data Science as a Service
+from Change Healthcare](https://aws.amazon.com/blogs/apn/accelerating-machine-learning-development-with-data-science-as-a-service-from-change-healthcare/)
+
+**Related videos:**
+
+- [End-to-End
+machine learning using Spark and Amazon SageMaker AI](https://www.youtube.com/watch?v=FKgivdwzO5g)
+
+**Related examples:**
+
+- [Amazon SageMaker AI secure MLOps](https://github.com/aws-samples/amazon-sagemaker-secure-mlops)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec06-bp01.html*
+
+---
+
+# MLSEC06-BP02 Monitor human interactions with data for anomalous activity
+
+Implement comprehensive monitoring of data access events to detect
+unauthorized or suspicious activities. By auditing user interactions
+with data, you can identify potential security threats such as
+unusual access patterns, abnormal locations, or activity that
+exceeds normal baselines. Use specialized AWS services for anomaly
+detection alongside data classification to assess risks and protect
+your machine learning assets.
+
+**Desired outcome:** You have
+comprehensive visibility into human interactions with your data,
+with logging enabled for create, read, update, and delete
+operations. You can identify who accessed specific data elements,
+what actions they took, and when those actions occurred. Your
+monitoring system automatically flags anomalous activities based on
+established baselines and alerts you to potential security threats.
+Data classification is integrated with your monitoring approach to
+prioritize security events based on data sensitivity.
+
+**Common anti-patterns:**
+
+- Implementing logging without monitoring or analysis
+capabilities.
+- Focusing only on system-level access without tracking specific
+data interactions.
+- Failing to establish user activity baselines for anomaly
+detection.
+- Not classifying data to differentiate between access to
+sensitive and non-sensitive information.
+- Monitoring access events without automated alerting mechanisms.
+
+**Benefits of establishing this best
+practice:**
+
+- Early detection of potential data breaches or insider threats.
+- Improved ability to investigate security incidents with
+comprehensive audit trails.
+- Improves adherence to data protection regulations and
+requirements.
+- Better visibility into how data is being used across your ML
+systems.
+- Reduced risk of unauthorized data access or exfiltration.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Protecting your machine learning data requires visibility into who
+is accessing it and how it's being used. By monitoring human
+interactions with your data, you can identify potential security
+threats before they lead to data breaches or misuse. This involves
+implementing comprehensive logging for data access events,
+classifying your data based on sensitivity, and using automated
+tools to detect anomalous behavior.
+
+Start by enabling logging for data interactions, particularly
+focusing on human access rather than just system-to-system
+communications. Your logs should capture details about who
+accessed the data, what specific elements they accessed, what
+actions they took, and when those interactions occurred. This
+creates an audit trail that serves as the foundation for your
+monitoring strategy.
+
+Next, classify your data based on sensitivity and importance. By
+knowing which datasets contain personally identifiable information
+(PII), intellectual property, or other sensitive information, you
+can prioritize monitoring efforts and apply appropriate security
+controls. This classification details the potential impact of
+unauthorized access to different datasets.
+
+Finally, implement anomaly detection to identify unusual patterns
+that might indicate security threats. These anomalies could
+include access from unusual locations, outside normal working
+hours, excessive access volume, or access to data that's not
+typically needed for an employee's role. When anomalies are
+detected, your system should generate alerts to prompt
+investigation.
+
+### Implementation steps
+
+- **Enable data access
+logging**. Verify that you have data access logging
+for human CRUD (create, read, update, and delete)
+operations, including the details of who accessed what
+elements, what action they took, and at what time. Leverage
+[AWS CloudTrail](https://aws.amazon.com/cloudtrail/) to capture API calls and user activities
+across your AWS environment. Configure CloudTrail to log
+data events for
+[Amazon S3](https://aws.amazon.com/s3/) buckets containing your training and inference
+data. For SageMaker AI environments, use
+[Amazon SageMaker AI Logging and Monitoring](https://docs.aws.amazon.com/sagemaker/latest/dg/logging-cloudwatch.html) capabilities to
+track access to ML models and datasets.
+- **Classify your data**. Use
+[Amazon Macie](https://aws.amazon.com/macie/) for protecting and classifying training and
+inference data in
+[Amazon S3](https://aws.amazon.com/s3/). Amazon Macie is a fully managed security service
+that uses ML to automatically discover, classify, and
+protect sensitive data in AWS. The service recognizes
+sensitive data, such as personally identifiable information
+(PII) or intellectual property. Configure Macie to perform
+regular automated scans of your S3 buckets to identify and
+tag sensitive data. Create custom data identifiers in Macie
+to recognize organization-specific sensitive data patterns
+beyond the standard patterns Macie detects.
+- **Monitor and protect**. Use
+[Amazon GuardDuty](https://aws.amazon.com/guardduty/) to monitor for malicious and unauthorized
+activities. This will enable protecting AWS accounts,
+workloads, and data stored in
+[Amazon S3](https://aws.amazon.com/s3/). Configure GuardDuty to analyze CloudTrail logs,
+VPC flow logs, and DNS logs to detect suspicious activities.
+Pay special attention to the
+[GuardDuty
+S3 Finding Types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-s3.html) which can detect anomalous access
+patterns to your S3-stored data.
+- **Set up anomaly detection**.
+Implement automated anomaly detection for data access
+patterns using
+[Amazon CloudWatch Anomaly Detection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html). Create CloudWatch
+metrics for access frequency, data volume transferred,
+access times, and other relevant metrics. Configure
+CloudWatch alarms to alert when anomalies are detected based
+on these metrics.
+- **Establish data access
+baselines**. Create baseline profiles of normal
+user access patterns using
+[AWS CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor access trends over time. Set up
+dashboards that visualize normal patterns of data access by
+team, role, or time period. Use these baselines to fine-tune
+anomaly detection thresholds and reduce false positives.
+- **Implement alerting
+mechanisms**. Configure
+[Amazon EventBridge](https://aws.amazon.com/eventbridge/) to trigger automated responses when
+suspicious access events are detected. Route alerts to your
+security team through notification channels like
+[Amazon SNS](https://aws.amazon.com/sns/) for immediate response. Create different alerting
+thresholds based on data classification and sensitivity.
+- **Centralize logging and
+monitoring**. Use
+[Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) (formerly Amazon OpenSearch Service) to create a centralized repository for log analysis
+and visualization. Build comprehensive dashboards to monitor
+data access patterns across your organization. Implement log
+retention policies that comply with your regulatory
+requirements.
+- **Control and audit data exploration
+activities**. Implement
+[AWS Lake Formation](https://aws.amazon.com/lake-formation/) with
+[Amazon SageMaker AI Studio](https://aws.amazon.com/sagemaker/studio/) to provide fine-grained access
+controls for data exploration. Configure Lake Formation
+permissions to restrict data access based on user roles and
+data classification. Use
+[AWS IAM](https://aws.amazon.com/iam/) to enforce least-privilege access to sensitive
+data.
+- **Monitor access to AI training
+data**. Implement specialized monitoring for
+datasets used to train AI models, as these may contain
+particularly sensitive information or be subject to greater
+privacy concerns. Use
+[Amazon SageMaker AI Model Monitor](https://aws.amazon.com/sagemaker/model-monitor/) to detect drift in model
+behavior that might indicate data access issues. Implement
+enterprise-ready security and privacy controls for
+foundation models.
+
+## Resources
+
+**Related documents:**
+
+- [CloudWatch Logs for Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/logging-cloudwatch.html)
+- [GuardDuty
+S3 Protection finding types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-s3.html)
+- [AWS CloudTrail Documentation](https://docs.aws.amazon.com/cloudtrail/)
+- [Configure
+security in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/security.html)
+- [Building
+a Self-Service, Secure, & Continually Compliant
+Environment on AWS](https://aws.amazon.com/blogs/architecture/building-a-self-service-secure-continually-compliant-environment-on-aws/)
+- [How
+to Use New Advanced Security Features for Amazon Cognito user pools](https://aws.amazon.com/blogs/security/how-to-use-new-advanced-security-features-for-amazon-cognito-user-pools/)
+- [Best
+practices for setting up Amazon Macie with AWS Organizations](https://aws.amazon.com/blogs/security/best-practices-for-setting-up-amazon-macie-with-aws-organizations/)
+
+**Related videos:**
+
+- [Protect
+Your Data in S3 with Amazon Macie and Amazon GuardDuty - AWS
+Online Tech Talks](https://www.youtube.com/watch?v=lvPT71jAIXk)
+- [Protecting
+sensitive data with Amazon Macie and Amazon GuardDuty](https://www.youtube.com/watch?v=h7pq95RMuEQ)
+
+**Related examples:**
+
+- [AWS Security Hub CSPM automated response and remediation](https://github.com/aws-solutions/aws-security-hub-automated-response-and-remediation)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsec06-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSUS01.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSUS01.md
@@ -1,0 +1,154 @@
+# MLSUS01
+
+**Pillar**: Unknown  
+**Best Practices**: 1
+
+---
+
+# MLSUS01-BP01 Define the overall environmental impact or benefit
+
+Measure your workload's impact and its contribution to the overall
+sustainability goals of the organization. Understand the
+environmental footprint of machine learning systems to make informed
+decisions about resource allocation and optimization.
+
+**Desired outcome:** You gain a clear
+understanding of how your ML workload impacts your organization's
+sustainability objectives, including energy consumption, carbon
+emissions, and resource utilization. You have established specific
+sustainability objectives and success criteria to measure against,
+which assists you when optimizing your ML workloads and
+demonstrating their environmental value proposition in relation to
+their impact.
+
+**Common anti-patterns:**
+
+- Focusing solely on model accuracy without considering
+environmental trade-offs.
+- Implementing ML systems without measuring their carbon
+footprint.
+- Overprovisioning resources for ML workloads.
+- Unnecessarily retraining models when not required.
+
+**Benefits of establishing this best
+practice:**
+
+- Improved alignment between ML initiatives and organizational
+sustainability goals.
+- Enhanced ability to meet regulatory and reporting requirements.
+- Transparent assessment of the sustainability impact of ML
+projects.
+- Identification of opportunities to optimize ML systems for lower
+environmental impact.
+
+**Level of risk exposed if this best practice
+is not established:** High
+
+## Implementation guidance
+
+Understanding the environmental impact of your ML workloads is
+essential for sustainable AI development. ML operations can be
+resource-intensive, requiring substantial computing power for
+training and inference, which translates to energy consumption and
+carbon emissions. By measuring and tracking this impact, you can
+make informed decisions about architecture choices, region
+selection, and optimization strategies.
+
+The cloud provides significant advantages for sustainable ML
+development through its economies of scale and renewable energy
+investments. By leveraging AWS's efficiency, you can reduce your
+carbon footprint compared to on-premises alternatives. However,
+you still need to make conscious decisions about how you design,
+deploy, and operate your ML workloads.
+
+Consider the full lifecycle of your ML system, from data
+collection and processing to model training, deployment, and
+ongoing operations. Each stage has different resource requirements
+and environmental impacts. For example, training large models is
+typically more computationally intensive than inference, but if
+your model serves millions of predictions daily, the inference
+stage might have a larger cumulative impact over time.
+
+### Implementation steps
+
+- **Establish sustainability objectives
+for ML workloads**. Begin by defining specific
+sustainability goals for your ML projects that align with
+your organization's broader environmental commitments.
+Determine what metrics you'll track (for example, carbon
+emissions per training run or energy efficiency per
+inference) and set concrete targets for improvement.
+- **Assess the environmental impact of
+data processing**. Evaluate how much data you're
+storing and processing for your ML workloads. Consider
+implementing data lifecycle management using
+[Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) policies to automatically transition
+infrequently accessed data to more efficient storage classes
+or archive data that's no longer needed for active training.
+- **Measure the impact of model
+training**. Calculate the computational resources
+and associated carbon emissions of your model training
+processes using tools like the
+[AWS Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/). Consider factors such
+as instance types, training duration, and region selection.
+Track these metrics over time to identify trends and
+opportunities for improvement.
+- **Optimize model training frequency
+and approach**. Determine how often retraining is
+truly necessary based on model drift monitoring. Implement
+incremental training where possible using
+[Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) to update existing models with new data
+rather than retraining from scratch. Use techniques like
+transfer learning to leverage pre-trained models and reduce
+computational requirements.
+- **Assess inference
+efficiency**. Evaluate the environmental impact of
+your deployed models in production. Consider techniques like
+model compression, quantization, and distillation to reduce
+the computational requirements of inference while
+maintaining acceptable accuracy. Use
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize models for
+specific deployment targets.
+- **Calculate the net sustainability
+value**. Compare the environmental impact of your
+ML workload with its benefits, including the sustainability
+improvements it enables. For example, if your ML system
+optimizes energy usage in manufacturing processes, calculate
+the net reduction in emissions to demonstrate its overall
+positive impact.
+- **Implement ongoing monitoring and
+reporting**. Establish a regular cadence for
+reviewing sustainability metrics and reporting on progress
+toward your goals. Use
+[AWS CloudWatch](https://aws.amazon.com/cloudwatch/) to monitor resource utilization and create
+dashboards to track your sustainability KPIs over time.
+- **For GenAI workloads, consider your
+model customization strategy**. When implementing
+generative AI solutions, evaluate whether fine-tuning
+existing foundation models like
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) models is more environmentally efficient than
+training custom models from scratch. Consider prompt
+engineering and retrieval-augmented generation (RAG)
+approaches that can achieve business goals with lower
+computational intensity than full model training.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/)
+- [AWS Sustainability Data Initiative](https://sustainability.aboutamazon.com/about/the-climate-pledge)
+- [AWS Well-Architected Framework: Sustainability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html)
+- [Corporate
+Climate Action - Science Based Targets initiative
+(SBTi)](https://sciencebasedtargets.org/)
+- [Greenhouse Gas
+Protocol](https://ghgprotocol.org/)
+- [Optimize
+AI/ML workloads for sustainability: Part 1, identify business
+goals, validate ML use, and process data](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-1-identify-business-goals-validate-ml-use-and-process-data/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus01-bp01.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSUS02.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSUS02.md
@@ -1,0 +1,278 @@
+# MLSUS02
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLSUS02-BP01 Consider AI services and pre-trained models
+
+Using AI services and pre-trained models can significantly reduce
+the resources needed for machine learning workloads, enabling you to
+quickly implement AI capabilities without developing custom models
+from scratch.
+
+**Desired outcome:** You identify
+opportunities to use managed AI services or pre-trained models
+instead of building custom models, reducing the environmental impact
+of training and deploying ML solutions while accelerating time to
+market. By using existing capabilities through APIs or fine-tuning
+pre-trained models, you minimize computational resources required
+for data preparation, model training, and deployment.
+
+**Common anti-patterns:**
+
+- Building custom models from scratch when suitable managed
+services already exist.
+- Collecting and processing large datasets unnecessarily when
+pre-trained models could be utilized.
+- Ignoring transfer learning opportunities that could reduce
+training time and computational resources.
+- Overlooking model optimization techniques that could reduce
+inference resource requirements.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced environmental impact through decreased computational
+resource usage.
+- Lower operational costs for ML development and deployment.
+- Faster time-to-market for ML-powered solutions.
+- Access to state-of-the-art models without specialized ML
+expertise.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When developing machine learning solutions, evaluate whether you
+truly need to build a custom model or if existing services and
+pre-trained models can meet your requirements. Many common use
+cases like image recognition, natural language processing, or
+recommendation systems can use pre-built capabilities available
+through APIs. These managed services handle the underlying
+infrastructure, data processing, and model maintenance, reducing
+both environmental impact and operational overhead.
+
+If fully managed services don't meet your specific requirements,
+consider starting with pre-trained models that you can fine-tune
+with your data. This approach, known as transfer learning, allows
+you to benefit from models that have already undergone
+resource-intensive training on large datasets. By fine-tuning, you
+can achieve similar or better performance than training from
+scratch while using significantly fewer computational resources.
+
+For example, instead of training a computer vision model from
+scratch, you could use a pre-trained image recognition model from
+Amazon Rekognition or fine-tune a model available through
+SageMaker AI JumpStart with your specific images. This approach
+reduces the carbon footprint associated with extensive model
+training while delivering high-quality results.
+
+### Implementation steps
+
+- **Assess your ML use case
+requirements**. Before developing an ML solution,
+clearly define your requirements and success criteria.
+Understand the specific problem you're trying to solve, the
+data you have available, and the performance metrics that
+matter for your application.
+- **Explore AWS AI services**.
+[AWS AI services](https://aws.amazon.com/machine-learning/ai-services/) provide ready-to-use capabilities through
+APIs for common ML tasks. These services include
+[Amazon Rekognition](https://aws.amazon.com/rekognition/) for image and video analysis,
+[Amazon Comprehend](https://aws.amazon.com/comprehend/) for natural language processing,
+[Amazon
+Forecast](https://aws.amazon.com/forecast/) for time-series forecasting, and
+[Amazon Personalize](https://aws.amazon.com/personalize/) for personalization and recommendations.
+- **Evaluate foundation models in Amazon
+Bedrock**.
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) provides serverless access to leading
+foundation models from AI companies like Anthropic, Cohere,
+AI21 Labs, and Amazon's own Nova models through a single
+API. These models can handle tasks like text generation,
+summarization, chatbots, and content creation without
+requiring model training.
+- **Explore pre-trained models from AWS Marketplace**.
+[AWS Marketplace](https://aws.amazon.com/marketplace/b/c3714653-8485-4e34-b35b-82c2203e81c1) offers over 1,400 ML-related assets that
+you can subscribe to, including pre-trained models for
+various industry-specific use cases that can be deployed
+with minimal configuration.
+- **Leverage SageMaker AI
+JumpStart**.
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) provides pre-trained, open-source models
+for a wide range of problem types to get started with
+machine learning. You can incrementally train and fine-tune
+these models before deployment, reducing the computational
+resources needed compared to training from scratch.
+- **Consider Hugging Face
+models**.
+[Hugging
+Face with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/hugging-face.html) enables you to use
+thousands of pre-trained transformer models for NLP,
+computer vision, and audio tasks. These models can be
+fine-tuned with your specific data to achieve high-quality
+results with minimal training.
+- **Implement efficient fine-tuning
+techniques**. When customizing pre-trained models,
+use efficient fine-tuning methods like parameter-efficient
+fine-tuning (PEFT), low-rank adaptation (LoRA), or
+quantization to minimize computational resources while
+maintaining performance.
+- **Monitor resource usage and
+optimize**. After deploying your solution,
+continuously monitor its resource consumption and
+performance. Look for opportunities to optimize through
+model compression, quantization, or pruning to further
+reduce computational requirements.
+- **Leverage expanded pre-trained model
+libraries**. Use the expanded
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) catalog which now includes broader
+selection of pre-trained models and industry-specific
+solutions, reducing the need for custom model development
+and associated computational resources.
+- **For generative AI workloads,
+implement retrieval-augmented generation (RAG)**.
+For generative AI applications requiring domain-specific
+knowledge, consider using
+[retrieval-augmented
+generation](https://aws.amazon.com/what-is/retrieval-augmented-generation/) with SageMaker AI JumpStart foundation models
+instead of fine-tuning large models, which can significantly
+reduce computational resources while improving accuracy.
+
+## Resources
+
+**Related documents:**
+
+- [AWS AI Services](https://aws.amazon.com/machine-learning/ai-services/)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Choose
+the best data source for your Amazon SageMaker AI training
+job](https://aws.amazon.com/blogs/machine-learning/choose-the-best-data-source-for-your-amazon-sagemaker-training-job/)
+- [Pre-trained
+machine learning models available in AWS Marketplace](https://aws.amazon.com/marketplace/solutions/machine-learning/pre-trained-models)
+- [Resources
+for using Hugging Face with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/hugging-face.html)
+- [Optimize
+AI/ML workloads for sustainability: Part 2, model
+development](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-2-model-development/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus02-bp01.html*
+
+---
+
+# MLSUS02-BP02 Select sustainable Regions
+
+Choose the Regions where you implement your workloads based on both
+your business requirements and sustainability goals.
+
+**Desired outcome:** You select AWS Regions that align with your organizational sustainability
+objectives while meeting your business requirements. By choosing
+Regions with renewable energy sources and lower carbon intensity,
+you reduce the environmental impact of your machine learning
+workloads while maintaining optimal performance for your business
+needs.
+
+**Common anti-patterns:**
+
+- Selecting Regions based solely on proximity without considering
+environmental impact.
+- Ignoring renewable energy availability when deploying machine
+learning workloads.
+- Deploying workloads across multiple Regions without considering
+their carbon footprints.
+
+**Benefits of establishing this best
+practice:**
+
+- Alignment with organizational sustainability goals and ESG
+initiatives.
+- Enhanced reputation as an environmentally responsible
+organization.
+- Potential cost savings through efficient Region selection.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When deploying your machine learning workloads, Region selection
+plays a crucial role in meeting both your operational requirements
+and sustainability goals. While factors such as latency, data
+residency, and service availability remain important,
+incorporating sustainability considerations into your Region
+selection process can minimize your environmental impact. AWS is
+continuously expanding its renewable energy projects globally,
+making it increasingly possible to host your workloads in Regions
+powered by sustainable energy sources.
+
+The cloud offers significant sustainability advantages compared to
+on-premises deployments due to higher utilization rates, more
+energy-efficient infrastructure, and AWS' commitment to renewable
+energy. By selecting Regions thoughtfully, you can further enhance
+these sustainability benefits while still meeting your business
+needs.
+
+### Implementation steps
+
+- **Understand your business
+requirements first**. Identify the non-negotiable
+requirements for your workload, including data sovereignty
+regulations, compliance-aligned needs, latency requirements,
+and service availability in specific Regions. Create a
+shortlist of Regions that meet these baseline requirements.
+- **Research AWS renewable energy
+projects**. Use the
+[Amazon
+Around the Globe](https://sustainability.aboutamazon.com/about/around-the-globe?energyType=true) resource to identify Regions that
+are near Amazon renewable energy projects. AWS achieved
+powering its operations with
+[100%
+renewable energy](https://www.aboutamazon.com/news/sustainability/amazon-renewable-energy-goal) in 2023, seven years ahead of their
+original 2030 commitment.
+- **Consider the grid's carbon
+intensity**. Look for Regions where the electrical
+grid has lower published carbon intensity. This information
+may be available through regional utility reports or
+sustainability documentation. Lower carbon intensity means
+reduced emissions even for non-renewable energy sources.
+- **Evaluate the trade-offs**.
+When selecting Regions, consider potential trade-offs
+between sustainability goals and business requirements such
+as latency or availability. In some cases, minor performance
+trade-offs may be acceptable to achieve significant
+sustainability improvements.
+- **Monitor sustainability
+metrics**. After deployment, track relevant
+sustainability metrics to verify that your Region selection
+is delivering the expected environmental benefits. Consider
+implementing dashboards with key performance indicators
+(KPIs) for sustainability tracking.
+- **Review and adjust
+periodically**. As AWS adds more renewable energy
+projects and as your business requirements evolve,
+periodically reassess your Region selections to continually
+align with your sustainability goals.
+
+## Resources
+
+**Related documents:**
+
+- [AWS Global Infrastructure](https://aws.amazon.com/about-aws/global-infrastructure/)
+- [Delivering
+on net-zero carbon by 2040](https://sustainability.aboutamazon.com/about/around-the-globe)
+- [Climate
+solutions](https://sustainability.aboutamazon.com/about/the-climate-pledge)
+- [AWS Well-Architected Framework - Sustainability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html)
+- [How
+to select a Region for your workload based on sustainability
+goals](https://aws.amazon.com/blogs/architecture/how-to-select-a-region-for-your-workload-based-on-sustainability-goals/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus02-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSUS03.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSUS03.md
@@ -1,0 +1,403 @@
+# MLSUS03
+
+**Pillar**: Unknown  
+**Best Practices**: 3
+
+---
+
+# MLSUS03-BP01 Minimize idle resources
+
+Minimize your environmental impact by efficiently managing compute
+resources in your ML data pipeline. Use serverless architectures
+that provision resources only when needed, reducing energy
+consumption and carbon footprint.
+
+**Desired outcome:** You implement a
+serverless, event-driven architecture for your ML data pipelines
+that only provisions resources when work needs to be done. This
+approach reduces idle resources, optimizes utilization of computing
+infrastructure, and reduces your organization's environmental impact
+while maintaining performance and scalability.
+
+**Common anti-patterns:**
+
+- Provisioning compute instances that run 24/7 regardless of
+workload requirements.
+- Overprovisioning resources rather than scaling dynamically.
+- Using traditional batch processing with fixed schedules instead
+of event-driven approaches.
+- Failing to monitor and optimize resource utilization metrics.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower carbon footprint and energy consumption.
+- Improved resource efficiency across your ML pipeline.
+- Automatic scaling to match workload demands.
+- Simplified maintenance with managed services.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Adopting a serverless architecture for your ML data pipelines
+significantly reduces idle resources by allocating compute power
+only when needed. This approach uses AWS managed services that
+automatically scale based on workload, avoiding the need to
+maintain an always-on infrastructure. When you design your data
+pipeline using serverless technologies like AWS Glue and AWS Step Functions, you not only optimize resource utilization but also
+distribute the sustainability impact across the tenants of those
+services, reducing your individual environmental contribution.
+
+The key principle is to transition from a static infrastructure
+model to an event-driven approach where resources are provisioned
+in response to triggers. This verifies that compute resources are
+only active during actual processing tasks rather than sitting
+idle waiting for work. AWS managed services handle the underlying
+infrastructure optimization, allowing you to focus on your ML
+workloads while maintaining efficiency.
+
+### Implementation steps
+
+- **Evaluate your current
+infrastructure**. Assess your existing data
+pipeline architecture to identify components that run
+continuously but have low utilization. Look for workloads
+with predictable patterns or batch processes that could
+benefit from an event-driven approach using
+[AWS CloudWatch metrics](https://aws.amazon.com/cloudwatch/) to identify utilization patterns.
+- **Adopt managed services**.
+Replace self-managed infrastructure with AWS managed
+services to distribute sustainability impact across service
+tenants. Services like
+[AWS Glue](https://aws.amazon.com/glue/),
+[AWS Lambda](https://aws.amazon.com/lambda/), and
+[Amazon EMR Serverless](https://aws.amazon.com/emr/serverless/) provision resources on-demand and
+automatically scale with your workloads.
+- **Create serverless, event-driven data
+pipelines**. Use
+[AWS Glue](https://aws.amazon.com/glue/) for data processing and
+[AWS Step Functions](https://aws.amazon.com/step-functions/) for orchestration to build ETL and ELT
+pipelines that only consume resources when triggered. Step
+Functions can coordinate AWS Glue jobs efficiently,
+provisioning compute resources only when needed and
+releasing them immediately after completion.
+- **Implement efficient data
+storage**. Choose appropriate storage solutions
+like [Amazon S3](https://aws.amazon.com/s3/) for your data lake and
+[Amazon S3 Intelligent-Tiering](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/) to automatically move data
+between access tiers based on usage patterns, reducing
+storage costs and resource waste.
+- **Configure event-based
+triggers**. Set up event notifications through
+[Amazon EventBridge](https://aws.amazon.com/eventbridge/) to automatically launch processing jobs
+when new data arrives. This avoids the need for scheduled
+jobs that might run when no new data is available, reducing
+unnecessary compute usage.
+- **Optimize compute
+resources**. For AWS Glue jobs, configure
+appropriate worker types and dynamically allocate resources
+based on workload requirements. Use features like
+[AWS Glue Auto Scaling](https://docs.aws.amazon.com/glue/latest/dg/auto-scaling.html) to automatically adjust capacity as
+needed during jobs.
+- **Implement monitoring and
+metrics**. Set up comprehensive monitoring of your
+serverless infrastructure using
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track resource utilization, job
+execution time, and idle periods. Use these metrics to
+identify further optimization opportunities.
+- **Establish automatic cleanup
+processes**. Implement automated processes to
+remove temporary resources, intermediate data, and other
+artifacts after job completion to avoid unnecessary storage
+costs and reduce digital waste.
+- **Optimize data transfer**.
+Minimize data movement between services by processing data
+close to where it's stored when possible. Use
+[AWS Glue DataBrew](https://aws.amazon.com/glue/features/databrew/) for data preparation tasks within the
+same environment as your data storage.
+- **Use AI-powered
+optimization**. Use Amazon Q data integration in
+AWS Glue to automatically generate optimized ETL jobs for
+common data sources. This reduces development time while
+implementing efficient resource utilization patterns from
+the start.
+
+## Resources
+
+**Related documents:**
+
+- [What
+is AWS Lambda?](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html)
+- [What
+is Amazon EMR Serverless?](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/emr-serverless.html)
+- [Using
+auto scaling for AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/auto-scaling.html)
+- [What
+is Amazon EventBridge?](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html)
+- [Start
+an AWS Glue job with Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-glue.html)
+- [Serverless
+Applications Lens - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/welcome.html)
+- [Optimize
+AI/ML workloads for sustainability: Part 3, deployment and
+monitoring](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-3-deployment-and-monitoring/)
+- [Fuel
+your data with Generative AI](https://aws.amazon.com/blogs/enterprise-strategy/fuel-your-data-with-generative-ai/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus03-bp01.html*
+
+---
+
+# MLSUS03-BP02 Implement data lifecycle policies aligned with your sustainability goals
+
+Classify your data to identify its business relevance and implement
+efficient storage strategies that support your sustainability goals.
+By understanding your data's importance, you can appropriately tier
+storage, implement retention policies, and manage the entire
+lifecycle to reduce your environmental footprint while meeting
+business requirements.
+
+**Desired outcome:** You have a
+comprehensive data management strategy that classifies data based on
+business importance and implements automatic storage optimization.
+Your workloads store data in the most energy-efficient storage tiers
+possible, and data that no longer serves a business purpose is
+automatically purged, resulting in minimal storage footprint and
+reduced environmental impact.
+
+**Common anti-patterns:**
+
+- Storing data indefinitely without classification or lifecycle
+policies.
+- Using a single storage tier for data regardless of access
+patterns.
+- Manually managing data retention and deletion.
+- Keeping redundant or obsolete data that no longer serves
+business purposes.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced storage infrastructure and energy consumption.
+- Improved data governance and adherence.
+- Enhanced system performance with streamlined data management.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Implementing data lifecycle policies begins with understanding the
+relationship between your data and business outcomes. Each
+category of data has different requirements for retention, access
+patterns, and eventual disposal. By aligning these requirements
+with sustainability goals, you can optimize storage utilization
+while improving business continuity.
+
+Start by creating a data classification framework that categorizes
+data based on its criticality, frequency of access, and business
+value over time. This classification will guide your decisions
+about which storage tiers to use and when data should be moved or
+deleted. For instance, frequently accessed operational data might
+remain in high-performance storage, while rarely accessed archival
+data can be moved to more energy-efficient cold storage options.
+
+Once you've classified your data, use AWS storage features like S3
+Lifecycle policies to automate data transitions between storage
+tiers and eventual deletion. For example, you can configure
+policies that automatically transition data from S3 Standard to S3
+Intelligent-Tiering, S3 Standard-IA, S3 One Zone-IA, and
+eventually to Amazon Glacier or S3 Glacier Deep Archive based on
+access patterns and age.
+
+### Implementation steps
+
+- **Define your data classification
+framework.** Develop a comprehensive data
+classification system that categorizes data based on
+business importance, access frequency, and regulatory
+requirements. Include clear definitions for each data
+category and establish ownership for classification
+decisions.
+- **Map retention requirements to data
+classes.** For each data classification, determine
+appropriate retention periods that satisfy business needs,
+regulatory requirements, and sustainability goals. Document
+these requirements to guide policy implementation.
+- **Analyze current storage usage
+patterns.** Use
+[Amazon S3 Storage Lens](https://aws.amazon.com/s3/storage-analytics-insights/) to gain visibility into your current
+storage usage patterns, identifying opportunities for
+optimization and tracking progress on storage efficiency
+metrics.
+- **Implement S3 Lifecycle
+policies.** Configure
+[Amazon S3 Lifecycle policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) to automatically transition
+data between storage classes and enforce deletion timelines
+based on your defined retention requirements.
+- **Deploy intelligent storage
+tiering.** Implement
+[Amazon S3 Intelligent-Tiering storage class](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/) to automatically
+move data between access tiers based on changing access
+patterns, optimizing for both cost and sustainability.
+- **Establish monitoring and
+reporting.** Create dashboards to track storage
+optimization metrics, including total storage used, storage
+class distribution, and lifecycle transition metrics.
+Regularly review these metrics to identify further
+optimization opportunities.
+- **Continuously refine data
+classification.** Review and update your data
+classification framework regularly to align it with evolving
+business needs and sustainability goals.
+
+## Resources
+
+**Related documents:**
+
+- [Managing
+the lifecycle of objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+- [Managing
+storage costs with Amazon S3 Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)
+- [Comparing
+the Amazon S3 storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html#sc-compare)
+- [Assessing
+your storage activity and usage with Amazon S3 Storage
+Lens](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens.html)
+- [Setting
+an S3 Lifecycle configuration on a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html)
+- [Data
+discovery and cataloging in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus03-bp02.html*
+
+---
+
+# MLSUS03-BP03 Adopt sustainable storage options
+
+Reduce the volume of data to be stored and adopt sustainable storage
+options to limit the carbon impact of your workload. For artifacts
+like models and log files that must be kept for long-term regulatory
+and audit requirements, use efficient compression algorithms and use
+energy efficient cold storage.
+
+**Desired outcome:** You optimize
+your ML workload storage to minimize environmental impact while
+improving adherence to regulatory requirements. By implementing
+efficient storage practices, you reduce data redundancy, properly
+size resources, use energy-efficient storage options, and implement
+effective compression techniques. This results in reduced carbon
+footprint, lower storage costs, and improved overall sustainability
+of your ML systems.
+
+**Common anti-patterns:**
+
+- Storing redundant copies of datasets across multiple locations.
+- Over-provisioning storage resources for notebooks and instances.
+- Using inefficient file formats like CSV instead of columnar
+formats such as parquet.
+- Keeping data in high-performance storage regardless of access
+frequency.
+
+**Benefits of establishing this best
+practice:**
+
+- Lower operational costs through efficient resource utilization.
+- Improved data access performance through appropriate format
+selection.
+- Improved ability to adhere to regulatory requirements through
+proper long-term storage planning.
+- Reduced waste through optimization of storage resources.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Storage is a critical component of ML workloads, with large
+datasets and model artifacts requiring significant resources. By
+optimizing how you store, compress, and manage this data, you can
+substantially reduce the environmental impact of your ML systems.
+Consider the entire lifecycle of your data, from initial
+collection through processing to long-term retention. For
+frequently accessed data, choose efficient formats and compression
+algorithms. For infrequently accessed data, use Amazon S3 storage
+tiers that minimize energy consumption while improving your
+adherence to regulatory requirements. By right-sizing your storage
+resources and removing redundant data, you can achieve both
+sustainability goals and cost optimization.
+
+### Implementation steps
+
+- **Reduce redundancy of processed
+data**. If you can re-create an infrequently
+accessed dataset, use the
+[Amazon S3 One Zone-IA](https://aws.amazon.com/s3/storage-classes/#__) class to minimize the total data
+stored. Implement S3 Lifecycle policies to automatically
+transition objects to more energy-efficient storage tiers
+based on access patterns.
+- **Right size block storage for
+notebooks**. Don't over-provision block storage of
+your notebooks and use centralized object storage services
+like [Amazon S3](https://aws.amazon.com/s3/) for common datasets to avoid data duplication.
+Monitor usage patterns and adjust storage allocations
+accordingly.
+- **Use efficient file
+formats**. Use
+[Parquet](https://parquet.apache.org/)
+to train your models. Compared to CSV, they can reduce
+[your
+storage by up to 87%](https://docs.aws.amazon.com/whitepapers/latest/building-data-lakes/monitoring-optimizing-data-lake-environment.html#data-lake-optimization2). These columnar formats not only
+reduce storage requirements but also improve query
+performance.
+- **Migrate to more efficient
+compression algorithms**. Evaluate different
+compression algorithms and select the most efficient for
+your data. For example,
+[Zstandard](https://github.com/facebook/zstd)
+produces 10–15% smaller files than
+[Gzip](https://www.gzip.org/) at the
+same compression speed.
+- **Implement storage lifecycle
+management**. Configure
+[S3
+Intelligent-Tiering](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/) to automatically move data
+between access tiers based on changing usage patterns. For
+long-term archival needs, use
+[S3 Glacier Deep Archive](https://aws.amazon.com/s3/storage-classes/glacier/) to minimize energy consumption
+for rarely accessed data.
+- **Monitor and optimize storage
+utilization**. Regularly review and clean up
+unnecessary data and snapshots. Use
+[Amazon S3 Storage Lens](https://aws.amazon.com/s3/storage-analytics-insights/) to gain visibility into usage
+patterns and identify optimization opportunities across your
+organization.
+- **Centralize and share
+datasets**. Implement a centralized data catalog
+using
+[AWSAWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html) to make datasets discoverable and
+reusable, reducing the need for multiple copies of the same
+data.
+- **For generative AI workloads, use AI
+for intelligent data management**. Implement
+embeddings storage with efficient vector databases like
+[Amazon OpenSearch Service](https://aws.amazon.com/opensearch-service/) to optimize storage of large language
+model context.
+
+## Resources
+
+**Related documents:**
+
+- [Understanding
+and managing Amazon S3 storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html)
+- [Managing
+storage costs with Amazon S3 Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)
+- [Amazon S3 Storage Analytics and Insights](https://aws.amazon.com/s3/storage-analytics-insights/)
+- [AWS Well-Architected Framework: Performance Efficiency Pillar -
+Data Management](https://docs.aws.amazon.com/wellarchitected/latest/performance-efficiency-pillar/data-management.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus03-bp03.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSUS04.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSUS04.md
@@ -1,0 +1,658 @@
+# MLSUS04
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLSUS04-BP01 Define sustainable performance criteria
+
+Creating machine learning models that balance accuracy with
+environmental impact is essential for sustainable AI development.
+When we focus exclusively on model accuracy, we overlook the
+economic, environmental, and social costs of achieving marginal
+performance improvements. Since the relationship between model
+accuracy and complexity is logarithmic at best, continuing to train
+a model longer or searching extensively for better hyperparameters
+often yields only minimal gains while significantly increasing
+resource consumption.
+
+**Desired outcome:** You establish
+balanced performance criteria for your ML models that satisfy your
+business requirements without excessive resource usage. You
+implement mechanisms to optimize training efficiency, reducing
+carbon footprint and costs while maintaining appropriate model
+performance. Your machine learning lifecycle incorporates
+sustainability as a core consideration alongside traditional metrics
+like accuracy.
+
+**Common anti-patterns:**
+
+- Pursuing maximum model accuracy without considering
+environmental impact.
+- Using oversized models when smaller models would be sufficient.
+- Allowing training jobs to run indefinitely with minimal
+performance improvements.
+- Ignoring resource utilization metrics during model development.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced energy consumption and carbon footprint from ML
+operations.
+- Lower computational costs for model training and deployment.
+- Faster development cycles with earlier training completion.
+- Better alignment between business requirements and model
+capabilities.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When developing machine learning models, balancing accuracy with
+sustainability requires deliberate consideration of how much
+performance is actually needed. The incremental gains in accuracy
+often diminish significantly beyond certain thresholds, while
+computational costs continue to rise. By defining sustainable
+performance criteria upfront, you create guardrails that reduce
+unnecessary environmental impact.
+
+These criteria should reflect your specific business needs rather
+than abstract notions of best possible performance. For many
+applications, a model that is 95% accurate may provide the same
+business value as one that is 96% accurate but requires twice the
+computational resources to train. Understand this relationship to
+make informed trade-offs.
+
+Early stopping mechanisms represent one practical implementation
+of sustainable criteria. These techniques automatically terminate
+training when improvement plateaus, avoiding wasted computation.
+Tools like SageMaker AI Debugger and Automatic Model Tuning
+provide built-in capabilities to implement early stopping without
+compromising model quality.
+
+Regularly measuring and monitoring resource utilization can
+identify opportunities for optimization. Tracking metrics like CPU
+and GPU utilization, memory consumption, and training duration
+provides visibility into your model development's environmental
+impact and can identify inefficiencies.
+
+### Implementation steps
+
+- **Establish sustainable performance
+criteria**. Define concrete performance thresholds
+that meet your business requirements without excessive
+resource consumption. Consider both the absolute performance
+levels needed and the point at which additional gains become
+negligible. Include both accuracy and efficiency metrics in
+your criteria, such as inference latency, model size, and
+training resource requirements.
+- **Analyze the accuracy-resource
+tradeoff**. Conduct experiments to understand the
+relationship between model performance and resource
+consumption for your specific use case. Plot accuracy
+against training time, model size, or computational
+resources to identify the point of diminishing returns. Use
+this data to set reasonable stopping criteria for your
+training jobs.
+- **Configure early stopping in training
+jobs**. Set up SageMaker AI Automatic Model Tuning
+with early stopping to terminate training jobs that are not
+showing significant improvement. Navigate to the SageMaker AI
+console, create a hyperparameter tuning job, and enable the
+early stopping option. Alternatively, configure early
+stopping programmatically using the SageMaker AI Python SDK by
+setting the early_stopping_type parameter
+to **Auto**.
+- **Implement debugging
+rules**. Use SageMaker AI Debugger to automatically
+stop training when specific conditions are met. Add rules
+like LossNotDecreasing to your training
+script to detect when your model stops improving. For
+example, configure the rule to stop training if the loss
+doesn't decrease by at least 0.01% over the last ten epochs.
+- **Monitor resource
+utilization**. Track the efficiency of your
+training jobs using CloudWatch metrics or SageMaker AI
+Debugger's Profiling Report. Monitor metrics such as
+CPUUtilization,
+GPUUtilization,
+GPUMemoryUtilization,
+MemoryUtilization, and
+DiskUtilization. Identify patterns of
+resource underutilization that might indicate opportunities
+for right-sizing your infrastructure.
+- **Right-size your training
+infrastructure**. Based on utilization metrics,
+adjust the instance types and counts for your training jobs.
+Select the most efficient instance type that meets your
+performance requirements rather than defaulting to the most
+powerful option. For distributed training jobs, verify that
+you're using an appropriate number of instances to maximize
+utilization.
+- **Validate against business
+requirements**. Before finalizing your model,
+verify that it meets the business requirements while
+adhering to your sustainable performance criteria. Document
+the tradeoffs made and the rationale behind them to provide
+transparency to stakeholders.
+- **Use no-code ML for rapid
+prototyping**. Use
+[SageMaker AI
+Canvas](https://aws.amazon.com/sagemaker/canvas/) with natural language support for data
+exploration and model development to quickly validate ML
+approaches before investing in resource-intensive custom
+development. Canvas can generate models with minimal
+computational overhead for initial feasibility testing.
+Export Canvas-generated models and code to notebooks for
+further optimization and sustainable development practices.
+- **Use AI-powered code generation for
+sustainable development**. Use AI-powered
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+efficient ML code, automate performance optimization
+scripts, and accelerate the implementation of sustainable ML
+practices while reducing development resource consumption.
+- **Consider smaller specialized
+models**. For generative AI applications, evaluate
+whether smaller, domain-specific models can meet your needs
+instead of using large general-purpose models. Techniques
+like retrieval-augmented generation (RAG) can enhance
+smaller models' capabilities while maintaining lower
+resource requirements. Fine-tuning a smaller base model on
+your specific data often provides better sustainability
+outcomes than using larger generic models.
+
+## Resources
+
+**Related documents:**
+
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Model
+Registration Deployment with Model Registry](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry.html)
+- [Stop
+Training Jobs Early](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-early-stopping.html)
+- [Model
+Explainability](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-model-explainability.html)
+- [Amazon SageMaker AI Debugger - Built-in Rules:
+LossNotDecreasing](https://docs.aws.amazon.com/sagemaker/latest/dg/debugger-built-in-rules.html#loss-not-decreasing)
+- [SageMaker AI job metrics](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html#cloudwatch-metrics-jobs)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp01.html*
+
+---
+
+# MLSUS04-BP02 Select energy-efficient algorithms
+
+Choosing energy-efficient algorithms minimizes resource usage while
+maintaining performance, reducing your machine learning workloads'
+environmental impact and operational costs.
+
+**Desired outcome:** You establish a
+systematic approach for selecting and optimizing algorithms that
+deliver the necessary performance while minimizing computational
+resources. Your ML workloads run more efficiently, reducing energy
+consumption, carbon footprint, and infrastructure costs without
+significant performance degradation.
+
+**Common anti-patterns:**
+
+- Defaulting to the most complex algorithm without evaluating
+simpler alternatives.
+- Ignoring model compression techniques that could reduce resource
+requirements.
+- Overlooking the environmental impact of computational resources.
+- Focusing solely on model accuracy without considering resource
+efficiency.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced energy consumption and carbon footprint.
+- Faster inference times and improved user experience.
+- Ability to deploy ML models on resource-constrained devices.
+- Extended battery life for edge devices running ML workloads.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Energy-efficient algorithm selection requires balancing model
+performance with resource consumption. When developing machine
+learning models, computational efficiency directly impacts
+sustainability and cost. Starting with simpler algorithms provides
+a baseline for comparison and often delivers sufficient results
+without excessive resource demands. Modern approaches like model
+distillation, pruning, and quantization enable you to achieve
+near-equivalent results using significantly fewer resources.
+
+The environmental impact of ML workloads increases with model
+complexity, making optimization techniques essential for
+sustainable AI development. By systematically evaluating algorithm
+efficiency alongside performance metrics, you can make informed
+decisions that reduce your carbon footprint while maintaining
+service quality.
+
+### Implementation steps
+
+- **Begin with a simple algorithm to
+establish a baseline:** Start your development
+process with straightforward algorithms that provide a
+reference point for performance and resource usage. Then
+[test
+different algorithms with increasing complexity](https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlper-07.html) to
+observe whether performance improvements justify additional
+resource consumption. Measure both model accuracy and
+resource utilization metrics to make informed decisions
+about complexity trade-offs.
+- **Explore simplified versions of
+popular algorithms:** Research and implement
+distilled or optimized versions of standard algorithms that
+deliver similar performance with reduced computational
+requirements. For example, DistilBERT, a distilled version
+of
+[BERT](https://en.wikipedia.org/wiki/BERT_(language_model)),
+has 40% fewer parameters, runs 60% faster, and preserves 97%
+of its performance. Similar approaches exist for many common
+model architectures.
+- **Implement model compression
+techniques:** Apply pruning to remove model weights
+that contribute minimally to predictions, reducing model
+size and computational requirements. Use quantization to
+represent numerical values with lower precision,
+significantly decreasing memory usage and processing demands
+while maintaining acceptable accuracy levels.
+- **Leverage AWS optimization
+services:** Deploy
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to automatically optimize your ML
+models for inference on cloud resources and edge devices.
+SageMaker AI Neo analyzes your model and generates optimized
+code that maximizes performance while minimizing resource
+consumption, allowing you to deploy more efficient models
+across diverse deployment targets.
+- **Monitor and optimize resource
+utilization:** Track the
+[resources
+provisioned](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ResourceConfig.html) for your training and inference jobs
+(InstanceCount, InstanceType, and VolumeSizeInGB) and their
+[efficient
+use](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html#cloudwatch-metrics-jobs) (CPUUtilization, GPUUtilization,
+GPUMemoryUtilization, MemoryUtilization, and
+DiskUtilization) through the
+[SageMaker AI
+Console](https://docs.aws.amazon.com/sagemaker/latest/dg/training-metrics.html#view-train-metrics-sm),
+[CloudWatch
+Console](https://docs.aws.amazon.com/sagemaker/latest/dg/training-metrics.html#view-train-metrics-cw) or your
+[SageMaker AI
+Debugger Profiling Report](https://docs.aws.amazon.com/sagemaker/latest/dg/debugger-profiling-report.html#debugger-profiling-report-walkthrough-system-usage). Use these insights to
+right-size your resources and identify optimization
+opportunities.
+- **Consider hardware-specific
+optimizations:** Choose appropriate instance types
+for training and inference based on your model's
+characteristics. Some algorithms perform better on GPU
+instances, while others may be more efficient on CPU or
+specialized accelerators like AWS Inferentia. Matching your
+algorithm to the optimal hardware can significantly improve
+energy efficiency.
+- **Use optimized foundation model
+containers:** Deploy models using SageMaker AI's
+optimized foundation model containers that include
+pre-configured environments with built-in quantization and
+optimization techniques. These containers support frameworks
+like Hugging Face Transformers and provide automatic
+performance optimizations.
+- **Use AI-powered code generation for
+algorithm optimization**. Use AI-powered
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+optimized algorithm implementations, automate model
+compression code, and accelerate the development of
+energy-efficient ML solutions.
+- **Apply efficient architectures for
+foundation models:** When working with generative
+AI models, consider parameter-efficient fine-tuning
+approaches like LoRA (Low-Rank Adaptation) or P-tuning
+instead of full fine-tuning. These techniques can reduce the
+computational resources required while achieving comparable
+performance. Leverage pre-trained foundation models
+available through SageMaker AI JumpStart to avoid the
+energy-intensive process of training from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [The
+AWS Inferentia Chip With DLAMI](https://docs.aws.amazon.com/dlami/latest/devguide/tutorial-inferentia.html)
+- [Prepare
+Model for Compilation](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-compilation-preparing-model.html)
+- [Optimize
+AI/ML workloads for sustainability: Part 2, model
+development](https://aws.amazon.com/blogs/architecture/optimize-ai-ml-workloads-for-sustainability-part-2-model-development/)
+
+**Related videos:**
+
+- [Deploy
+an ML model for best performance, cost, and prediction
+quality](https://www.youtube.com/watch?v=ftCFf57dQQY)
+- [SageMaker AI
+HyperPod: Revolutionizing Foundation Model Training with
+Resilience and Performance](https://aws.amazon.com/awstv/watch/c60e1437f63/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp02.html*
+
+---
+
+# MLSUS04-BP03 Archive or delete unnecessary training artifacts
+
+Remove training artifacts that are unused and no longer required to
+limit wasted resources. Determine when you can archive training
+artifacts to more energy-efficient storage or safely delete them.
+
+**Desired outcome:** You reduce your
+environmental footprint by removing unnecessary storage of ML
+training artifacts. Your organization maintains only essential
+training data and models, efficiently archives what might be needed
+later, and systematically removes what is no longer required. This
+approach not only conserves resources but also simplifies management
+of your machine learning assets.
+
+**Common anti-patterns:**
+
+- Keeping training artifacts indefinitely.
+- Ignoring the accumulation of unused logs, models, and experiment
+data.
+- Not implementing systematic cleanup processes for completed
+experiments.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced storage costs and resource consumption.
+- Improved organization and discoverability of important ML
+artifacts.
+- Enhanced security through reduced data surface area.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning workflows generate substantial volumes of
+artifacts during the development process. These include experiment
+data, logs, model checkpoints, and various intermediary outputs.
+While some of these artifacts are essential for long-term use,
+many become unnecessary after model deployment or project
+completion.
+
+Consider the lifecycle of your ML artifacts. Some might need
+preservation for compliance-aligned or reproducibility purposes,
+while others can be safely removed once they've served their
+immediate purpose. For artifacts that must be retained but are
+rarely accessed, consider using tiered storage options that
+balance accessibility with resource efficiency.
+
+### Implementation steps
+
+- **Organize your ML experiments with
+management tools**. Use
+[SageMaker AI Experiments](https://aws.amazon.com/sagemaker/ai/experiments/) to track, compare, and organize your
+machine learning experiments in a structured manner. This
+organization makes it more straightforward to identify which
+artifacts are essential and which can be archived or
+deleted.
+- **Implement regular cleanup
+procedures**. Follow the
+[clean
+up training resources](https://docs.aws.amazon.com/sagemaker/latest/dg/ex1-cleanup.html) guidance from AWS to
+systematically remove SageMaker AI resources you no longer
+need. Create automated cleanup workflows that run on a
+schedule to avoid the accumulation of unused artifacts.
+- **Set appropriate log retention
+policies**. By default, Amazon CloudWatch retains
+logs indefinitely, which consumes unnecessary resources.
+Implement
+[limited
+retention time](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SettingLogRetention) for your notebooks and training logs
+to automatically expire and delete logs after they're no
+longer needed.
+- **Establish storage lifecycle
+policies**. Configure
+[Amazon S3 lifecycle policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html) to automatically transition
+training artifacts to more cost-effective and
+energy-efficient storage classes like Amazon Glacier or S3 Glacier Deep Archive based on access patterns.
+- **Monitor storage
+utilization**. Use
+[Amazon S3 Storage Lens](https://aws.amazon.com/s3/storage-analytics-insights/) to gain visibility into your storage
+usage patterns and identify opportunities for optimization.
+Track metrics regularly to verify that your cleanup
+procedures are effective.
+- **Implement container image
+cleanup**. Use
+[Amazon ECR lifecycle policies](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) to automatically clean up
+unused container images that may have been created during
+training jobs. This avoids the accumulation of outdated or
+unused container images.
+- **Establish artifact tagging
+standards**. Create a consistent tagging strategy
+for ML artifacts to identify their purpose, associated
+projects, and expiration dates. This makes it simpler to
+determine what can be archived or deleted during cleanup
+processes.
+- **Leverage managed MLflow for
+experiment tracking**. Use
+[managed
+MLflow on SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html) to create, manage, analyze, and
+compare your machine learning experiments with better
+organization and tracking capabilities, making it more
+straightforward to identify which experiments and associated
+artifacts can be safely archived or deleted.
+- **For GenAI foundation models,
+implement token usage monitoring and cleanup**. For
+generative AI projects, monitor token usage and intermediate
+outputs, which can quickly accumulate. Implement automated
+cleanup of temporary prompts, completions, and generated
+content that isn't required for the final model.
+
+## Resources
+
+**Related documents:**
+
+- [Clean
+up Amazon SageMaker AI notebook instance resources](https://docs.aws.amazon.com/sagemaker/latest/dg/ex1-cleanup.html)
+- [Cataloging
+and analyzing your data with S3 Inventory](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-inventory.html)
+- [What
+Is Amazon EventBridge?](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html)
+- [Working
+with log groups and log streams](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SettingLogRetention)
+- [Automate
+the cleanup of images by using lifecycle policies in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html)
+- [AWS Systems Manager for Automation](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation.html)
+- [What
+Is AWS Config?](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html)
+- [Optimizing
+MLOps for Sustainability](https://aws.amazon.com/blogs/machine-learning/optimizing-mlops-for-sustainability/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp03.html*
+
+---
+
+# MLSUS04-BP04 Use efficient model tuning methods
+
+Optimize your machine learning model's hyperparameters with
+resource-efficient strategies that minimize computational needs
+while improving performance. Efficient tuning methods can
+significantly reduce costs, energy consumption, and time-to-market
+compared to resource-intensive brute force approaches.
+
+**Desired outcome:** You can
+systematically find optimal hyperparameters for your machine
+learning models while minimizing computational resource consumption.
+By implementing intelligent search strategies and following best
+practices for optimization, you achieve better model performance
+with fewer resources, reduce your environmental footprint, and
+accelerate time-to-market for your ML solutions.
+
+**Common anti-patterns:**
+
+- Using grid search, which tests the most possible combinations of
+hyperparameters.
+- Running many concurrent training jobs without considering how
+results from previous jobs can inform later ones.
+- Specifying excessively broad hyperparameter ranges without
+proper understanding of their impact.
+- Using random search when more efficient options like Bayesian or
+Hyperband are available.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduce computational resources required for hyperparameter
+tuning by up to 10x compared to random search.
+- Decrease energy consumption and associated carbon emissions from
+ML training.
+- Find optimal hyperparameters faster, accelerating
+time-to-market.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Hyperparameter tuning is a crucial step in machine learning model
+development that directly impacts both model performance and
+resource utilization. Efficient tuning strategies can dramatically
+reduce the computational resources required while finding optimal
+or near-optimal parameter settings.
+
+When approaching hyperparameter tuning, consider the relationship
+between tuning strategy and resource consumption. Grid search,
+which exhaustively tests the most possible combinations, is the
+most resource-intensive approach and should generally be avoided.
+Random search provides better resource efficiency but lacks
+intelligence in selecting which configurations to test. More
+sophisticated approaches like Bayesian optimization and Hyperband
+can find optimal hyperparameters with significantly fewer training
+jobs, reducing both time and resource usage.
+
+The efficiency of your hyperparameter tuning is also affected by
+how you configure concurrent jobs and specify parameter ranges.
+Running too many concurrent jobs can waste resources when using
+methods that benefit from sequential exploration. Similarly,
+specifying unnecessarily wide parameter ranges increases the
+search space complexity without adding value.
+
+### Implementation steps
+
+- **Choose an efficient search
+strategy**. Implement Bayesian optimization or
+Hyperband search strategies instead of random or grid
+search. Bayesian search uses information from previous
+trials to make intelligent guesses about promising
+hyperparameter configurations, typically requiring 10 times
+fewer jobs than random search to find optimal parameters.
+For large models like deep neural networks addressing
+computer vision problems,
+[Amazon SageMaker AI Hyperband](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-how-it-works.html) can find optimal hyperparameters
+up to three times faster than Bayesian search.
+- **Optimize job concurrency
+settings**. Configure your hyperparameter tuning
+jobs with appropriate concurrency settings. With Bayesian
+optimization, running fewer concurrent jobs often yields
+better results since the algorithm benefits from information
+gathered in previous iterations. Balance the tradeoff
+between parallelism (which speeds up overall completion
+time) and sequential learning (which improves optimization
+efficiency) based on your specific requirements for
+time-to-completion versus resource efficiency.
+- **Define thoughtful parameter
+ranges**. Carefully select which hyperparameters to
+tune and their corresponding value ranges. Focus on
+parameters that significantly impact model performance and
+limit ranges to reasonable values based on domain knowledge
+or prior experiments. For parameters known to be log-scaled
+(learning rates, regularization strengths), convert them to
+log space to improve optimization efficiency. This focused
+approach reduces the search space complexity, discovering
+optimal configurations with fewer resources.
+- **Leverage early stopping
+capabilities**. Implement mechanisms to terminate
+underperforming training jobs early to avoid wasting
+resources on unpromising hyperparameter configurations. Use
+Amazon SageMaker AI's built-in early stopping functionality
+that automatically terminates training jobs that are
+unlikely to produce better models than previously completed
+jobs.
+- **Monitor resource
+utilization**. Track metrics related to resource
+provisioning and utilization for your hyperparameter tuning
+jobs. Use Amazon SageMaker AI's integration with Amazon CloudWatch to monitor CPU utilization, GPU utilization,
+memory usage, and other resource metrics. Analyze these
+metrics to identify optimization opportunities in your
+tuning strategy.
+- **Integrate with your MLOps
+pipeline**. Incorporate efficient hyperparameter
+tuning as a standard component of your MLOps workflow.
+Automate the process of selecting optimal hyperparameters
+and retraining models when necessary. This verifies the
+consistent application of efficient tuning practices across
+your machine learning projects.
+- **Leverage pre-trained models to
+reduce tuning scope**. Start with pre-trained
+models from the expanded
+[SageMaker AI
+JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) catalog or
+[Amazon
+Bedrock](https://aws.amazon.com/bedrock/) foundation models, which often require
+minimal hyperparameter tuning for your use case,
+significantly reducing computational resources compared to
+training from scratch.
+- **Leverage AI-powered code generation
+for tuning automation**. Use AI-powered development
+tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+efficient hyperparameter tuning scripts, automate
+optimization workflows, and accelerate the implementation of
+resource-efficient tuning strategies.
+- **Consider warm-starting tuning
+jobs**. Use the results from previous
+hyperparameter tuning jobs to initialize new jobs when
+incrementally improving models or adapting to changing data
+patterns. This approach reduces the resources required to
+find good hyperparameters compared to starting from scratch.
+
+## Resources
+
+**Related documents:**
+
+- [Best
+Practices for Hyperparameter Tuning](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html)
+- [Automatic
+model tuning with SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning.html)
+- [Managed
+Spot Training in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-managed-spot-training.html)
+- [Amazon SageMaker AI Training Compiler](https://docs.aws.amazon.com/sagemaker/latest/dg/training-compiler.html)
+- [Choosing
+the Best Number of Concurrent Training Jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html#automatic-model-tuning-parallelism)
+- [Choosing
+Hyperparameter Ranges](https://docs.aws.amazon.com/sagemaker/latest/dg/automatic-model-tuning-considerations.html#automatic-model-tuning-choosing-ranges)
+- [Amazon SageMaker AI Hyperband Search Strategy](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-sagemaker-automatic-model-tuning-provides-faster-hyperparameter-tuning-hyperband-search-strategy/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus04-bp04.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSUS05.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSUS05.md
@@ -1,0 +1,533 @@
+# MLSUS05
+
+**Pillar**: Unknown  
+**Best Practices**: 4
+
+---
+
+# MLSUS05-BP01 Align SLAs with sustainability goals
+
+Define service level agreements (SLAs) that support your
+sustainability goals while meeting your business requirements.
+Define SLAs to meet your business requirements, not exceed them.
+Make trade-offs that significantly reduce environmental impacts in
+exchange for acceptable decreases in service levels.
+
+**Desired outcome:** You establish
+SLAs that balance business requirements with sustainability
+objectives, optimizing resource utilization while maintaining
+acceptable service levels. By implementing appropriate inference
+methods based on latency tolerance, availability needs, and response
+time requirements, you can reduce idle resources, minimize energy
+consumption, and lower your machine learning workload's
+environmental impact.
+
+**Common anti-patterns:**
+
+- Maintaining always-on inference endpoints for workloads with
+sporadic or batch processing needs.
+- Setting unnecessarily stringent response time requirements when
+users can tolerate some latency.
+- Configuring excessive redundancy beyond what's needed for
+business continuity.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced infrastructure costs through optimized resource
+utilization.
+- Lower carbon footprint from minimized idle computing resources.
+- Alignment of technical operations with organizational
+sustainability goals.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+When designing machine learning systems, your SLA choices directly
+impact resource consumption and environmental sustainability. By
+carefully analyzing your actual business requirements rather than
+automatically opting for maximum performance, you can identify
+opportunities to make sustainable trade-offs without compromising
+essential functionality.
+
+Consider your application's true latency requirements,
+availability needs, and processing patterns. For example, if your
+users can tolerate a response time of seconds rather than
+milliseconds, asynchronous or batch processing approaches can
+dramatically reduce resource usage compared to always-on real-time
+endpoints. Similarly, if your application can gracefully handle
+occasional unavailability during instance failures, you can avoid
+overprovisioning redundant capacity.
+
+The goal is to make conscious trade-offs that balance
+sustainability with business needs, focusing on what's truly
+required rather than defaulting to full time maximum performance.
+
+### Implementation steps
+
+- **Queue incoming requests and process
+them asynchronously**. If your users can tolerate
+some latency, deploy your model on
+[serverless](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+or
+[asynchronous
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html) to reduce resources that are idle between
+tasks and minimize the impact of load spikes. These options
+will automatically scale the instance or endpoint count to
+zero when there are no requests to process, so you only
+maintain an inference infrastructure when your endpoint is
+processing requests.
+- **Adjust availability**. If
+your users can tolerate some latency in the rare case of a
+failover, don't provision extra capacity. If an outage
+occurs or an instance fails, Amazon SageMaker AI
+[automatically
+attempts to distribute your instances across Availability
+Zones](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html#deployment-best-practices-availability-zones). Adjusting availability is an example of a
+[conscious
+trade off](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-as-a-non-functional-requirement.html) you can make to meet your sustainability
+targets.
+- **Adjust response time**.
+When you don't need real-time inference, use
+[SageMaker AI Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html). Unlike a persistent endpoint,
+clusters are decommissioned when batch transform jobs finish
+so you don't continuously maintain an inference
+infrastructure.
+- **Conduct workload
+analysis**. Assess your machine learning workload's
+usage patterns and latency requirements to determine the
+most sustainable deployment option. Identify periods of peak
+activity versus low or no usage to determine if on-demand
+scaling is appropriate for your needs.
+- **Define sustainability
+metrics**. Establish key metrics to track your
+sustainability improvements, such as compute hours saved,
+idle time reduced, or overall carbon footprint reduction.
+Include these metrics alongside traditional performance
+indicators in your operational dashboards.
+- **Leverage enhanced serverless
+inference capabilities**. Use improved
+[SageMaker AI
+Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) with increased memory
+configurations and better cold-start performance for
+variable workloads that don't require always-on
+infrastructure.
+- **Optimize large language model
+deployments with serverless deployment or batch
+processing**. For generative AI workloads using
+large language models (LLMs), consider serverless model
+inference through SageMaker AI or implement
+[Bedrock
+batch processing](https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html) for non-interactive generation tasks
+like content summarization or document analysis to reduce
+resource consumption.
+
+## Resources
+
+**Related documents:**
+
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [Batch
+transform for inference with Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Best
+practices for deploying models on SageMaker AI Hosting
+Services](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-best-practices.html)
+- [Amazon SageMaker AI Inference Recommender](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-recommender.html)
+- [Sustainability
+as a non-functional requirement](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-as-a-non-functional-requirement.html)
+- **Related services:**
+- [Amazon
+Bedrock](https://aws.amazon.com/bedrock/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp01.html*
+
+---
+
+# MLSUS05-BP02 Use efficient silicon
+
+Choosing the right compute architecture for your machine learning
+workloads can significantly reduce energy consumption and carbon
+footprint while maintaining high performance.
+
+**Desired outcome:** You select and
+deploy the most energy-efficient instance types for your machine
+learning workloads, resulting in reduced power consumption, lower
+costs, and a more sustainable ML infrastructure without compromising
+performance or functionality.
+
+**Common anti-patterns:**
+
+- Using general-purpose instances for specialized ML workloads.
+- Selecting hardware based primarily on performance without
+considering power efficiency.
+- Not optimizing ML models to work efficiently on specialized
+hardware.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced energy consumption by up to 60% with purpose-built ML
+accelerators.
+- Decreased carbon footprint of your ML operations.
+- Improved performance-per-watt metrics for your ML
+infrastructure.
+- Better alignment with organizational sustainability goals.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+The energy efficiency of your ML infrastructure directly impacts
+both your operating costs and environmental footprint. By
+selecting purpose-built hardware accelerators designed
+specifically for ML workloads, you can achieve significant
+sustainability improvements while maintaining or even improving
+performance.
+
+AWS has developed several specialized compute architectures
+optimized for different ML workload types, from training to
+inference. Each is designed to deliver maximum performance per
+watt to assist in meeting sustainability goals while effectively
+running your ML applications. These purpose-built solutions are
+particularly important for large-scale ML deployments where small
+efficiency improvements can result in substantial energy savings
+when scaled across your infrastructure.
+
+When choosing compute resources for your ML workloads, consider
+not only the raw performance but also the energy efficiency of the
+hardware. The most powerful instance sometimes isn't the most
+sustainable choice, as matching the hardware capabilities to your
+specific workload requirements can often lead to better
+sustainability outcomes.
+
+### Implementation steps
+
+- **Assess your ML workload
+requirements**. Before selecting compute resources,
+analyze your ML workload characteristics including model
+size, batch processing capabilities, latency requirements,
+and throughput needs. This assessment can determine which
+specialized hardware will provide the optimal balance
+between performance and sustainability.
+- **Use AWS Graviton3 for CPU-based ML
+inference**.
+[AWS Graviton3](https://aws.amazon.com/ec2/graviton/) processors offer the best performance per
+watt in Amazon EC2, using up to 60% less energy than
+comparable instances. They deliver up to three times better
+performance compared to Graviton2 processors for ML
+workloads and support bfloat16, making them ideal for
+efficient CPU-based inference.
+- **Deploy AWS Inferentia for deep
+learning inference**. Amazon EC2
+[Inf2
+instances](https://aws.amazon.com/machine-learning/inferentia/) offer up to 50% better performance per watt
+over comparable Amazon EC2 instances. These instances are
+purpose-built to run deep learning models at scale and
+assist in meeting sustainability goals when deploying
+ultra-large models.
+- **Leverage AWS Trainium for ML
+training**. Amazon EC2
+[Trn2
+instances](https://aws.amazon.com/machine-learning/trainium/) based on custom-designed AWS Trainium chips
+offer up to 50% cost-to-train savings over comparable
+instances. When using a Trainium-based instance cluster,
+total energy consumption for training BERT Large from
+scratch is approximately 25% lower compared to same-sized
+clusters of comparable accelerated EC2 instances.
+- **Optimize your models for the target
+hardware**. Use the
+[AWS Neuron SDK](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/) to compile and optimize your ML models
+specifically for AWS Inferentia and Trainium chips. This
+verifies that your models can take full advantage of the
+hardware's power-efficient design and specialized ML
+acceleration features.
+- **Monitor and measure power
+efficiency**. Use Amazon CloudWatch metrics to
+track the resource utilization of your ML workloads. Compare
+performance-per-watt metrics across different instance types
+to validate your efficiency improvements and identify areas
+for further optimization.
+- **Leverage purpose-built training
+infrastructure**. For large-scale model training,
+use
+[SageMaker AI
+HyperPod](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-hyperpod.html) which provides purpose-built infrastructure
+for distributed training with automatic checkpoint storage
+and recovery, optimizing resource utilization for
+long-running training jobs.
+- **Evaluate serverless options for
+intermittent workloads**. For ML inference
+workloads with variable traffic patterns, consider
+[Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html) to automatically scale
+compute resources based on traffic, reducing idle resource
+waste.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon EC2 instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
+- [Specifications
+for Amazon EC2 accelerated computing instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html#aws-inferentia-instances)
+- [AWS Neuron SDK Documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/)
+- [What
+is Amazon SageMaker AI?](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html)
+
+**Related examples:**
+
+- [AWS Graviton Technical Guide](https://github.com/aws/aws-graviton-getting-started)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp02.html*
+
+---
+
+# MLSUS05-BP03 Optimize models for inference
+
+Optimize machine learning models for inference to achieve higher
+performance with lower computational resources, reducing both costs
+and environmental impact.
+
+**Desired outcome:** You achieve more
+efficient machine learning inference with optimized models that use
+less computational resources, consume less energy, and deliver
+faster predictions. This optimization can reduce operational costs
+and carbon footprint while improving the user experience through
+faster response times.
+
+**Common anti-patterns:**
+
+- Deploying models directly from training without optimization.
+- Using generic frameworks for inference when optimized
+alternatives exist.
+- Selecting oversized models when smaller ones would suffice for
+the task.
+- Ignoring hardware-specific optimizations for deployment targets.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced inference costs through more efficient resource
+utilization.
+- Improved response times for better user experience.
+- Extended battery life for edge device deployments.
+- Ability to deploy complex models on resource-constrained
+devices.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Model optimization for inference represents a critical step in the
+machine learning lifecycle that is often overlooked. While data
+scientists typically focus on model accuracy during development,
+the computational efficiency of these models during deployment
+significantly impacts costs, energy consumption, and user
+experience.
+
+Model compilation transforms your trained models into optimized
+forms that can run more efficiently on specific hardware. This
+process analyzes your model's computational graph, applies various
+optimizations like operator fusion and memory layout
+transformations, and generates optimized code that takes advantage
+of hardware-specific capabilities. The result is a model that
+delivers the same predictions but requires less computational
+resources and energy.
+
+The optimization approach varies based on your model type and
+deployment target. For tree-based models like XGBoost, specialized
+compilers can significantly reduce inference latency. For deep
+learning models, frameworks can avoid training-specific operations
+and optimize the execution path. For edge deployments, additional
+optimizations like quantization can reduce model size while
+maintaining acceptable accuracy.
+
+### Implementation steps
+
+- **Select appropriate model
+architectures**. Choose model architectures that
+naturally lend themselves to efficient inference. Consider
+simpler architectures or distilled versions of larger models
+when possible. Balance accuracy requirements against
+efficiency needs for your specific use case.
+- **Use open-source model
+compilers**. Use specialized tools like
+[Treelite](https://treelite.readthedocs.io/en/latest/)
+for decision tree ensembles such as XGBoost, LightGBM, and
+RandomForest. These compilers transform models into
+optimized C code that improves prediction throughput through
+more efficient memory access patterns and computational
+optimizations.
+- **Leverage Amazon SageMaker AI
+Neo**. Use
+[Amazon SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html) to optimize models for inference on
+Amazon SageMaker AI in the cloud and supported edge devices.
+Neo automatically optimizes models trained in TensorFlow,
+PyTorch, MXNet, and other frameworks, delivering up to 25
+times the performance improvement while maintaining
+accuracy. The Neo runtime consumes only a fraction of the
+resources required by full deep learning frameworks.
+- **Consider quantization
+techniques**. Apply post-training quantization to
+reduce model precision from 32-bit floating point to 16-bit
+or 8-bit integers where appropriate. This reduces model size
+and improves computational efficiency, particularly on
+hardware with specialized integer arithmetic capabilities.
+- **Optimize for specific hardware
+targets**. Configure your model compilation process
+to target the specific hardware where inference will run.
+Different optimizations apply to CPUs, GPUs, and specialized
+accelerators like AWS Inferentia or AWS Trainium.
+- **Use efficient model serving
+architectures**. Implement
+[SageMaker AI
+multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html) and inference pipelines to
+build modular inference architectures that efficiently share
+resources across models and processing stages, allowing for
+improved resource utilization and optimization.
+- **Leverage AI-powered code generation
+for optimization automation**. Use AI-powered
+development tools like
+[Amazon Q Developer](https://aws.amazon.com/q/developer/) and
+[Kiro](https://kiro.ai/) to generate
+model optimization code, automate inference pipeline
+creation, and accelerate the implementation of efficient
+deployment strategies.
+- **Test performance under realistic
+conditions**. Measure inference latency,
+throughput, and resource utilization under realistic
+workloads before deploying to production. Compare optimized
+models against baselines to quantify improvements and verify
+that optimization doesn't impact accuracy.
+
+## Resources
+
+**Related documents:**
+
+- [Model
+performance optimization with SageMaker AI Neo](https://docs.aws.amazon.com/sagemaker/latest/dg/neo.html)
+- [SageMaker AI
+JumpStart pretrained models](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html)
+- [Multi-model
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Edge
+Devices](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-edge-devices.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp03.html*
+
+---
+
+# MLSUS05-BP04 Deploy multiple models behind a single endpoint
+
+Host multiple models behind a single endpoint to improve endpoint utilization. Sharing
+endpoint resources is more sustainable and less expensive than deploying a single model behind
+one endpoint.
+
+**Desired outcome:** Your organization achieves greater efficiency
+in your model deployments by consolidating multiple models on shared infrastructure. This can
+reduce costs by increasing utilization of your endpoint resources, minimize environmental impact
+through reduced carbon emissions, and simplify your model deployment architecture.
+
+**Common anti-patterns:**
+
+- Deploying each model on its own dedicated endpoint regardless of utilization patterns.
+- Over-provisioning resources for endpoints that serve infrequently accessed models.
+- Creating separate infrastructure for similar models that could share resources.
+
+**Benefits of establishing this best practice:**
+
+- Reduced costs through better utilization of compute resources.
+- Decreased carbon footprint by up to 90% compared to single-model deployments.
+- Improved scalability for serving multiple models.
+- Enhanced operational efficiency for inference workloads.
+
+**Level of risk exposed if this best practice is not established:**
+Medium
+
+## Implementation guidance
+
+Model deployment architecture significantly impacts both cost and sustainability. By
+hosting multiple models behind a single endpoint, you can substantially improve resource
+utilization, reducing both expenses and environmental impact. Amazon SageMaker AI provides several
+approaches to implement this practice, each suitable for different scenarios depending on your
+model types, access patterns, and processing requirements.
+
+Consider your workload characteristics when selecting a deployment approach. For a large
+collection of similar models that aren't accessed simultaneously, multi-model endpoints (MME)
+offer the most efficient solution. When you need to deploy different model types with varying
+framework requirements, multi-container endpoints (MCE) provide flexibility. For sequential
+processing workflows, inference pipelines allow you to chain preprocessing, prediction, and
+postprocessing steps.
+
+### Implementation steps
+
+- **Assess your model deployment needs**. Evaluate your
+current deployment architecture, focusing on model similarity, access patterns, and
+resource requirements. Identify opportunities to consolidate models based on these
+characteristics.
+- **Select the appropriate deployment method**. Choose from
+one of SageMaker AI's three approaches based on your workload requirements:
+
+Multi-model endpoints for similar models with varied access patterns
+- Multi-container endpoints for heterogeneous models requiring different
+frameworks
+- Inference pipelines for sequential processing workflows
+
+- **Implement multi-model endpoints**. Use SageMaker AI's multi-model
+endpoint capability to host multiple models within a single container. This approach is
+ideal when you have many similar models that use the same framework and don't need to be
+accessed simultaneously. Configure the endpoint to dynamically load and unload models
+based on usage patterns to optimize memory utilization.
+- **Deploy multi-container endpoints**. When your models
+require different containers or frameworks, use [SageMaker AI multi-container
+endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html) to host up to 15 containers on a single endpoint. Configure each
+container with its specific model and framework requirements while sharing the
+underlying infrastructure resources.
+- **Create inference pipelines**. For workflows that require
+sequential processing, implement a [SageMaker AI inference pipeline](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html) to
+chain multiple containers. Define the sequence to handle preprocessing, model inference,
+and postprocessing steps as a unified flow, passing outputs from one container as inputs
+to the next.
+- **Monitor and optimize resource utilization**. Use [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) to track endpoint metrics
+including CPU utilization, memory usage, and invocation patterns. Analyze this data to
+further optimize your deployment by adjusting instance types or scaling configurations
+based on actual usage.
+- **Implement cost tracking**. Set up cost allocation tags to
+monitor the efficiency gains from your consolidated endpoint deployment. Compare the
+costs before and after implementation to quantify savings and justify the architectural
+approach.
+- **Leverage modular deployment architectures**. Use [SageMaker AI
+multi-container endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html) and [inference pipelines](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html) to
+create modular inference architectures that can efficiently share resources across
+different model components and processing stages.
+- **Consider sustainability metrics**. Track carbon emission
+reductions resulting from your optimized deployment architecture. Using [AWS
+Customer Carbon Footprint Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/), you can measure the environmental impact of
+your workloads and report on sustainability improvements.
+
+## Resources
+
+**Related documents:**
+
+- [Multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html)
+- [Multi-container endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-endpoints.html)
+- [Inference
+pipelines in Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipelines.html)
+- [Deploy
+models with Amazon SageMaker AI Serverless Inference](https://docs.aws.amazon.com/sagemaker/latest/dg/serverless-endpoints.html)
+- [Automatic
+scaling of Amazon SageMaker AI models](https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-auto-scaling.html)
+- [Asynchronous
+inference](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp04.html*
+
+---

--- a/skills/wa-review/references/lenses/machine-learning/MLSUS06.md
+++ b/skills/wa-review/references/lenses/machine-learning/MLSUS06.md
@@ -1,0 +1,281 @@
+# MLSUS06
+
+**Pillar**: Unknown  
+**Best Practices**: 2
+
+---
+
+# MLSUS06-BP01 Measure material efficiency
+
+Measure efficiency of your workload in provisioned resources per
+unit of work to determine not only the business success of the
+workload, but also its material efficiency. Use this measure as a
+baseline for your sustainability improvement process.
+
+**Desired outcome:** You can quantify
+and track the resources required by your machine learning workload
+to deliver its business outcomes. By measuring resources per unit of
+work, you create a sustainable baseline that allows you to track
+improvements over time, make data-driven decisions about resource
+optimization, and demonstrate the environmental impact of your
+sustainability efforts.
+
+**Common anti-patterns:**
+
+- Focusing exclusively on business metrics without considering
+resource consumption.
+- Measuring total resource usage without normalizing by business
+outcomes.
+- Making optimization decisions without quantitative data on
+resource efficiency.
+
+**Benefits of establishing this best
+practice:**
+
+- Creates a clear way to measure sustainability progress over
+time.
+- Enables comparison of different implementations based on
+material efficiency.
+- Provides data to demonstrate ROI on sustainability improvements.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Material efficiency is a critical aspect of sustainable machine
+learning workloads. By measuring the resources provisioned per
+unit of work, you gain visibility into how efficiently your
+workload uses cloud resources to deliver business value. This
+approach normalizes your sustainability metrics across different
+workload sizes, usage patterns, and business outcomes.
+
+When implementing material efficiency measurements, you should
+first determine what constitutes a *unit of
+work* for your specific ML workload. This could be a
+model training run, a prediction request, a processed transaction,
+or another relevant business outcome. Then, establish which
+resources to track. Typically, this is compute (vCPU minutes),
+storage (GB), and network (GB transferred). By dividing your
+provisioned resources by these units of work, you create a
+normalized efficiency metric that can be tracked over time.
+
+For example, a recommendation engine might track vCPU minutes per
+recommendation delivered, or a fraud detection system could
+measure GB of storage per fraudulent transaction identified.
+Tracking these metrics can determine if changes to your
+architecture, algorithms, or deployment strategies are improving
+efficiency or creating waste.
+
+### Implementation steps
+
+- **Define your unit of work**.
+Identify what business outcomes your ML workload produces,
+such as model training completions, predictions made,
+insights generated, or transactions processed. Verify that
+this metric directly relates to business value delivered.
+- **Establish resource
+metrics**. Track key resource consumption metrics
+using Amazon CloudWatch. For ML workloads, important metrics
+include compute utilization (vCPU minutes), memory usage,
+storage consumption (GB), and network transfer (GB). AWS Cost Explorer can identify key cost drivers in your ML
+workload.
+- **Calculate baseline
+efficiency**. Divide your resource consumption
+metrics by your units of work to create efficiency ratios
+(for example, vCPU minutes per prediction, GB storage per
+model training run, or network transfer per transaction).
+Document these values as your baseline for future
+comparisons.
+- **Set improvement targets**.
+Based on your baseline measurements, set realistic targets
+for reducing resource consumption per unit of work. Consider
+both absolute reductions (total resources) and percentage
+improvements over the baseline.
+- **Implement monitoring and
+reporting**. Use Amazon CloudWatch dashboards to
+visualize your efficiency metrics over time. Set up alerts
+for significant deviations from expected efficiency. Amazon SageMaker AI provides built-in monitoring capabilities for ML
+workloads to track resource utilization.
+- **Quantify improvement
+benefits**. When implementing changes, calculate
+both the immediate resource savings and the projected
+long-term benefits. Include the return on investment from
+your improvement activities to demonstrate value to
+stakeholders.
+- **Review and optimize
+regularly**. Schedule regular reviews of your
+efficiency metrics to identify new optimization
+opportunities. As your workload evolves, your baseline and
+targets may need adjustment.
+
+## Resources
+
+**Related documents:**
+
+- [Analyzing
+your costs and usage with AWS Cost Explorer](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/ce-what-is.html)
+- [Data
+and model quality monitoring with Amazon SageMaker AI Model
+Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [AWS Trusted Advisor](https://docs.aws.amazon.com/awssupport/latest/user/trusted-advisor.html)
+- [Measure
+results and replicate successes](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/measure-results-and-replicate-successes.html)
+- [AWS Well-Architected Framework - Sustainability Pillar](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html)
+- [Cloud
+Financial Management with AWS](https://aws.amazon.com/aws-cost-management/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus06-bp01.html*
+
+---
+
+# MLSUS06-BP02 Retrain only when necessary
+
+Because of model drift, robustness requirements, or new ground truth
+data being available, models usually need to be retrained. Instead
+of retraining arbitrarily, monitor your ML model in production,
+automate your model drift detection and only retrain when your
+model's predictive performance has fallen below defined KPIs.
+
+**Desired outcome:** You will
+establish a data-driven approach to model retraining that optimizes
+computational resources while maintaining model performance. By
+implementing automated monitoring and drift detection systems, you
+can identify when your model's performance degrades below acceptable
+thresholds and retrain only when necessary. This reduces unnecessary
+computational overhead while verifying that your models remain
+accurate and relevant.
+
+**Common anti-patterns:**
+
+- Retraining models on a fixed schedule regardless of performance.
+- Manual monitoring of model performance leading to delayed
+detection of drift.
+- Retraining without clear performance thresholds or KPIs.
+
+**Benefits of establishing this best
+practice:**
+
+- Reduced computational resources and carbon footprint.
+- Lower operational costs for model maintenance.
+- More efficient use of data science team resources.
+
+**Level of risk exposed if this best practice
+is not established:** Medium
+
+## Implementation guidance
+
+Machine learning models deployed in production environments
+naturally experience degradation in performance over time due to
+changes in data patterns, user behaviors, or business
+environments. This phenomenon, known as model drift, requires
+retraining to maintain optimal performance. However, retraining a
+model consumes significant computational resources, which impacts
+both operational costs and environmental sustainability.
+
+By implementing automated monitoring systems and establishing
+clear performance thresholds, you can make data-driven decisions
+about when to retrain your models. This approach verifies that
+you're using computational resources efficiently while maintaining
+the effectiveness of your ML systems. Through continuous
+monitoring, you can detect both concept drift (changes in the
+relationship between input and output variables) and data drift
+(changes in the distribution of input data).
+
+Your monitoring strategy should incorporate both technical metrics
+(such as accuracy, precision, recall) and business-relevant KPIs
+that directly tie to organizational outcomes. By correlating these
+metrics with specific thresholds for retraining, you create a
+sustainable approach to model maintenance that optimizes both
+performance and resource utilization.
+
+### Implementation steps
+
+- **Determine key performance
+indicators**. Work with business stakeholders to
+identify minimum acceptable accuracy levels and maximum
+acceptable error rates for your models. These KPIs should
+directly connect to business outcomes and provide clear
+thresholds for when retraining becomes necessary. Consider
+both technical metrics (precision, recall, F1 score) and
+business metrics (conversion rates, user engagement, revenue
+impact) when establishing these thresholds.
+- **Monitor your model deployed in
+Production**. Implement
+[Amazon SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to continuously evaluate your
+deployed models. SageMaker AI Model Monitor provides
+capabilities for data quality monitoring, model quality
+monitoring, bias drift monitoring, and feature attribution
+drift monitoring. Configure alerts based on your established
+KPIs to automatically notify your team when performance
+begins to degrade.
+- **Set up baseline metrics**.
+Create a baseline of your model's performance metrics
+immediately after deployment. This serves as a reference
+point against which future performance can be measured.
+SageMaker AI Model Monitor can automatically generate these
+baselines from your training data or initial inference data.
+- **Configure drift detection
+thresholds**. Define specific threshold values that
+indicate when drift has occurred to a degree that warrants
+retraining. These thresholds should be based on your KPIs
+and statistical measures of data or concept drift. Configure
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) alarms to go off when these thresholds are
+exceeded.
+- **Automate your retraining
+pipelines**. Use
+[Amazon SageMaker AI Pipelines](https://aws.amazon.com/sagemaker/pipelines/),
+[AWS Step Functions for Amazon SageMaker AI](https://docs.aws.amazon.com/step-functions/latest/dg/connect-sagemaker.html), or third-party
+tools to create automated workflows that can be initiated
+when drift is detected. These pipelines should handle data
+preparation, model training, evaluation, and deployment with
+minimal manual intervention.
+- **Optimize retraining
+frequency**. Based on historical drift patterns,
+adjust monitoring sensitivity and retraining thresholds to
+optimize the frequency of retraining. Finding the right
+balance keeps models performant while minimizing
+computational overhead.
+- **Establish canary
+deployments**. When deploying retrained models, use
+[SageMaker AI
+deployment options](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails.html) like canary deployments to
+gradually shift traffic to the new model while monitoring
+performance, allowing for quick rollback if issues arise.
+- **Leverage enhanced bias and drift
+detection**. Use improved
+[SageMaker AI
+Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html) capabilities with enhanced bias detection,
+new fairness metrics, and better visualization tools to more
+accurately detect when retraining is necessary.
+- **Implement feedback loops for
+generative models**. Establish mechanisms to
+collect user feedback and engagement metrics to detect when
+outputs become less relevant or helpful. Use
+[Amazon SageMaker AI JumpStart](https://aws.amazon.com/sagemaker/jumpstart/) for fine-tuning foundation models
+when drift is detected in generative applications.
+
+## Resources
+
+**Related documents:**
+
+- [Amazon SageMaker AI Model Monitor documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)
+- [Amazon SageMaker AI Pipelines documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/pipelines.html)
+- [Amazon SageMaker AI Clarify](https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html)
+- [Amazon SageMaker AI Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [AWS Step Functions for Data Science](https://docs.aws.amazon.com/step-functions/latest/dg/connect-sagemaker.html)
+- [SageMaker AI
+Deployment Guardrails](https://docs.aws.amazon.com/sagemaker/latest/dg/deployment-guardrails.html)
+- [SageMaker AI Governance](https://aws.amazon.com/sagemaker/ai/ml-governance/)
+- [Optimizing
+MLOps for Sustainability](https://aws.amazon.com/blogs/machine-learning/optimizing-mlops-for-sustainability/)
+
+**Related videos:**
+
+- [SageMaker AI
+HyperPod: Revolutionizing Foundation Model Training with
+Resilience and Performance](https://aws.amazon.com/awstv/watch/c60e1437f63/)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus06-bp02.html*
+
+---

--- a/skills/wa-review/references/lenses/serverless-applications/sustainability.md
+++ b/skills/wa-review/references/lenses/serverless-applications/sustainability.md
@@ -1,0 +1,17 @@
+# Sustainability
+
+**Pages**: 1
+
+---
+
+# Sustainability pillar
+
+The sustainability pillar includes the ability to continually improve sustainability impacts by reducing energy
+consumption and increasing efficiency across all components of a workload by maximizing the benefits from the
+provisioned resources and minimizing the total resources required.
+
+There are no sustainability practices unique to this lens. For information on Sustainability, refer to the [Sustainability Pillar whitepaper](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/sustainability.html*
+
+---


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR — merge LAST in this sequence:**
> **#77 (ML lens) → #81 (Data Analytics lens) → this PR (serverless Sustainability fix).**
> This branch is stacked on #81, so until #77 and #81 merge, this PR's diff also shows their commits. It resolves automatically as they land. Please **merge #77, then #81, then this.**

## Overview
Fixes a crawler traversal bug where a pillar expressed as a **single content page** (a leaf with no child best practices) was silently dropped. The **serverless lens's "Sustainability" pillar** is exactly this shape (`sustainability.html`, depth 1, no children) — it was **missing from the shipped lens** (only 5 of 6 pillar files present). This restores it.

Addresses the serverless/pillar-as-leaf case in #80.

## The fix
`discover_leaf_pages` only captured leaves at `depth >= 2`. Now it also captures a leaf that is itself a matched pillar node:
```python
elif current_section and href and (depth >= 2 or matched):
```

## Result
Regenerated the serverless lens (skill + Power copies): **5 → 6 pillar files**, adding `sustainability.md`.

## Verification
- serverless gains **only** `sustainability.md`; the other 5 files are byte-unchanged.
- migration and data-analytics re-crawl **byte-identical** (no regression).
- Re-crawl idempotent; both copies identical; no error-page leakage.
- evals/ unit tests: 23 passed. README serverless count 5 → 6.

## Note
Other lenses still have related traversal gaps (iot/government partial, M&A/maori empty) tracked in #80 — those are not built yet and are left for a follow-up; this PR fixes only the shipped serverless lens.
