### PR TITLE
Add model benchmark for WA review across Bedrock providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ evals/                              Automated evaluation runner (Bedrock)
   grade.py                            LLM-as-judge grader
   report.py                           Scoring and terminal output
   config.yaml                         Bedrock region and model config
+  benchmark.py                        Multi-model comparison runner
+  benchmark_report.py                 Generate markdown tables from benchmark results
+  benchmark_config.yaml               Models, prompt, and grading criteria
   pyproject.toml                      Dependencies (use uv sync)
 
 install.sh                          One-command setup (macOS/Linux)
@@ -762,6 +765,62 @@ All skills are evaluated using an automated LLM-as-judge framework with paired c
 - Skills never produce worse output than baseline — they improve or match
 
 The evaluation framework is included in [`evals/`](./evals) so you can reproduce results on your own models and prompts. Use `--parallel` for ~3x faster runs.
+
+---
+
+## 🏎️ Model Benchmark
+
+Compare how different foundation models perform on Well-Architected review tasks — measuring **quality**, **latency**, **throughput**, and **token cost** side by side.
+
+<!-- BENCHMARK-START -->
+### Model Benchmark Results
+
+**Last run:** 2026-07-01T11:48:24Z | **Region:** us-east-1 | **Prompt:** 1,595 chars | **Max tokens:** 4,096
+
+| Model | Input Tokens | Output Tokens | Latency (s) | Tokens/s | Quality |
+|-------|-------------:|--------------:|------------:|---------:|--------:|
+| claude-sonnet-5 | 793 | 4,096 | 44.1 | 93 | 5.0/5 |
+| r1 | 517 | 1,559 | 11.0 | 142 | 4.8/5 |
+| nova-2-lite | 512 | 1,553 | 7.8 | 198 | 3.9/5 |
+| llama4-maverick-17b-instruct | 503 | 1,051 | 5.1 | 207 | 3.6/5 |
+| nova-pro | 549 | 1,067 | 5.6 | 190 | 3.6/5 |
+| pixtral-large-2502 | 620 | 2,741 | 33.2 | 83 | 3.6/5 |
+| llama3-3-70b-instruct | 505 | 1,255 | 13.4 | 93 | 3.4/5 |
+| claude-haiku-4-5-20251001 | 587 | 4,096 | 22.0 | 186 | 3.3/5 |
+| nova-lite | 549 | 1,603 | 10.2 | 157 | 2.5/5 |
+
+<details><summary>Benchmark details</summary>
+
+- Task: Well-Architected review of an e-commerce Terraform architecture
+- Temperature: 0
+- Models tested: 9
+- Quality graded by: unknown
+- Criteria: coverage of 6 pillars, identification of key risks, actionability
+- Run with: `cd evals && python benchmark.py --grade`
+
+</details>
+<!-- BENCHMARK-END -->
+
+**Run it yourself:**
+
+```bash
+cd evals
+uv sync
+
+# Quick run (no grading) — just latency and token counts
+uv run python benchmark.py
+
+# Full run with quality grading
+uv run python benchmark.py --grade
+
+# Test specific models
+uv run python benchmark.py --models us.anthropic.claude-sonnet-5 us.amazon.nova-pro-v1:0
+
+# Publish results to this README
+uv run python benchmark_report.py results/benchmark-YYYYMMDD-HHMMSS.json --update-readme
+```
+
+Configure models and prompts in [`evals/benchmark_config.yaml`](evals/benchmark_config.yaml). Add new models as they become available in Bedrock and re-run to keep the table current.
 
 ---
 

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+Model Benchmark — Compare Bedrock models on wa-review quality, cost, and latency.
+
+Sends the same WA review prompt to multiple models via the Converse API,
+capturing: output text, input/output token counts, wall-clock latency,
+and (optionally) LLM-as-judge quality scores.
+
+Usage:
+    python benchmark.py                    # Run all models in config
+    python benchmark.py --models us.anthropic.claude-sonnet-5 us.amazon.nova-pro-v1:0
+    python benchmark.py --grade            # Also run quality grading
+    python benchmark.py --results results/benchmark-2026-07-01.json  # Custom output path
+"""
+
+import argparse
+import json
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import boto3
+import yaml
+from botocore.config import Config as BotoConfig
+
+SCRIPT_DIR = Path(__file__).parent
+CONFIG_PATH = SCRIPT_DIR / "benchmark_config.yaml"
+RESULTS_DIR = SCRIPT_DIR / "results"
+
+
+def load_config(path: Path = CONFIG_PATH) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _extract_text(response: dict) -> str:
+    """Extract text from a Converse API response, handling thinking/reasoning blocks."""
+    text_parts = []
+    for block in response["output"]["message"]["content"]:
+        if "text" in block:
+            text_parts.append(block["text"])
+        elif "reasoningContent" in block:
+            reasoning = block["reasoningContent"].get("reasoningText", {}).get("text", "")
+            if reasoning:
+                text_parts.append(reasoning)
+    return "\n".join(text_parts)
+
+
+THINKING_MODELS = {"claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7"}
+
+
+def _needs_thinking(model_id: str) -> bool:
+    """Check if a model requires extended thinking configuration."""
+    return any(m in model_id for m in THINKING_MODELS)
+
+
+def _converse_with_retries(client, kwargs: dict, inference_config: dict, model_id: str):
+    """Attempt converse call with fallback retries for validation errors."""
+    try:
+        return client.converse(**kwargs)
+    except client.exceptions.ValidationException as e:
+        err_msg = str(e).lower()
+        # Retry 1: drop temperature if unsupported
+        if "temperature" in err_msg and "temperature" in inference_config:
+            del inference_config["temperature"]
+            return client.converse(**kwargs)
+        # Retry 2: switch thinking type from enabled to adaptive
+        if "thinking.type.enabled" in err_msg or "adaptive" in err_msg:
+            kwargs["additionalModelRequestFields"] = {
+                "thinking": {"type": "adaptive"},
+                "output_config": {"effort": "medium"},
+            }
+            inference_config.pop("temperature", None)
+            return client.converse(**kwargs)
+        # Retry 3: add thinking if model requires it
+        if "think" in err_msg or "budget" in err_msg:
+            inference_config.pop("temperature", None)
+            kwargs["additionalModelRequestFields"] = {
+                "thinking": {"type": "adaptive"},
+                "output_config": {"effort": "medium"},
+            }
+            return client.converse(**kwargs)
+        raise
+
+
+def call_model(client, model_id: str, messages: list[dict], system: str | None = None,
+               max_tokens: int = 4096, temperature: float = 0) -> dict:
+    """Call a single model via Converse API. Returns metrics + output."""
+    inference_config = {"maxTokens": max_tokens}
+
+    kwargs = {
+        "modelId": model_id,
+        "messages": messages,
+        "inferenceConfig": inference_config,
+    }
+
+    if _needs_thinking(model_id):
+        kwargs["additionalModelRequestFields"] = {
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "medium"},
+        }
+    else:
+        if temperature is not None:
+            inference_config["temperature"] = temperature
+
+    if system:
+        kwargs["system"] = [{"text": system}]
+
+    start = time.time()
+    try:
+        response = _converse_with_retries(client, kwargs, inference_config, model_id)
+    except Exception as e:
+        return {"model_id": model_id, "error": str(e), "latency_s": time.time() - start}
+
+    latency = time.time() - start
+    usage = response.get("usage", {})
+    output_text = _extract_text(response)
+
+    if not output_text:
+        return {"model_id": model_id, "error": "empty response (no text blocks)", "latency_s": round(latency, 2)}
+
+    return {
+        "model_id": model_id,
+        "output": output_text,
+        "input_tokens": usage.get("inputTokens", 0),
+        "output_tokens": usage.get("outputTokens", 0),
+        "total_tokens": usage.get("totalTokens", 0),
+        "latency_s": round(latency, 2),
+        "stop_reason": response.get("stopReason", "unknown"),
+    }
+
+
+def grade_output(client, grading_model: str, prompt: str, output: str,
+                 criteria: list[str], region: str) -> dict:
+    """Use an LLM judge to score the output against criteria."""
+    grading_prompt = f"""You are an expert evaluator for AWS Well-Architected reviews.
+
+Score the following model output against each criterion on a 1-5 scale:
+1 = completely fails  2 = poor  3 = adequate  4 = good  5 = excellent
+
+MODEL INPUT (the prompt given):
+{prompt}
+
+MODEL OUTPUT (to evaluate):
+{output}
+
+CRITERIA:
+{json.dumps(criteria, indent=2)}
+
+Respond with ONLY a JSON object:
+{{
+  "scores": {{
+    "<criterion>": {{"score": <1-5>, "reason": "<one sentence>"}},
+    ...
+  }},
+  "overall": <1-5 average rounded to 1 decimal>
+}}"""
+
+    inference_config = {"maxTokens": 2048, "temperature": 0}
+    kwargs = {
+        "modelId": grading_model,
+        "messages": [{"role": "user", "content": [{"text": grading_prompt}]}],
+        "inferenceConfig": inference_config,
+    }
+
+    try:
+        response = client.converse(**kwargs)
+    except client.exceptions.ValidationException as e:
+        if "temperature" in str(e).lower():
+            del inference_config["temperature"]
+            response = client.converse(**kwargs)
+        else:
+            return {"error": str(e)}
+
+    text = _extract_text(response)
+    if not text:
+        return {"error": "grading model returned empty response"}
+    try:
+        start = text.find("{")
+        end = text.rfind("}") + 1
+        return json.loads(text[start:end])
+    except (json.JSONDecodeError, ValueError):
+        return {"raw": text, "error": "failed to parse grading JSON"}
+
+
+def run_benchmark(config: dict, models: list[str], grade: bool = False) -> dict:
+    """Run the benchmark across all models."""
+    region = config["region"]
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=region,
+        config=BotoConfig(read_timeout=300),
+    )
+
+    prompt_config = config["prompt"]
+    system_prompt = prompt_config.get("system")
+    user_prompt = prompt_config["user"]
+    messages = [{"role": "user", "content": [{"text": user_prompt}]}]
+
+    max_tokens = config.get("max_tokens", 4096)
+    temperature = config.get("temperature", 0)
+
+    print(f"Benchmarking {len(models)} models in {region}")
+    print(f"Prompt length: ~{len(user_prompt)} chars")
+    print(f"Max tokens: {max_tokens}, Temperature: {temperature}")
+    print("-" * 60)
+
+    results = []
+
+    def run_one(model_id):
+        print(f"  → {model_id}...")
+        try:
+            result = call_model(client, model_id, messages, system=system_prompt,
+                                max_tokens=max_tokens, temperature=temperature)
+        except Exception as e:
+            return {"model_id": model_id, "error": str(e), "latency_s": 0}
+        if "error" not in result:
+            tokens_per_sec = result["output_tokens"] / result["latency_s"] if result["latency_s"] > 0 else 0
+            result["tokens_per_sec"] = round(tokens_per_sec, 1)
+            print(f"  ✓ {model_id}: {result['output_tokens']} tokens, "
+                  f"{result['latency_s']}s, {result['tokens_per_sec']} tok/s")
+        else:
+            print(f"  ✗ {model_id}: {result['error'][:80]}")
+        return result
+
+    with ThreadPoolExecutor(max_workers=config.get("concurrency", 4)) as executor:
+        futures = {executor.submit(run_one, m): m for m in models}
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    # Sort by model_id for consistent output
+    results.sort(key=lambda r: r["model_id"])
+
+    # Optional grading pass
+    if grade and config.get("grading"):
+        grading_model = config["grading"]["model"]
+        criteria = config["grading"]["criteria"]
+        print(f"\nGrading with {grading_model}...")
+        for r in results:
+            if "error" in r:
+                r["grade"] = {"error": "skipped — model call failed"}
+                continue
+            print(f"  Grading {r['model_id']}...")
+            r["grade"] = grade_output(client, grading_model, user_prompt,
+                                      r["output"], criteria, region)
+
+    return {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "config": {
+            "region": region,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "prompt_chars": len(user_prompt),
+            "models_tested": len(models),
+        },
+        "results": results,
+    }
+
+
+def print_summary(benchmark: dict):
+    """Print a comparison table."""
+    results = benchmark["results"]
+    print("\n" + "=" * 90)
+    print(f"{'Model':<45} {'In Tok':>7} {'Out Tok':>8} {'Latency':>8} {'Tok/s':>7} {'Grade':>6}")
+    print("-" * 90)
+    for r in sorted(results, key=lambda x: x.get("latency_s", 999)):
+        if "error" in r:
+            print(f"{r['model_id']:<45} {'ERROR':>7} {'':<8} {r['latency_s']:>7.1f}s {'':<7} {'—':>6}")
+            continue
+        grade_str = "—"
+        if "grade" in r and "overall" in r.get("grade", {}):
+            grade_str = f"{r['grade']['overall']:.1f}"
+        print(f"{r['model_id']:<45} {r['input_tokens']:>7,} {r['output_tokens']:>8,} "
+              f"{r['latency_s']:>7.1f}s {r['tokens_per_sec']:>6.0f} {grade_str:>6}")
+    print("=" * 90)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark Bedrock models on WA review tasks")
+    parser.add_argument("--config", type=Path, default=CONFIG_PATH, help="Config file path")
+    parser.add_argument("--models", nargs="+", help="Override model list from config")
+    parser.add_argument("--grade", action="store_true", help="Run LLM-as-judge quality grading")
+    parser.add_argument("--results", type=Path, help="Custom output file path")
+    parser.add_argument("--concurrency", type=int, help="Max parallel model calls")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    models = args.models or config["models"]
+    if args.concurrency:
+        config["concurrency"] = args.concurrency
+
+    benchmark = run_benchmark(config, models, grade=args.grade)
+    print_summary(benchmark)
+
+    # Save results
+    RESULTS_DIR.mkdir(exist_ok=True)
+    out_path = args.results or RESULTS_DIR / f"benchmark-{time.strftime('%Y%m%d-%H%M%S')}.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(benchmark, f, indent=2, ensure_ascii=False)
+    print(f"\nResults saved to: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/benchmark_config.yaml
+++ b/evals/benchmark_config.yaml
@@ -1,0 +1,108 @@
+# Model Benchmark Configuration
+# Run: python benchmark.py [--grade] [--models model1 model2 ...]
+
+region: us-east-1
+
+# Models to benchmark (broad mix: frontier / mid / fast across providers)
+# Uses cross-region inference profile IDs (us.*) for reliability.
+# To add models: check available profiles with `aws bedrock list-inference-profiles`
+models:
+  # Anthropic Claude
+  - us.anthropic.claude-sonnet-5
+  - us.anthropic.claude-haiku-4-5-20251001-v1:0
+  # Amazon Nova
+  - us.amazon.nova-pro-v1:0
+  - us.amazon.nova-lite-v1:0
+  - us.amazon.nova-2-lite-v1:0
+  # DeepSeek
+  - us.deepseek.r1-v1:0
+  # Meta Llama
+  - us.meta.llama4-maverick-17b-instruct-v1:0
+  - us.meta.llama3-3-70b-instruct-v1:0
+  # Mistral
+  - us.mistral.pixtral-large-2502-v1:0
+
+# Generation settings
+max_tokens: 4096
+temperature: 0
+concurrency: 4
+
+# Prompt: a realistic WA review question with code context
+prompt:
+  system: |
+    You are an AWS Well-Architected expert performing a review.
+    Analyze the architecture described and provide findings grouped by pillar.
+    For each finding use: severity (HIGH/MEDIUM/LOW), the issue, why it matters, and a concrete recommendation.
+    Be specific — cite AWS services and configuration details.
+  user: |
+    Review the following architecture for a customer-facing e-commerce platform:
+
+    Infrastructure (Terraform):
+    ```hcl
+    resource "aws_ecs_service" "api" {
+      name            = "api-service"
+      cluster         = aws_ecs_cluster.main.id
+      task_definition = aws_ecs_task_definition.api.arn
+      desired_count   = 2
+      launch_type     = "FARGATE"
+
+      network_configuration {
+        subnets         = [aws_subnet.private_a.id]
+        security_groups = [aws_security_group.api.id]
+      }
+    }
+
+    resource "aws_db_instance" "main" {
+      engine               = "postgres"
+      instance_class       = "db.r5.2xlarge"
+      allocated_storage    = 100
+      multi_az             = false
+      storage_encrypted    = true
+      deletion_protection  = false
+      backup_retention_period = 1
+      publicly_accessible  = false
+    }
+
+    resource "aws_elasticache_cluster" "sessions" {
+      engine          = "redis"
+      node_type       = "cache.r5.large"
+      num_cache_nodes = 1
+    }
+
+    resource "aws_s3_bucket" "assets" {
+      bucket = "ecommerce-assets-prod"
+    }
+
+    resource "aws_cloudfront_distribution" "cdn" {
+      enabled = true
+      origin {
+        domain_name = aws_s3_bucket.assets.bucket_regional_domain_name
+        origin_id   = "s3-assets"
+      }
+      default_cache_behavior {
+        viewer_protocol_policy = "allow-all"
+        allowed_methods        = ["GET", "HEAD"]
+        cached_methods         = ["GET", "HEAD"]
+      }
+    }
+    ```
+
+    The platform handles ~10,000 orders/day with peak traffic 5x during flash sales.
+    Current pain points: occasional 502 errors during peaks, 4-hour RTO target not being met,
+    monthly AWS bill is $18k and growing 20% QoQ.
+
+    Perform a Well-Architected review covering all six pillars.
+
+# Quality grading (used with --grade flag)
+# Use Sonnet 4.6 for grading — reliable text output without thinking budget issues
+grading:
+  model: us.anthropic.claude-sonnet-4-6
+  criteria:
+    - "Covers all 6 WA pillars (Operational Excellence, Security, Reliability, Performance Efficiency, Cost Optimization, Sustainability)"
+    - "Identifies the single-AZ ECS deployment as a reliability risk"
+    - "Flags multi_az=false on RDS as HIGH severity"
+    - "Identifies CloudFront allow-all viewer_protocol_policy as a security issue"
+    - "Recommends auto-scaling for the ECS service to handle flash sale peaks"
+    - "Notes the single Redis node as a SPOF"
+    - "Addresses the cost concern with specific right-sizing or pricing model recommendations"
+    - "Provides actionable recommendations (not just generic advice)"

--- a/evals/benchmark_report.py
+++ b/evals/benchmark_report.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""
+Generate a markdown report from benchmark results and optionally update the README.
+
+Usage:
+    python benchmark_report.py results/benchmark-20260701-143022.json
+    python benchmark_report.py results/benchmark-20260701-143022.json --update-readme
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+README_PATH = REPO_ROOT / "README.md"
+
+# Markers in README where benchmark table gets inserted
+BENCH_START = "<!-- BENCHMARK-START -->"
+BENCH_END = "<!-- BENCHMARK-END -->"
+
+
+def load_results(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def format_model_name(model_id: str) -> str:
+    """Shorten model ID for display."""
+    name = model_id
+    for prefix in ("us.", "anthropic.", "amazon.", "meta.", "mistral.", "deepseek.", "cohere."):
+        name = name.replace(prefix, "")
+    name = re.sub(r"-v\d+:\d+$", "", name)
+    return name
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate markdown table from benchmark results."""
+    results = benchmark["results"]
+    config = benchmark["config"]
+    timestamp = benchmark.get("timestamp", "unknown")
+
+    lines = []
+    lines.append(f"### Model Benchmark Results")
+    lines.append(f"")
+    lines.append(f"**Last run:** {timestamp} | **Region:** {config['region']} | "
+                 f"**Prompt:** {config['prompt_chars']:,} chars | "
+                 f"**Max tokens:** {config['max_tokens']:,}")
+    lines.append(f"")
+
+    has_grades = any("grade" in r and "overall" in r.get("grade", {}) for r in results)
+
+    # Header
+    header = "| Model | Input Tokens | Output Tokens | Latency (s) | Tokens/s |"
+    separator = "|-------|-------------:|--------------:|------------:|---------:|"
+    if has_grades:
+        header += " Quality |"
+        separator += "--------:|"
+    lines.append(header)
+    lines.append(separator)
+
+    # Sort by quality (if graded) then by latency
+    def sort_key(r):
+        if "error" in r:
+            return (0, 999)
+        grade = r.get("grade", {}).get("overall", 0)
+        return (-grade, r["latency_s"])
+
+    for r in sorted(results, key=sort_key):
+        name = format_model_name(r["model_id"])
+        if "error" in r:
+            row = f"| {name} | — | — | {r['latency_s']:.1f} | — |"
+            if has_grades:
+                row += " — |"
+            lines.append(row)
+            continue
+
+        row = (f"| {name} | {r['input_tokens']:,} | {r['output_tokens']:,} | "
+               f"{r['latency_s']:.1f} | {r['tokens_per_sec']:.0f} |")
+        if has_grades:
+            grade = r.get("grade", {}).get("overall")
+            row += f" {grade:.1f}/5 |" if grade else " — |"
+        lines.append(row)
+
+    lines.append("")
+    lines.append(f"<details><summary>Benchmark details</summary>")
+    lines.append(f"")
+    lines.append(f"- Task: Well-Architected review of an e-commerce Terraform architecture")
+    lines.append(f"- Temperature: {config['temperature']}")
+    lines.append(f"- Models tested: {config['models_tested']}")
+    if has_grades:
+        grading_model = benchmark.get("config", {}).get("grading_model", "unknown")
+        lines.append(f"- Quality graded by: {grading_model}")
+        lines.append(f"- Criteria: coverage of 6 pillars, identification of key risks, actionability")
+    lines.append(f"- Run with: `cd evals && python benchmark.py --grade`")
+    lines.append(f"")
+    lines.append(f"</details>")
+
+    return "\n".join(lines)
+
+
+def update_readme(markdown: str):
+    """Insert benchmark markdown between markers in README."""
+    if not README_PATH.exists():
+        print(f"README not found at {README_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    content = README_PATH.read_text(encoding="utf-8")
+
+    if BENCH_START not in content:
+        print(f"Marker '{BENCH_START}' not found in README. Add it where you want the table.", file=sys.stderr)
+        sys.exit(1)
+
+    pattern = re.compile(
+        rf"({re.escape(BENCH_START)})\n.*?\n({re.escape(BENCH_END)})",
+        re.DOTALL,
+    )
+    replacement = f"{BENCH_START}\n{markdown}\n{BENCH_END}"
+    new_content = pattern.sub(replacement, content)
+
+    README_PATH.write_text(new_content, encoding="utf-8")
+    print(f"✓ README updated with benchmark results")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate benchmark report")
+    parser.add_argument("results_file", type=Path, help="Path to benchmark JSON results")
+    parser.add_argument("--update-readme", action="store_true", help="Update README.md with results")
+    args = parser.parse_args()
+
+    benchmark = load_results(args.results_file)
+    markdown = generate_markdown(benchmark)
+
+    print(markdown)
+
+    if args.update_readme:
+        update_readme(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -1,0 +1,202 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "boto3"
+version = "1.43.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/ee/97798453d8e9dba0c60458870b07c78ac685fc21cdddd8eb3e20190249c6/boto3-1.43.38.tar.gz", hash = "sha256:a8d1e175a87a743e755237d884d7e5f4606e61e5602e9823469a1a630e379b3c", size = 112691, upload-time = "2026-06-30T19:55:31.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/60/e0e3baeb394e084c5136a46b8e944ba87a26bb1f67f7b3064eb035bb7e77/boto3-1.43.38-py3-none-any.whl", hash = "sha256:edffb4a8f49c0a61e8f4aa4104cc2da3c362de8042fc0819216d5e5ce5d38380", size = 140030, upload-time = "2026-06-30T19:55:29.494Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6c/815f49f0c582396b1a4c37df554ffab6bb420abd5a96d5329183a97022de/botocore-1.43.38.tar.gz", hash = "sha256:70fbd5c74f5742f5975ddcc61e6afb5174cb80577c2ccc17c6898ad3a49b51f3", size = 15628316, upload-time = "2026-06-30T19:55:19.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/b4/fdff7920b3776b37f8b42d4e6eabb141974fa88f9fb1aae5c2224bdaf635/botocore-1.43.38-py3-none-any.whl", hash = "sha256:54c1c41aff82422d2b88a8a7d782fde8ae1299a45f088d00011d85c4bc44b0cc", size = 15312254, upload-time = "2026-06-30T19:55:14.837Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wa-skill-evals"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.35.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## Summary
- New benchmark harness (`evals/benchmark.py`) that compares foundation models on a realistic WA review task
- Captures quality (LLM-as-judge, 8 criteria), latency, throughput, and token usage per model
- `benchmark_report.py` renders the results as a markdown table
- Initial run: 9 models across Anthropic, Amazon, DeepSeek, Meta, Mistral

## Results

The harness reports latency, throughput and judge score per model. Run it against the models available in your own account; the table is produced locally, not published here.

## Test plan
- [x] All 9 models complete without errors
- [x] Quality grading produces parseable JSON scores
- [x] Script handles thinking models (Sonnet 5) and reasoning models (DeepSeek R1)
- [x] One model failure doesn't crash the whole run

---

_Edited to remove measurement figures. The measurement harnesses ship in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
