### PR TITLE
Add cost dimension to model benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,19 +775,19 @@ Compare how different foundation models perform on Well-Architected review tasks
 <!-- BENCHMARK-START -->
 ### Model Benchmark Results
 
-**Last run:** 2026-07-01T11:48:24Z | **Region:** us-east-1 | **Prompt:** 1,595 chars | **Max tokens:** 4,096
+**Last run:** 2026-07-01T12:07:35Z | **Region:** us-east-1 | **Prompt:** 1,595 chars | **Max tokens:** 4,096
 
-| Model | Input Tokens | Output Tokens | Latency (s) | Tokens/s | Quality |
-|-------|-------------:|--------------:|------------:|---------:|--------:|
-| claude-sonnet-5 | 793 | 4,096 | 44.1 | 93 | 5.0/5 |
-| r1 | 517 | 1,559 | 11.0 | 142 | 4.8/5 |
-| nova-2-lite | 512 | 1,553 | 7.8 | 198 | 3.9/5 |
-| llama4-maverick-17b-instruct | 503 | 1,051 | 5.1 | 207 | 3.6/5 |
-| nova-pro | 549 | 1,067 | 5.6 | 190 | 3.6/5 |
-| pixtral-large-2502 | 620 | 2,741 | 33.2 | 83 | 3.6/5 |
-| llama3-3-70b-instruct | 505 | 1,255 | 13.4 | 93 | 3.4/5 |
-| claude-haiku-4-5-20251001 | 587 | 4,096 | 22.0 | 186 | 3.3/5 |
-| nova-lite | 549 | 1,603 | 10.2 | 157 | 2.5/5 |
+| Model | Input Tokens | Output Tokens | Latency (s) | Tokens/s | Cost | Quality |
+|-------|-------------:|--------------:|------------:|---------:|------:|--------:|
+| claude-sonnet-5 | 793 | 3,983 | 41.8 | 95 | $0.0621 | 5.0/5 |
+| r1 | 517 | 1,566 | 11.0 | 142 | $0.0092 | 4.8/5 |
+| nova-2-lite | 512 | 1,431 | 8.0 | 179 | $0.0002 | 4.2/5 |
+| pixtral-large-2502 | 620 | 1,565 | 19.1 | 82 | $0.0106 | 3.8/5 |
+| claude-haiku-4-5-20251001 | 587 | 4,096 | 21.6 | 190 | $0.0169 | 3.8/5 |
+| nova-pro | 549 | 1,316 | 9.1 | 145 | $0.0046 | 3.6/5 |
+| llama4-maverick-17b-instruct | 503 | 985 | 5.4 | 182 | $0.0005 | 3.5/5 |
+| llama3-3-70b-instruct | 505 | 1,133 | 9.9 | 114 | $0.0012 | 3.3/5 |
+| nova-lite | 549 | 1,739 | 9.2 | 189 | $0.0004 | 2.3/5 |
 
 <details><summary>Benchmark details</summary>
 

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -133,6 +133,17 @@ def call_model(client, model_id: str, messages: list[dict], system: str | None =
     }
 
 
+def compute_cost(result: dict, pricing: dict) -> float | None:
+    """Compute cost in USD for a single model invocation. Returns None if pricing unavailable."""
+    model_id = result["model_id"]
+    if model_id not in pricing or "error" in result:
+        return None
+    rates = pricing[model_id]
+    input_cost = (result["input_tokens"] / 1_000_000) * rates["input"]
+    output_cost = (result["output_tokens"] / 1_000_000) * rates["output"]
+    return round(input_cost + output_cost, 6)
+
+
 def grade_output(client, grading_model: str, prompt: str, output: str,
                  criteria: list[str], region: str) -> dict:
     """Use an LLM judge to score the output against criteria."""
@@ -234,6 +245,13 @@ def run_benchmark(config: dict, models: list[str], grade: bool = False) -> dict:
     # Sort by model_id for consistent output
     results.sort(key=lambda r: r["model_id"])
 
+    # Compute cost per invocation
+    pricing = config.get("pricing", {})
+    for r in results:
+        cost = compute_cost(r, pricing)
+        if cost is not None:
+            r["cost_usd"] = cost
+
     # Optional grading pass
     if grade and config.get("grading"):
         grading_model = config["grading"]["model"]
@@ -263,19 +281,32 @@ def run_benchmark(config: dict, models: list[str], grade: bool = False) -> dict:
 def print_summary(benchmark: dict):
     """Print a comparison table."""
     results = benchmark["results"]
-    print("\n" + "=" * 90)
-    print(f"{'Model':<45} {'In Tok':>7} {'Out Tok':>8} {'Latency':>8} {'Tok/s':>7} {'Grade':>6}")
-    print("-" * 90)
+    has_cost = any("cost_usd" in r for r in results)
+    width = 100 if has_cost else 90
+    print("\n" + "=" * width)
+    header = f"{'Model':<45} {'In Tok':>7} {'Out Tok':>8} {'Latency':>8} {'Tok/s':>7} {'Grade':>6}"
+    if has_cost:
+        header += f" {'Cost':>8}"
+    print(header)
+    print("-" * width)
     for r in sorted(results, key=lambda x: x.get("latency_s", 999)):
         if "error" in r:
-            print(f"{r['model_id']:<45} {'ERROR':>7} {'':<8} {r['latency_s']:>7.1f}s {'':<7} {'—':>6}")
+            line = f"{r['model_id']:<45} {'ERROR':>7} {'':<8} {r['latency_s']:>7.1f}s {'':<7} {'—':>6}"
+            if has_cost:
+                line += f" {'—':>8}"
+            print(line)
             continue
         grade_str = "—"
         if "grade" in r and "overall" in r.get("grade", {}):
             grade_str = f"{r['grade']['overall']:.1f}"
-        print(f"{r['model_id']:<45} {r['input_tokens']:>7,} {r['output_tokens']:>8,} "
-              f"{r['latency_s']:>7.1f}s {r['tokens_per_sec']:>6.0f} {grade_str:>6}")
-    print("=" * 90)
+        line = (f"{r['model_id']:<45} {r['input_tokens']:>7,} {r['output_tokens']:>8,} "
+                f"{r['latency_s']:>7.1f}s {r['tokens_per_sec']:>6.0f} {grade_str:>6}")
+        if has_cost:
+            cost = r.get("cost_usd")
+            cost_str = f"${cost:.4f}" if cost is not None else "—"
+            line += f" {cost_str:>8}"
+        print(line)
+    print("=" * width)
 
 
 def main():

--- a/evals/benchmark_config.yaml
+++ b/evals/benchmark_config.yaml
@@ -93,6 +93,38 @@ prompt:
 
     Perform a Well-Architected review covering all six pillars.
 
+# Pricing per 1M tokens (USD) — used to compute cost per invocation.
+# Source: https://aws.amazon.com/bedrock/pricing/ (checked 2026-07-01)
+# Update these when pricing changes or new models are added.
+pricing:
+  us.anthropic.claude-sonnet-5:
+    input: 3.00
+    output: 15.00
+  us.anthropic.claude-haiku-4-5-20251001-v1:0:
+    input: 0.80
+    output: 4.00
+  us.amazon.nova-pro-v1:0:
+    input: 0.80
+    output: 3.20
+  us.amazon.nova-lite-v1:0:
+    input: 0.06
+    output: 0.24
+  us.amazon.nova-2-lite-v1:0:
+    input: 0.04
+    output: 0.16
+  us.deepseek.r1-v1:0:
+    input: 1.35
+    output: 5.40
+  us.meta.llama4-maverick-17b-instruct-v1:0:
+    input: 0.34
+    output: 0.34
+  us.meta.llama3-3-70b-instruct-v1:0:
+    input: 0.72
+    output: 0.72
+  us.mistral.pixtral-large-2502-v1:0:
+    input: 2.00
+    output: 6.00
+
 # Quality grading (used with --grade flag)
 # Use Sonnet 4.6 for grading — reliable text output without thinking budget issues
 grading:

--- a/evals/benchmark_report.py
+++ b/evals/benchmark_report.py
@@ -52,10 +52,14 @@ def generate_markdown(benchmark: dict) -> str:
     lines.append(f"")
 
     has_grades = any("grade" in r and "overall" in r.get("grade", {}) for r in results)
+    has_cost = any("cost_usd" in r for r in results)
 
     # Header
     header = "| Model | Input Tokens | Output Tokens | Latency (s) | Tokens/s |"
     separator = "|-------|-------------:|--------------:|------------:|---------:|"
+    if has_cost:
+        header += " Cost |"
+        separator += "------:|"
     if has_grades:
         header += " Quality |"
         separator += "--------:|"
@@ -73,6 +77,8 @@ def generate_markdown(benchmark: dict) -> str:
         name = format_model_name(r["model_id"])
         if "error" in r:
             row = f"| {name} | — | — | {r['latency_s']:.1f} | — |"
+            if has_cost:
+                row += " — |"
             if has_grades:
                 row += " — |"
             lines.append(row)
@@ -80,6 +86,9 @@ def generate_markdown(benchmark: dict) -> str:
 
         row = (f"| {name} | {r['input_tokens']:,} | {r['output_tokens']:,} | "
                f"{r['latency_s']:.1f} | {r['tokens_per_sec']:.0f} |")
+        if has_cost:
+            cost = r.get("cost_usd")
+            row += f" ${cost:.4f} |" if cost is not None else " — |"
         if has_grades:
             grade = r.get("grade", {}).get("overall")
             row += f" {grade:.1f}/5 |" if grade else " — |"


### PR DESCRIPTION
## Summary
- Adds per-model rate configuration (USD per 1M tokens) to `benchmark_config.yaml`
- Computes cost per invocation from actual token usage
- Surfaces cost in the terminal output and the markdown table
- Rates are looked up from the provider's own pricing page; refresh them as they change

## Results

Cost is computed from the token usage each invocation reports, multiplied by the configured rates. Run the benchmark to see the quality/cost frontier for the models you have access to — it moves with every model release and price change.

## Test plan
- [x] Benchmark completes with cost computed for all 9 models
- [x] Rendered table includes a Cost column
- [x] Terminal summary shows cost
- [x] Models without pricing config gracefully show "—"

---

_Edited to remove measurement figures. The measurement harnesses ship in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
