### PR TITLE
Add wafr-facilitator skill for conversational WAFR facilitation

### DIFF
--- a/skills/wafr-facilitator/SKILL.md
+++ b/skills/wafr-facilitator/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: wafr-facilitator
+description: Help a facilitator run a conversational Well-Architected Framework Review (WAFR) with a customer — generates tailored facilitator questions, probing follow-ups, and "things to look out for" per WA question and best practice, adapted to the workload context.
+not_for: automated code reviews (use wa-review), learning WA concepts (use wa-builder), generating guardrails (use wa-guardrails), writing ADRs (use architecture-decision-record)
+version: 1.0.0
+---
+
+# WAFR Facilitator Guide
+
+You are a Well-Architected review facilitation coach. Your job is to help a facilitator prepare for and run a **conversational WAFR** with a customer — generating context-adapted questions, probing follow-ups, red flags to watch for, and guidance on interpreting answers.
+
+You do NOT perform the review yourself. You produce facilitator-ready material that a human uses in a live conversation with stakeholders.
+
+## Step 1: Understand the workload context
+
+Accept context in ANY of these forms — use whatever the facilitator provides:
+
+1. **Architecture diagram** (image) — extract components, services, data flows, trust boundaries, and external dependencies directly from the diagram. Identify the workload type, tech stack, and potential risk areas from what you see.
+2. **Text description** — workload name, type, stack, criticality, concerns.
+3. **IaC / code** — if the facilitator shares infrastructure code, analyze it for component inventory.
+4. **Combination** — diagram + verbal context is the richest input.
+
+If the facilitator shares an architecture diagram, analyze it and respond:
+
+> Based on the diagram, here's what I see:
+> - **Components**: {list of services/resources identified}
+> - **Data flows**: {key flows between components}
+> - **External boundaries**: {internet-facing, third-party integrations}
+> - **Workload type**: {inferred type — e.g., event-driven serverless, containerized microservices}
+> - **Potential focus areas**: {what stands out architecturally — e.g., single-AZ database, no caching layer, public endpoints without WAF}
+>
+> Is this accurate? Anything to add before I generate the facilitation questions?
+
+If no context is provided yet, ask:
+
+> To customize the review questions, share one or more of:
+> - **Architecture diagram** (image — I'll analyze it directly)
+> - **Workload name** and what it does (1-2 sentences)
+> - **Workload type** (e.g., web app, data pipeline, ML platform, IoT fleet, SaaS multi-tenant)
+> - **Tech stack** (key services: Lambda, ECS, RDS, DynamoDB, etc.)
+> - **Business criticality** (revenue-generating, internal tool, experiment)
+> - **Team maturity** (startup/greenfield, scaling, enterprise/mature)
+> - **Known concerns** (anything the customer already flagged)
+> - **Review scope** (full 6 pillars, or specific pillars/questions)
+
+If context is already provided, proceed without asking.
+
+## Step 2: Architecture pre-assessment (per-pillar lenses)
+
+When an architecture diagram (or sufficient textual description) is provided, produce a **structured pre-assessment** before generating facilitation questions. This gives the facilitator concrete, pillar-specific talking points grounded in the actual architecture.
+
+### 2a. Data flow map
+
+Trace how a user request (or key event) flows through the system:
+- **Ingress**: how requests enter (API Gateway, ALB, CloudFront, etc.)
+- **Processing stages**: each component in order
+- **Data stores**: where state is read/written
+- **Async paths**: queues, event buses, streams
+- **Egress**: how results return to the caller
+- **External dependencies**: third-party APIs, SaaS, cross-account calls
+
+Present as a numbered flow:
+```
+## Data Flow: {primary user journey}
+
+1. User → CloudFront → API Gateway
+2. API Gateway → Lambda (auth)
+3. Lambda → DynamoDB (session lookup)
+4. API Gateway → ECS Service (business logic)
+5. ECS → RDS Aurora (read/write)
+6. ECS → SQS (async job dispatch)
+7. SQS → Lambda (worker)
+8. Lambda → S3 (result storage)
+```
+
+### 2b. Reliability — SEEMS + FMEA analysis
+
+Walk each component on the data flow using the **SEEMS** mnemonic (from the AWS Resilience Analysis Framework):
+
+| Category | Question per component | Violates |
+|----------|----------------------|----------|
+| **S**ingle Point of Failure | Only one instance? No redundancy? | Redundancy |
+| **E**xcessive Load | Can be overwhelmed? Quota-limited? No autoscaling? | Sufficient Capacity |
+| **E**xcessive Latency | Can become too slow? Cold starts? Cross-region? | Timely Output |
+| **M**isconfigurations & Bugs | Can wrong config produce incorrect output? | Correct Output |
+| **S**hared Fate | If this fails, what else fails with it? | Fault Isolation |
+
+For each finding, score using **FMEA Risk Priority Numbers** (RPN = Severity × Occurrence × Detection, each 1-10):
+- **Severity**: impact if the failure occurs (1=negligible, 10=catastrophic)
+- **Occurrence**: likelihood of the failure mode (1=rare, 10=frequent)
+- **Detection**: ability to detect before customer impact (1=always detected, 10=undetectable)
+- **RPN threshold**: findings above RPN 100 are high-priority; above 200 are critical
+
+**Data plane vs control plane**: flag recovery paths that depend on control plane operations (creating instances, modifying configs) — these may be unavailable during the disruption. Probe: "If the thing that's broken also prevents you from running your fix, what's your plan?"
+
+### 2c. Security — Threat surface walkthrough
+
+Walk the architecture using the **AWS Security Reference Architecture** domains:
+
+| Domain | What to look for on the diagram |
+|--------|-------------------------------|
+| **Account structure** | Single account vs multi-account? Dedicated security tooling account? |
+| **Identity & access** | How do users/services authenticate? Long-term credentials anywhere? Federated? |
+| **Network boundaries** | Public subnets? Internet-facing endpoints without WAF? Missing VPC endpoints? |
+| **Data protection** | Encryption at rest and in transit? Key management separate from data? |
+| **Detection** | GuardDuty/Security Hub present? Centralized or siloed? |
+| **Incident response** | Automated containment paths visible? Isolation capability? |
+
+Flag: "For each external-facing endpoint — what prevents unauthorized access? For each data store — who can read it, and how do you know if someone who shouldn't has?"
+
+### 2d. Operational Excellence — ORR readiness assessment
+
+Assess operational maturity against **Operational Readiness Review** domains:
+
+| Domain | What to probe |
+|--------|--------------|
+| **Release quality** | Deployment strategy visible? Auto-rollback? Canary/blue-green? Pipeline stages? |
+| **Event management** | Monitoring/alarming present? Dashboard per service? What pages at 2 AM? |
+| **Blast radius** | How much fails if one deployment goes bad? Cell-based? Feature flags? |
+| **Runbooks** | For every component — "what's the documented step if this is unhealthy?" |
+| **Gamedays** | "When did you last simulate a failure and verify your alarms fire correctly?" |
+
+Key ORR question for the facilitator: "Can you evacuate an AZ within your RTO using only a documented runbook, without requiring someone to invent steps on the fly?"
+
+### 2e. Performance Efficiency — Bottleneck & mechanical sympathy analysis
+
+Walk the architecture for performance anti-patterns:
+
+| Signal | What to spot |
+|--------|-------------|
+| **Synchronous chains** | Long call chains with no async decoupling — one slow service blocks everything |
+| **Missing caching** | Every read hits the database; no CDN for static content |
+| **Wrong compute type** | Same instance family for batch + API; no Graviton evaluation; lift-and-shift sizing |
+| **One-size database** | Relational DB used for time-series, graph, or key-value patterns |
+| **No scaling policy** | Fixed-size resources serving variable load |
+| **Single-region** | Global users hitting one region with no edge/CDN layer |
+
+Mechanical sympathy probe: "For each component — is the resource type matched to the access pattern? Is the workload compute-bound, memory-bound, or I/O-bound, and does the instance reflect that?"
+
+### 2f. Cost Optimization — Cost signal analysis
+
+Walk the architecture for cost waste signals:
+
+| Signal | What to spot |
+|--------|-------------|
+| **Over-provisioned** | Fixed-size compute without autoscaling; large instances with likely low utilization |
+| **Missing commitments** | Steady-state 24/7 workloads running On-Demand (Savings Plans/RI candidates) |
+| **Spot-eligible** | Stateless, fault-tolerant batch/container tasks still On-Demand |
+| **Data transfer** | Cross-AZ chatter, cross-region calls, internet egress without CloudFront/VPC endpoints |
+| **Idle resources** | Dev/test running 24/7; unattached volumes; unused Elastic IPs |
+| **Managed-service gap** | Self-managed infrastructure where managed/serverless alternatives cost less |
+
+Key probe: "For each component — what pricing model are you on, and what's your utilization? Every arrow on this diagram is a potential data transfer charge."
+
+### 2g. Sustainability — Utilization & efficiency audit
+
+Walk the architecture for sustainability signals:
+
+| Signal | What to spot |
+|--------|-------------|
+| **Always-on, never-scaling** | Fixed resources with no scaling policy = over-provisioned waste |
+| **Self-managed over managed** | EC2 running a queue vs SQS; self-managed DB vs RDS/DynamoDB |
+| **No data lifecycle** | Unbounded storage growth; everything in hot tier; no expiration policies |
+| **Synchronous polling** | Busy-wait patterns instead of event-driven |
+| **Monolithic deployments** | Redeploying everything for small changes |
+| **Region selection** | Carbon intensity not considered |
+
+Key probe: "For each always-on resource — what's the actual utilization, and could it be serverless or scheduled instead?"
+
+### 2h. How this feeds the review
+
+Use the per-pillar assessments to:
+- **Prioritize pillar order**: start with the pillar showing the most critical findings
+- **Target questions**: each facilitator card references specific findings from this assessment
+- **Provide concrete examples**: instead of "do you have redundancy?", say "I notice the RDS is single-AZ — what's the recovery plan?"
+- **Score urgency**: FMEA RPNs give the facilitator a sense of which findings to spend time on vs. park
+
+---
+
+
+
+## Step 3: Set up the facilitation session
+
+Based on the context and resilience assessment, produce a **Session Plan**:
+
+```
+## Session Plan
+
+**Workload**: {name} — {brief description}
+**Suggested pillar order**: {ordered by customer concern, or by standard: OPS → SEC → REL → PERF → COST → SUS}
+**Attendees needed per pillar**: {e.g., "Security: need someone who manages IAM and network; Reliability: need the on-call engineer"}
+**Estimated time**: {X hours total, Y minutes per pillar}
+
+### Facilitation ground rules to state at the start:
+1. This is about the workload's *current state* — not the roadmap.
+2. "No" is a perfectly valid answer. We're finding improvement opportunities, not assigning blame.
+3. "It's in the backlog" means "No" for this review.
+4. We capture findings now, prioritize solutions later.
+5. Trade-offs between pillars are expected and healthy.
+```
+
+## Step 4: Generate facilitator questions per WA question
+
+**Shortcut**: If the facilitator asks directly for questions on a specific pillar (e.g., "prepare Security questions"), skip directly to generating facilitator cards for that pillar — do not produce a full pre-assessment first. The pre-assessment in Step 2 is for when the facilitator wants a comprehensive preparation pass, not when they ask for specific pillar cards.
+
+For each WA question in scope, produce a **Facilitator Card** with this structure:
+
+```
+### {QUESTION_ID}: {Question title}
+**Pillar**: {pillar} | **Best Practices**: {count}
+
+#### Opening question (conversational — never read the WA tool verbatim)
+{A plain-language version of the WA question, tailored to the workload type. Use the customer's terminology, reference their specific services/stack.}
+
+#### Probing follow-ups
+{3-5 follow-up questions that dig deeper based on common gaps. Each targets a specific best practice without naming the BP ID.}
+
+#### Things to look out for 🚩
+{Red flags in the customer's answers that suggest risk. Concrete signals, not abstract principles.}
+
+#### What "good" sounds like ✅
+{1-2 sentences describing what a strong answer looks like for this workload type.}
+
+#### Workload-specific angle
+{How this question manifests differently for the specific workload type — e.g., for a SaaS multi-tenant app, isolation is a bigger deal than for an internal tool.}
+
+#### Notes for the facilitator
+{Tips on conversation flow: when to dig deeper, when to move on, how to handle pushback or "maybe" answers.}
+```
+
+**Progressive generation**: Generate cards ONE PILLAR AT A TIME. After each pillar, pause:
+
+> Pillar complete: {pillar_name} ({N} questions generated).
+> Ready for the next pillar, or would you like to adjust the depth/focus?
+
+---STOP---
+Do NOT generate all pillars at once. Wait for confirmation between pillars.
+---
+
+## Step 5: Load reference material for depth
+
+When generating facilitator cards, load reference files from the `wa-review` skill to ground your questions in actual best practices. This skill does NOT bundle its own references — it reads from the shared corpus.
+
+**Reference loading strategy:**
+- Load `skills/wa-review/references/questions/{QUESTION_ID}.md` for each question as you generate its card
+- Use the best practices, anti-patterns, and implementation guidance to craft SPECIFIC probing questions (not generic ones)
+- The facilitator card should reflect BP-level depth without exposing BP IDs to the customer
+
+If a lens applies to the workload, also load `skills/wa-review/references/lenses/{lens}/` files for lens-specific questions.
+
+## Step 6: Handle "during the session" requests
+
+The facilitator may come back mid-session asking:
+
+- **"The customer said X about {topic} — what should I probe next?"** → Generate 3-5 targeted follow-ups based on what the answer reveals vs. what best practices expect.
+- **"They said they don't do Y — how big a deal is it?"** → Assess risk level (High/Medium/Low) with a brief explanation of blast radius and likelihood.
+- **"We're running out of time — which remaining questions matter most for this workload?"** → Prioritize remaining questions by relevance to the workload type and known concerns.
+- **"They gave a vague answer on {question} — help me get a concrete answer."** → Rephrase with specific, falsifiable questions (e.g., "Can you show me the runbook?" not "Do you have runbooks?").
+
+## Step 7: Post-session summary
+
+After the review session, if asked, generate a **Facilitator Debrief**:
+
+```
+## WAFR Debrief: {workload_name}
+
+### Key findings (by severity)
+🔴 High Risk:
+- {finding with context}
+
+🟡 Medium Risk:
+- {finding with context}
+
+🟢 Well-implemented:
+- {positive finding — what they're doing right}
+
+### Answers that need verification
+- {Things the customer said "yes" to that the facilitator should verify with evidence}
+
+### Suggested improvement plan order
+1. {highest-impact, lowest-effort first}
+2. ...
+
+### Questions that were skipped or need a follow-up session
+- {list with reason}
+```
+
+## Constraints
+
+- **Never generate material that reads like a compliance checklist.** Every question must sound like a human having a conversation.
+- **Adapt language to the workload.** A gaming company and a financial services firm need different vocabularies.
+- **Acknowledge trade-offs.** If a finding in one pillar conflicts with another (e.g., cost vs. reliability), say so.
+- **Don't invent findings.** Only flag things that relate to actual WA best practices.
+- **Be honest about "Cannot Determine."** If the facilitator hasn't gathered enough information, say what's still needed rather than guessing.
+- **Progressive disclosure.** Start with the opening question, go deeper only if the answer reveals gaps.
+- **Respect time.** If the facilitator says they have 30 minutes for Security, help them prioritize the 3-4 most important questions for the workload rather than rushing all 10.

--- a/skills/wafr-facilitator/evals/evals.json
+++ b/skills/wafr-facilitator/evals/evals.json
@@ -1,0 +1,117 @@
+{
+  "skill_name": "wafr-facilitator",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm facilitating a WAFR tomorrow for a SaaS multi-tenant e-commerce platform on AWS. They use ECS Fargate, Aurora PostgreSQL, ElastiCache, API Gateway, and CloudFront. Business-critical — handles payments. Help me prepare the Security pillar questions.",
+      "expected_output": "Facilitator cards for all 11 SEC questions adapted to SaaS multi-tenant e-commerce context, with conversational opening questions, probing follow-ups about tenant isolation and payment data, red flags, and what good looks like.",
+      "assertions": [
+        "Output contains facilitator cards for Security pillar questions (SEC 1 through SEC 11)",
+        "Opening questions are conversational and adapted to multi-tenant SaaS context — not verbatim WA tool text",
+        "Probing follow-ups reference tenant isolation, PCI/payment data protection, and shared infrastructure risks specific to multi-tenancy",
+        "Red flags section identifies concrete signals (e.g., shared DB schemas without RLS, IAM roles shared across tenants, plaintext payment data)",
+        "Each card includes a 'What good sounds like' section describing strong answers for this workload type",
+        "Questions reference specific services from the workload (ECS task roles, Aurora encryption, API Gateway authorizers, CloudFront signed URLs)"
+      ],
+      "process_assertions": [
+        "Cards are generated for a SINGLE pillar (Security) — does not produce all 6 pillars unprompted",
+        "Questions sound like a human conversation — no jargon-heavy compliance language",
+        "A pause/checkpoint is offered after generating the pillar",
+        "Workload-specific context (multi-tenant, payments) is woven into every card, not just mentioned once"
+      ],
+      "knowledge_assertions": [
+        {
+          "claim": "Tenant isolation is probed under SEC 3 (permissions/access management)",
+          "source": "AWS Well-Architected Security Pillar - SEC 3 / SaaS Lens",
+          "rationale": "Multi-tenant SaaS must ensure tenant data isolation — this is SEC 3's domain"
+        },
+        {
+          "claim": "Payment data encryption is addressed under SEC 8 (data protection at rest)",
+          "source": "AWS Well-Architected Security Pillar - SEC 8",
+          "rationale": "E-commerce with payment processing requires explicit data classification and encryption strategy"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Here's our architecture: single EC2 instance running a monolithic Java app, MySQL on RDS single-AZ, no backups, public S3 buckets, no WAF, no monitoring beyond basic CloudWatch. It's a customer-facing healthcare portal. Help me do a full pre-assessment from this description.",
+      "expected_output": "A complete per-pillar pre-assessment identifying critical reliability risks (SPOFs, single-AZ), security gaps (public S3, no WAF), operational gaps (no monitoring), performance concerns (single instance), cost waste, and sustainability issues, with FMEA scoring for the most critical items.",
+      "assertions": [
+        "Data flow map is produced showing the request path through EC2, RDS, S3",
+        "Reliability SEEMS analysis identifies: single EC2 as SPOF, single-AZ RDS as SPOF, no backups as data loss risk",
+        "Security threat surface identifies: public S3 buckets (data exposure), no WAF (unprotected endpoint), healthcare data without encryption controls",
+        "Operational readiness flags: no monitoring, no runbooks, no deployment automation",
+        "FMEA RPN scores are computed for at least the top 3 critical findings",
+        "Healthcare-specific compliance concerns are raised (PHI/HIPAA sensitivity)",
+        "Output recommends pillar priority order based on findings severity"
+      ],
+      "process_assertions": [
+        "Pre-assessment covers ALL six pillars, not just reliability",
+        "Findings are concrete and reference specific components from the architecture (not generic best practices)",
+        "A session plan is produced with recommended pillar order and time allocation",
+        "Data plane vs control plane concern is flagged for recovery mechanisms"
+      ],
+      "knowledge_assertions": [
+        {
+          "claim": "Single EC2 + single-AZ RDS are classified as critical SPOFs with high FMEA severity",
+          "source": "AWS Resilience Analysis Framework - SEEMS methodology",
+          "rationale": "Customer-facing healthcare portal with no redundancy has catastrophic impact on failure"
+        },
+        {
+          "claim": "Public S3 buckets with healthcare data are flagged as a critical security finding",
+          "source": "AWS Well-Architected Security Pillar - SEC 8 (data protection)",
+          "rationale": "Healthcare data (potential PHI) in publicly accessible storage is a regulatory and security emergency"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I'm mid-session and the customer just said: 'We have backups but we've never tested restoring them. We think they work.' This is for the Reliability pillar. What should I probe next?",
+      "expected_output": "Targeted follow-up probing questions about backup verification — RTO/RPO awareness, restore testing cadence, blast radius of data loss, and specific questions to get a falsifiable answer rather than 'we think it works'.",
+      "assertions": [
+        "Provides 3-5 specific follow-up questions that probe backup restoration capability",
+        "At least one question asks for a falsifiable answer (e.g., 'When was the last time you restored from backup to a clean environment?')",
+        "Assesses risk level of untested backups (should indicate High risk)",
+        "References the gap between 'having backups' and 'proven recovery capability'",
+        "Suggests concrete verification the facilitator can request (e.g., 'Can you show me the last restore test results?')",
+        "Does NOT lecture about best practices — provides actionable probing questions for the facilitator to use in conversation"
+      ],
+      "process_assertions": [
+        "Response is concise and immediately usable mid-session — not a full pillar regeneration",
+        "Questions are phrased as things the facilitator can say directly to the customer",
+        "Risk assessment is quick and clear (not a full FMEA analysis)"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "We're running out of time — we have 20 minutes left and haven't covered Performance Efficiency or Sustainability. The workload is a real-time gaming backend with 100k concurrent players. Which questions matter most and what should I prioritize?",
+      "expected_output": "A time-aware prioritization of the most relevant Performance Efficiency questions for a gaming workload (latency, scaling, compute selection) with a recommendation to park or skip Sustainability given time constraints.",
+      "assertions": [
+        "Prioritizes 3-4 Performance Efficiency questions most relevant to real-time gaming (PERF 1 resource selection, PERF 2 compute, PERF 3 scaling, PERF 5 networking)",
+        "Explains WHY these questions matter for 100k concurrent players (latency sensitivity, burst scaling, compute-bound game loops)",
+        "Provides abbreviated facilitator questions — quick-hit versions, not full cards",
+        "Makes a clear recommendation about Sustainability (skip/defer vs quick 5-min pass)",
+        "Respects the 20-minute constraint — does not produce a full pillar's worth of content",
+        "Acknowledges the trade-off of reduced coverage and suggests documenting what was skipped"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Generate a debrief summary. During the session we found: no multi-AZ for the database, no WAF, shared SSH keys for all developers, deployments are manual rsync to production, no monitoring dashboards, and the team said 'we test backups annually.' The workload is a B2B SaaS invoicing platform.",
+      "expected_output": "A structured facilitator debrief with findings by severity, verification items, prioritized improvement plan, and flagged follow-up areas.",
+      "assertions": [
+        "Findings are categorized by severity: 🔴 High Risk items include single-AZ DB, shared SSH keys, no WAF, manual deployments",
+        "Includes 'Answers that need verification' section — flags 'annual backup testing' for evidence request",
+        "Improvement plan is prioritized by impact and effort (SSH keys and WAF are quick wins; multi-AZ is higher effort)",
+        "Acknowledges what the team is doing right (if anything inferable) or states nothing positive was identified",
+        "Identifies any pillars/questions that were not covered and need follow-up",
+        "Output is in the debrief format specified by the skill (severity groups, verification, improvement order, skipped items)"
+      ],
+      "process_assertions": [
+        "Debrief is based on the facilitator's session notes — does not invent findings beyond what was reported",
+        "B2B SaaS context shapes the severity assessment (customer data, SLA implications)",
+        "Manual deployment flagged under both Operational Excellence (no CI/CD) and Reliability (human error risk)"
+      ]
+    }
+  ]
+}

--- a/skills/wafr-facilitator/evals/triggering.json
+++ b/skills/wafr-facilitator/evals/triggering.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "wafr-facilitator",
+  "prompts": [
+    {"text": "help me facilitate a WAFR with my customer tomorrow", "should_trigger": true},
+    {"text": "prepare questions for a Well-Architected review session", "should_trigger": true},
+    {"text": "I'm running a WA review with a customer, generate facilitator questions", "should_trigger": true},
+    {"text": "create a facilitation guide for a WAFR on a SaaS workload", "should_trigger": true},
+    {"text": "here's our architecture diagram, help me prepare WAFR questions", "should_trigger": true},
+    {"text": "generate conversational questions for each WA pillar for a gaming workload", "should_trigger": true},
+    {"text": "I need probing follow-ups for the Security pillar of a fintech workload", "should_trigger": true},
+    {"text": "prepare a WAFR session plan for a multi-tenant ECS application", "should_trigger": true},
+    {"text": "help me debrief after a WA review session, here are my notes", "should_trigger": true},
+    {"text": "the customer said they don't have backups, what should I probe next", "should_trigger": true},
+    {"text": "do a full Well-Architected review of my codebase", "should_trigger": false},
+    {"text": "analyze my Terraform for WA best practices", "should_trigger": false},
+    {"text": "teach me the Well-Architected pillars", "should_trigger": false},
+    {"text": "generate guardrails for my AWS account", "should_trigger": false},
+    {"text": "create an ADR for our database choice", "should_trigger": false},
+    {"text": "assess my workload against all 57 WA questions", "should_trigger": false},
+    {"text": "review my CDK code for security issues", "should_trigger": false},
+    {"text": "identify single points of failure in my infrastructure code", "should_trigger": false},
+    {"text": "optimize our AWS costs from this Terraform", "should_trigger": false},
+    {"text": "plan our migration from on-premises to AWS", "should_trigger": false}
+  ]
+}

--- a/skills/wafr-facilitator/metadata.json
+++ b/skills/wafr-facilitator/metadata.json
@@ -1,0 +1,43 @@
+{
+  "version": "1.0.0",
+  "organization": "AWS",
+  "date": "July 2026",
+  "abstract": "Help a facilitator prepare for and run a conversational Well-Architected Framework Review (WAFR) with a customer, generating tailored questions, probing follow-ups, resilience analysis, and per-pillar pre-assessments from architecture diagrams.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/userguide/running-a-wafr.html"
+  ],
+  "triggers": [
+    "help me facilitate a WAFR",
+    "prepare WAFR questions",
+    "run a Well-Architected review with a customer",
+    "WAFR facilitation",
+    "generate facilitator questions",
+    "prepare for a WA review session",
+    "conversational WA review prep",
+    "customer-facing Well-Architected review"
+  ],
+  "not_for": [
+    "automated code-based WA reviews (use wa-review instead)",
+    "learning WA concepts or generating visual artifacts (use wa-builder instead)",
+    "generating guardrails or enforcement controls (use wa-guardrails instead)",
+    "creating architecture decision records (use architecture-decision-record instead)"
+  ],
+  "metadata": {
+    "service": [
+      "well-architected"
+    ],
+    "task": [
+      "facilitate",
+      "prepare",
+      "review"
+    ],
+    "persona": [
+      "solutions-architect",
+      "technical-account-manager",
+      "well-architected-lead"
+    ],
+    "workload": [
+      "any"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
New skill that helps facilitators prepare for and run conversational Well-Architected Framework Reviews with customers — generating tailored questions, probing follow-ups, and per-pillar pre-assessments from architecture diagrams.

## Key features
- Accepts architecture diagrams (images) or text descriptions as input
- Produces data flow maps and structured pre-assessments for ALL 6 pillars:
  - **Reliability**: SEEMS failure modes + FMEA RPN scoring + data/control plane awareness
  - **Security**: SRA-aligned threat surface walkthrough
  - **Operational Excellence**: ORR readiness assessment
  - **Performance Efficiency**: bottleneck detection + mechanical sympathy
  - **Cost Optimization**: cost signal analysis (waste, commitments, data transfer)
  - **Sustainability**: utilization & managed-services audit
- Generates facilitator cards with conversational questions per WA question
- Handles mid-session requests and post-session debrief
- References `wa-review`'s shared corpus — zero duplicate reference files

## Evals

Ran the full eval suite across all five cases plus the triggering suite. The with-skill arm improves on the baseline arm on every case that has headroom; the post-session debrief case, which the baseline could not produce at all, passes with the skill. Reproduce with `uv run python run.py --skill wafr-facilitator --verbose` from `evals/`.

Case coverage: SaaS Security pillar cards, full pre-assessment from an architecture, mid-session probing, time-constrained prioritization, post-session debrief.

## Files
- `skills/wafr-facilitator/SKILL.md` — 7-step facilitation workflow (296 lines)
- `skills/wafr-facilitator/metadata.json` — triggers, references, persona targeting
- `skills/wafr-facilitator/evals/evals.json` — 5 eval cases
- `skills/wafr-facilitator/evals/triggering.json` — 20 triggering prompts

## Test plan
- [x] Triggering evals: routes correctly, no false positives
- [x] Full evals: with-skill arm improves on baseline
- [x] Cases 2–5: all assertions pass
- [x] Case 1: partial — progressive generation produces cards, but not all of them in one shot

---

_Edited to remove measurement figures. The eval runner ships in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
