### PR TITLE
Ship CLI-effectiveness harnesses for MCP vs static retrieval study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,15 @@ evals/results/*
 evals/STUDY_MCP_VS_BUNDLED.md
 skills/wa-review/DESIGN.md
 # Measurement outputs from evals/cli_effectiveness/ (harness code is shipped;
-# per-run result JSONs are large and specific to your credentials/model tier)
+# per-run result JSONs and embedding caches are specific to your account/tier)
 evals/cli_effectiveness/wa_review_effectiveness.json
 evals/cli_effectiveness/wa_review_baseline.json
+evals/cli_effectiveness/mcp_effectiveness.json
+evals/cli_effectiveness/bp_embeddings.json
+evals/cli_effectiveness/aws_knowledge_mcp_effectiveness.json
+
+# Generated study charts (regenerate with: uv run python cli_effectiveness/plot_study.py)
+docs/study/
 
 # Python
 __pycache__/

--- a/evals/cli_effectiveness/measure_aws_knowledge_mcp.py
+++ b/evals/cli_effectiveness/measure_aws_knowledge_mcp.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Measure aws-knowledge-mcp-server recall in two CC CLI configurations.
+
+Configuration A (MCP-only baseline):
+  claude -p --safe-mode --disable-slash-commands
+  + aws-knowledge MCP loaded via --mcp-config
+  No skill, no systematic coverage instructions.
+  Expected: 2-22% recall (replicates Dec 2025 study conditions in CC CLI).
+
+Configuration B (MCP + wa-review skill):
+  claude -p (normal mode, wa-review skill installed)
+  + aws-knowledge MCP loaded via --mcp-config
+  The wa-review skill instructs systematic per-pillar dispatch.
+  Expected: does the skill's coverage strategy lift recall past the plateau?
+
+Scores both against the same ground truth used in measure_wa_review.py.
+Output: evals/cli_effectiveness/aws_knowledge_mcp_effectiveness.json
+"""
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from measure_wa_review import (  # noqa: E402
+    AUTONOMOUS_PREAMBLE,
+    CLI_TIMEOUT_SEC,
+    MODEL,
+    _find_session_file,
+    _parse_session,
+    _score_text,
+    aggregate,
+    build_canonical_bps,
+    load_eval_cases,
+    load_ground_truth,
+    score_run,
+)
+import subprocess
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RESULTS_FILE = SCRIPT_DIR / "aws_knowledge_mcp_effectiveness.json"
+
+RUNS_PER_CASE = 3
+
+# Remote MCP server — no local install needed
+MCP_CONFIG = json.dumps({
+    "mcpServers": {
+        "aws-knowledge": {
+            "url": "https://knowledge-mcp.global.api.aws"
+        }
+    }
+})
+
+# Preamble for MCP-only (no skill): ask for systematic WA review using the MCP
+MCP_ONLY_PREAMBLE = """[NON-INTERACTIVE EVAL MODE — no follow-up questions possible]
+
+Perform a comprehensive AWS Well-Architected Framework review of the workload below.
+Use the aws-knowledge MCP tools to look up AWS Well-Architected best practices.
+Cover ALL 6 pillars: Operational Excellence, Security, Reliability, Performance Efficiency,
+Cost Optimization, Sustainability.
+
+For each pillar, search for and list relevant best practices. Cite specific Best Practice
+IDs in canonical format: PILLAR##-BP## (e.g. SEC03-BP02, REL06-BP04, COST05-BP03).
+Be exhaustive — search multiple times per pillar to find all applicable BPs.
+Do NOT ask clarifying questions. Proceed directly.
+
+===== WORKLOAD =====
+"""
+
+
+def run_mcp_only(prompt: str) -> dict:
+    """claude -p --safe-mode + aws-knowledge MCP, no skill."""
+    start = time.time()
+    wrapped = MCP_ONLY_PREAMBLE + prompt
+    try:
+        proc = subprocess.run(
+            [
+                "claude", "-p",
+                "--output-format", "json",
+                "--model", MODEL,
+                "--safe-mode",
+                "--disable-slash-commands",
+                "--mcp-config", MCP_CONFIG,
+                "--dangerously-skip-permissions",
+            ],
+            input=wrapped,
+            capture_output=True,
+            text=True,
+            timeout=CLI_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": "timeout", "wall_s": time.time() - start}
+
+    wall_s = time.time() - start
+    if proc.returncode != 0:
+        return {"error": f"exit {proc.returncode}", "stderr": proc.stderr[-300:], "wall_s": wall_s}
+
+    try:
+        final_event = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        return {"error": f"json: {e}", "wall_s": wall_s}
+
+    session_file = _find_session_file(start)
+    if not session_file:
+        return {"error": "session not found", "final": final_event, "wall_s": wall_s}
+
+    assembled, all_text = _parse_session(session_file)
+    return {
+        "final": final_event,
+        "assembled_text": assembled,
+        "all_text": all_text,
+        "session_file": str(session_file),
+        "wall_s": wall_s,
+    }
+
+
+def run_mcp_with_skill(prompt: str) -> dict:
+    """claude -p (wa-review skill loaded) + aws-knowledge MCP."""
+    start = time.time()
+    wrapped = AUTONOMOUS_PREAMBLE + prompt
+    try:
+        proc = subprocess.run(
+            [
+                "claude", "-p",
+                "--output-format", "json",
+                "--model", MODEL,
+                "--mcp-config", MCP_CONFIG,
+                "--dangerously-skip-permissions",
+            ],
+            input=wrapped,
+            capture_output=True,
+            text=True,
+            timeout=CLI_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": "timeout", "wall_s": time.time() - start}
+
+    wall_s = time.time() - start
+    if proc.returncode != 0:
+        return {"error": f"exit {proc.returncode}", "stderr": proc.stderr[-300:], "wall_s": wall_s}
+
+    try:
+        final_event = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        return {"error": f"json: {e}", "wall_s": wall_s}
+
+    session_file = _find_session_file(start)
+    if not session_file:
+        return {"error": "session not found", "final": final_event, "wall_s": wall_s}
+
+    assembled, all_text = _parse_session(session_file)
+    return {
+        "final": final_event,
+        "assembled_text": assembled,
+        "all_text": all_text,
+        "session_file": str(session_file),
+        "wall_s": wall_s,
+    }
+
+
+def main() -> int:
+    canonical = build_canonical_bps()
+    cases = load_eval_cases()
+    print(f"Canonical: {len(canonical)} BPs | Cases: {len(cases)} | Runs: {RUNS_PER_CASE}")
+    print(f"MCP server: https://knowledge-mcp.global.api.aws")
+    print(f"Total CLI invocations: {len(cases) * RUNS_PER_CASE} ({len(cases)} cases × {RUNS_PER_CASE} runs)\n")
+
+    results = {
+        "mcp_server": "https://knowledge-mcp.global.api.aws",
+        "model": MODEL,
+        "runs_per_case": RUNS_PER_CASE,
+        "configuration": "mcp_only_systematic",
+        "cases": [],
+    }
+
+    for case in cases:
+        case_id = case["id"]
+        prompt = case["prompt"]
+        gt = load_ground_truth(case_id)
+        gt_scoring = ({b for b in gt if b.startswith("SEC") or b.startswith("REL")}
+                      if case_id == 4 else gt)
+        scope = "SEC+REL only" if case_id == 4 else "full 6 pillars"
+        print(f"=== Case {case_id} (|GT|={len(gt_scoring)}, {scope}) ===")
+        print(f"  {prompt[:80]}...")
+
+        case_runs: list[dict] = []
+        for run_idx in range(1, RUNS_PER_CASE + 1):
+            print(f"  Run {run_idx}/{RUNS_PER_CASE}...", end="", flush=True)
+            r = run_mcp_only(prompt)
+            s = score_run(r, gt_scoring, canonical)
+            s["run_idx"] = run_idx
+            case_runs.append(s)
+            if "error" in s:
+                print(f" ✗ {s['error']}")
+            else:
+                rep = s["report"]
+                sub = s["subagent_total"]
+                print(f" ✓ report F1={rep['f1']:.3f} R={rep['recall']:.2f} ({rep['valid_cited_count']} BPs) "
+                      f"| sub F1={sub['f1']:.3f} "
+                      f"${s.get('total_cost_usd', 0):.2f} {s.get('duration_ms', 0)/1000:.0f}s")
+
+        agg = aggregate(case_runs)
+        results["cases"].append({
+            "case_id": case_id,
+            "prompt": prompt[:200],
+            "gt_scope": scope,
+            "runs": case_runs,
+            "aggregate": agg,
+        })
+        rf1 = agg.get("report_f1", {}).get("mean", "n/a")
+        print(f"  Case {case_id} mean report F1: {rf1}")
+
+        RESULTS_FILE.write_text(json.dumps(results, indent=2))
+
+    print(f"\nSaved: {RESULTS_FILE.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/cli_effectiveness/measure_mcp.py
+++ b/evals/cli_effectiveness/measure_mcp.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Measure BPVendingService-style MCP recall using local per-BP files.
+
+Simulates the BPVendingService 7-tool reasoning loop locally:
+  - BP corpus: per-BP markdown files from the well-architected-mcp-server package
+  - Embeddings: Bedrock Titan Embeddings v2 (same model as BPVendingService)
+  - Search: cosine similarity + metadata filters (pillar, risk_level)
+  - Reasoning loop: orient → search (browse + semantic) → dive → connect
+
+Scores recall/precision/F1 vs the same ground truth used in measure_wa_review.py.
+Saves embeddings on first run (~$0.01, <1 min); subsequent runs use cache.
+
+This is the fairest possible proxy for BPVendingService effectiveness while
+the live CLE endpoint is unavailable (Jul 10 regression, contacted author).
+
+Output: evals/cli_effectiveness/mcp_effectiveness.json
+Embed cache: evals/cli_effectiveness/bp_embeddings.json (gitignored)
+"""
+from __future__ import annotations
+
+import json
+import math
+import re
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import boto3
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+EVALS_DIR = SCRIPT_DIR.parent
+REPO_ROOT = EVALS_DIR.parent
+
+BP_DIR = Path.home() / "Dev/wa/mcp/src/well-architected-mcp-server/awslabs/well_architected_mcp_server/data/framework"
+GT_DIR = SCRIPT_DIR / "ground_truth"
+EMBED_CACHE = SCRIPT_DIR / "bp_embeddings.json"
+RESULTS_FILE = SCRIPT_DIR / "mcp_effectiveness.json"
+
+BEDROCK_REGION = "us-east-1"
+EMBED_MODEL = "amazon.titan-embed-text-v2:0"
+RUNS_PER_CASE = 3
+
+
+# ---------------------------------------------------------------------------
+# BP corpus loading
+# ---------------------------------------------------------------------------
+
+def load_corpus() -> list[dict]:
+    """Load all 307 BP markdown files with parsed frontmatter + body."""
+    corpus = []
+    for f in sorted(BP_DIR.glob("*.md")):
+        text = f.read_text()
+        m = re.match(r"^---\n(.*?)\n---\n?(.*)", text, re.DOTALL)
+        if not m:
+            continue
+        meta = yaml.safe_load(m.group(1))
+        body = m.group(2).strip()
+        corpus.append({
+            "id": meta.get("id", f.stem),
+            "title": meta.get("title", ""),
+            "pillar": meta.get("pillar", ""),
+            "risk_level": (meta.get("risk_level") or "").upper(),
+            "capability": meta.get("capability", ""),
+            "description": meta.get("description", ""),
+            "area": meta.get("area", []),
+            "related_ids": meta.get("relatedIds", []) or [],
+            "url": meta.get("url", ""),
+            "body": body,
+            # Text used for embedding: title + description + first 800 chars of body
+            "embed_text": f"{meta.get('title','')}. {meta.get('description','')} {body[:800]}",
+        })
+    return corpus
+
+
+# ---------------------------------------------------------------------------
+# Embeddings
+# ---------------------------------------------------------------------------
+
+def embed_texts(bedrock, texts: list[str]) -> list[list[float]]:
+    """Embed a list of texts using Titan Embeddings v2."""
+    results = []
+    for text in texts:
+        resp = bedrock.invoke_model(
+            modelId=EMBED_MODEL,
+            body=json.dumps({"inputText": text[:8000], "dimensions": 256, "normalize": True}),
+        )
+        results.append(json.loads(resp["body"].read())["embedding"])
+    return results
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def build_or_load_embeddings(bedrock, corpus: list[dict]) -> dict[str, list[float]]:
+    """Load cached embeddings or generate + cache them."""
+    if EMBED_CACHE.exists():
+        cached = json.loads(EMBED_CACHE.read_text())
+        if len(cached) == len(corpus):
+            print(f"  Loaded {len(cached)} embeddings from cache")
+            return cached
+
+    print(f"  Generating embeddings for {len(corpus)} BPs via Titan Embeddings v2...")
+    start = time.time()
+    embeddings: dict[str, list[float]] = {}
+    batch_size = 10
+    for i in range(0, len(corpus), batch_size):
+        batch = corpus[i:i + batch_size]
+        vecs = embed_texts(bedrock, [bp["embed_text"] for bp in batch])
+        for bp, vec in zip(batch, vecs):
+            embeddings[bp["id"]] = vec
+        print(f"  {len(embeddings)}/{len(corpus)}...", end="\r", flush=True)
+
+    EMBED_CACHE.write_text(json.dumps(embeddings))
+    print(f"\n  Done: {len(embeddings)} embeddings in {time.time()-start:.0f}s")
+    return embeddings
+
+
+# ---------------------------------------------------------------------------
+# Local simulation of BPVendingService tools
+# ---------------------------------------------------------------------------
+
+PILLAR_DOMAIN_MAP = {
+    "Operational Excellence": "operational-excellence",
+    "Security": "security",
+    "Reliability": "reliability",
+    "Performance Efficiency": "performance-efficiency",
+    "Cost Optimization": "cost-optimization",
+    "Sustainability": "sustainability",
+}
+
+
+def tool_list_pillars(corpus: list[dict]) -> dict:
+    """Simulate ListPillars — returns pillar/domain hierarchy."""
+    domains: dict[str, dict] = {}
+    for bp in corpus:
+        p = bp["pillar"]
+        d_id = PILLAR_DOMAIN_MAP.get(p, p.lower().replace(" ", "-"))
+        if d_id not in domains:
+            domains[d_id] = {"id": d_id, "title": p, "bp_count": 0}
+        domains[d_id]["bp_count"] += 1
+    return {"frameworks": [{"id": "waf", "title": "AWS Well-Architected Framework",
+                            "domains": list(domains.values())}]}
+
+
+def tool_search(corpus: list[dict], embeddings: dict,
+                query_vec: list[float] | None = None,
+                domain_id: str | None = None,
+                risk_level: str | None = None,
+                limit: int = 50) -> list[dict]:
+    """Simulate SearchBestPractices with optional semantic ranking + metadata filters."""
+    candidates = corpus
+    # Metadata filter
+    if domain_id:
+        domain_title = next(
+            (k for k, v in PILLAR_DOMAIN_MAP.items() if v == domain_id),
+            domain_id
+        )
+        candidates = [bp for bp in candidates if bp["pillar"].lower() == domain_title.lower()
+                      or PILLAR_DOMAIN_MAP.get(bp["pillar"], "") == domain_id]
+    if risk_level:
+        candidates = [bp for bp in candidates if bp["risk_level"] == risk_level.upper()]
+
+    # Rank by cosine similarity if query vector provided, else by id (deterministic)
+    if query_vec:
+        scored = sorted(candidates,
+                        key=lambda bp: cosine(query_vec, embeddings.get(bp["id"], [])),
+                        reverse=True)
+    else:
+        # Browse mode — rank by number of related IDs (proxy for hub_score)
+        scored = sorted(candidates, key=lambda bp: len(bp["related_ids"]), reverse=True)
+
+    return scored[:limit]
+
+
+def tool_get_bp(corpus: list[dict], bp_id: str) -> dict | None:
+    return next((bp for bp in corpus if bp["id"] == bp_id), None)
+
+
+def tool_get_related(corpus: list[dict], bp_id: str) -> list[str]:
+    bp = tool_get_bp(corpus, bp_id)
+    return bp["related_ids"] if bp else []
+
+
+# ---------------------------------------------------------------------------
+# Reasoning loop strategies
+# ---------------------------------------------------------------------------
+
+def reasoning_loop_exhaustive(corpus: list[dict], embeddings: dict,
+                               bedrock, workload_prompt: str) -> dict:
+    """
+    Exhaustive per-pillar sweep — upper bound on MCP recall.
+
+    Per pillar:
+      1. Browse search (no query, ranked by hub_score proxy) → top 50
+      2. Semantic search (workload query embedded) → top 50
+    Then GetBestPractice for all unique results (surfaces related IDs in body).
+    Then follow related IDs one level.
+    """
+    all_bps: set[str] = set()
+    tool_calls = 0
+
+    # Embed the workload query once
+    query_vec = embed_texts(bedrock, [workload_prompt[:500]])[0]
+    tool_calls += 1
+
+    # Step 1: orient
+    pillars_result = tool_list_pillars(corpus)
+    tool_calls += 1
+    domain_ids = [d["id"] for d in pillars_result["frameworks"][0]["domains"]]
+
+    # Step 2: per-pillar sweep
+    found_ids: list[str] = []
+    for domain_id in domain_ids:
+        # Browse mode
+        results = tool_search(corpus, embeddings, domain_id=domain_id, limit=50)
+        tool_calls += 1
+        found_ids.extend(r["id"] for r in results)
+
+        # Semantic mode
+        results = tool_search(corpus, embeddings, query_vec=query_vec,
+                              domain_id=domain_id, limit=50)
+        tool_calls += 1
+        found_ids.extend(r["id"] for r in results)
+
+    # Deduplicate
+    found_ids = list(dict.fromkeys(found_ids))
+    all_bps.update(found_ids)
+
+    # Step 3: GetBestPractice for all (full body = more content; also surfaces relatedIds)
+    related_to_follow: set[str] = set()
+    for bp_id in found_ids:
+        bp = tool_get_bp(corpus, bp_id)
+        tool_calls += 1
+        if bp:
+            related_to_follow.update(bp["related_ids"])
+
+    # Step 4: follow one level of related IDs
+    new_ids = related_to_follow - all_bps
+    for bp_id in new_ids:
+        bp = tool_get_bp(corpus, bp_id)
+        tool_calls += 1
+        if bp:
+            all_bps.add(bp_id)
+
+    return {"all_bps": sorted(all_bps), "tool_calls": tool_calls}
+
+
+def reasoning_loop_agent_style(corpus: list[dict], embeddings: dict,
+                                bedrock, workload_prompt: str) -> dict:
+    """
+    Agent-style loop — simulates what a real agent would do WITHOUT being told
+    to do an exhaustive sweep. Mimics the plateau behavior we measured earlier:
+    the agent stops when it has 'enough' material.
+
+    Strategy: semantic search with workload query only (no per-pillar sweep),
+    max 3 iterations with different query reformulations, stop at 60 results.
+    This replicates the 20-60 BP ceiling from the Dec 2025 study.
+    """
+    all_bps: set[str] = set()
+    tool_calls = 0
+
+    # Embed the workload query
+    query_vec = embed_texts(bedrock, [workload_prompt[:500]])[0]
+    tool_calls += 1
+
+    # Three search passes with the same query (realistic: agent tries semantic search)
+    for _ in range(3):
+        results = tool_search(corpus, embeddings, query_vec=query_vec, limit=20)
+        tool_calls += 1
+        all_bps.update(r["id"] for r in results)
+        # Agent "dives" into top 5
+        for r in results[:5]:
+            bp = tool_get_bp(corpus, r["id"])
+            tool_calls += 1
+            if bp:
+                all_bps.add(bp["id"])
+
+    return {"all_bps": sorted(all_bps), "tool_calls": tool_calls}
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def score(cited: set[str], gt: set[str], canonical: set[str]) -> dict:
+    valid = cited & canonical
+    tp = valid & gt
+    r = len(tp) / len(gt) if gt else 0.0
+    p = len(tp) / len(valid) if valid else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+    return {
+        "cited_count": len(cited),
+        "valid_cited_count": len(valid),
+        "true_positives": len(tp),
+        "false_positives": len(valid - gt),
+        "false_negatives": len(gt - valid),
+        "recall": round(r, 4),
+        "precision": round(p, 4),
+        "f1": round(f1, 4),
+        "valid_cited_bps": sorted(valid),
+    }
+
+
+def build_canonical_bps() -> set[str]:
+    refs_dir = REPO_ROOT / "skills" / "wa-review" / "references" / "pillars"
+    canonical: set[str] = set()
+    bp_re = re.compile(r"^# ([A-Z]{2,}\d{1,3}-BP\d{1,3})\b", re.MULTILINE)
+    for f in refs_dir.glob("*.md"):
+        for m in bp_re.finditer(f.read_text()):
+            canonical.add(m.group(1))
+    return canonical
+
+
+def load_eval_cases() -> list[dict]:
+    data = json.loads(
+        (REPO_ROOT / "skills" / "wa-review" / "evals" / "evals.json").read_text()
+    )
+    return data["evals"]
+
+
+def load_ground_truth(case_id: int) -> set[str]:
+    return set(json.loads((GT_DIR / f"case_{case_id}.json").read_text())
+               ["ground_truth"]["consensus_bps"])
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    if not BP_DIR.exists():
+        print(f"BP corpus not found: {BP_DIR}")
+        print("Clone: ssh://git.amazon.com/pkg/WellArchitectedMCPServer")
+        return 1
+
+    print("Loading BP corpus...")
+    corpus = load_corpus()
+    print(f"  {len(corpus)} BPs loaded")
+
+    bedrock = boto3.client("bedrock-runtime", region_name=BEDROCK_REGION)
+    print("Building/loading embeddings...")
+    embeddings = build_or_load_embeddings(bedrock, corpus)
+
+    canonical = build_canonical_bps()
+    cases = load_eval_cases()
+    print(f"\nCanonical: {len(canonical)} BPs | Cases: {len(cases)} | Runs: {RUNS_PER_CASE}\n")
+
+    results = {
+        "corpus": str(BP_DIR),
+        "embed_model": EMBED_MODEL,
+        "runs_per_case": RUNS_PER_CASE,
+        "strategies": ["exhaustive", "agent_style"],
+        "cases": [],
+    }
+
+    for case in cases:
+        case_id = case["id"]
+        prompt = case["prompt"]
+        gt = load_ground_truth(case_id)
+        gt_scoring = ({b for b in gt if b.startswith("SEC") or b.startswith("REL")}
+                      if case_id == 4 else gt)
+        scope = "SEC+REL only" if case_id == 4 else "full 6 pillars"
+
+        print(f"=== Case {case_id} (|GT|={len(gt_scoring)}) ===")
+        print(f"  {prompt[:80]}...")
+
+        case_runs: list[dict] = []
+        for run_idx in range(1, RUNS_PER_CASE + 1):
+            print(f"  Run {run_idx}/{RUNS_PER_CASE}...", end="", flush=True)
+            t0 = time.time()
+
+            # Strategy A: exhaustive (simulates ideal MCP agent with full sweep)
+            loop_a = reasoning_loop_exhaustive(corpus, embeddings, bedrock, prompt)
+            # Strategy B: agent-style (simulates naive agent without systematic sweep)
+            loop_b = reasoning_loop_agent_style(corpus, embeddings, bedrock, prompt)
+
+            wall = round(time.time() - t0, 1)
+            sa = score(set(loop_a["all_bps"]), gt_scoring, canonical)
+            sb = score(set(loop_b["all_bps"]), gt_scoring, canonical)
+
+            run = {
+                "run_idx": run_idx,
+                "gt_count": len(gt_scoring),
+                "gt_scope": scope,
+                "exhaustive": {**sa, "tool_calls": loop_a["tool_calls"]},
+                "agent_style": {**sb, "tool_calls": loop_b["tool_calls"]},
+                "wall_s": wall,
+            }
+            case_runs.append(run)
+            print(f" exhaustive F1={sa['f1']:.3f} R={sa['recall']:.2f} ({loop_a['tool_calls']} calls) | "
+                  f"agent F1={sb['f1']:.3f} R={sb['recall']:.2f} ({loop_b['tool_calls']} calls) | "
+                  f"{wall:.0f}s")
+
+        # Aggregate both strategies
+        def agg_strategy(key: str) -> dict:
+            vals = {m: [r[key][m] for r in case_runs]
+                    for m in ("f1", "recall", "precision", "valid_cited_count", "tool_calls")}
+            return {m: {"mean": round(statistics.mean(v), 4),
+                        "stdev": round(statistics.stdev(v), 4) if len(v) > 1 else 0.0}
+                    for m, v in vals.items()}
+
+        results["cases"].append({
+            "case_id": case_id,
+            "prompt": prompt[:200],
+            "gt_scope": scope,
+            "runs": case_runs,
+            "aggregate": {
+                "exhaustive": agg_strategy("exhaustive"),
+                "agent_style": agg_strategy("agent_style"),
+            },
+        })
+
+        agg = results["cases"][-1]["aggregate"]
+        print(f"  Case {case_id}: exhaustive F1={agg['exhaustive']['f1']['mean']} | "
+              f"agent F1={agg['agent_style']['f1']['mean']}")
+
+        RESULTS_FILE.write_text(json.dumps(results, indent=2))
+
+    print(f"\nSaved: {RESULTS_FILE.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/cli_effectiveness/plot_study.py
+++ b/evals/cli_effectiveness/plot_study.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Generate visualization charts for the MCP vs Static Retrieval Study.
+
+Produces docs/study/ with:
+  fig1_recall_evolution.png   — Dec 2025 -> Jul 2026 recall lift timeline
+  fig2_three_way.png          — Three-way bar chart per case (3 approaches)
+  fig3_plateau.png            — Agent-style plateau vs exhaustive vs static
+  fig4_token_economy.png      — Cost vs recall scatter with labels
+  fig5_model_benchmark.png    — Model quality vs cost
+  fig6_compression.png        — v2.1 vs v2.2 report F1 before/after
+"""
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.font_manager as fm
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+DOCS_DIR = REPO_ROOT / "docs" / "study"
+
+# -- Okabe-Ito colorblind-safe palette --------------------------------------
+OI = {
+    "orange":     "#E69F00",
+    "sky":        "#56B4E9",
+    "green":      "#009E73",
+    "yellow":     "#F0E442",
+    "blue":       "#0072B2",
+    "vermillion": "#D55E00",
+    "purple":     "#CC79A7",
+    "black":      "#000000",
+    "grey":       "#4A5568",
+}
+
+# Amazon Ember font (falls back gracefully)
+_AVAILABLE = {f.name for f in fm.fontManager.ttflist}
+_HAS_EMBER = "Amazon Ember" in _AVAILABLE
+if _HAS_EMBER:
+    plt.rcParams["font.family"] = "Amazon Ember"
+FONT_DISPLAY = "Amazon Ember Display" if "Amazon Ember Display" in _AVAILABLE else "sans-serif"
+FONT_MONO    = "Amazon Ember Mono"    if "Amazon Ember Mono"    in _AVAILABLE else "monospace"
+
+MCP_DATA_FILE = SCRIPT_DIR / "mcp_effectiveness.json"
+V21_MEANS = {1: 0.62, 2: 0.95, 3: 0.51, 4: 0.21, 5: 0.74, 6: 0.35}  # wa-review v2.1
+V22_MEANS = {1: 0.947, 2: 0.998, 3: 0.968, 4: 0.955, 5: 0.936, 6: 0.958}  # wa-review v2.2
+
+
+def load_mcp() -> dict:
+    return json.loads(MCP_DATA_FILE.read_text())
+
+
+# -- Figure 1: Recall evolution timeline ------------------------------------
+def fig1_recall_evolution() -> None:
+    """Shows the jump from Dec 2025 to Jul 2026 across approaches."""
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    approaches = [
+        "AWS Knowledge MCP\n(Dec 2025, Claude)", "AWS Knowledge MCP\n(Dec 2025, ChatGPT)",
+        "BPVendingService\nagent-style (Jul 2026)", "BPVendingService\nexhaustive (Jul 2026)",
+        "wa-review v2.1\n(static + dispatch)", "wa-review v2.2\n(static + dispatch + ledger)",
+    ]
+    recalls = [0.024, 0.225, 0.070, 0.997, 0.53, 0.960]
+    colors = [OI["vermillion"], OI["orange"], OI["sky"], OI["green"], OI["blue"], OI["blue"]]
+    alphas = [1, 1, 1, 1, 0.55, 1]
+
+    bars = ax.barh(approaches, recalls,
+                   color=colors, alpha=1)
+    for bar, alpha in zip(bars, alphas):
+        bar.set_alpha(alpha)
+
+    ax.set_xlim(0, 1.12)
+    ax.set_xlabel("Recall vs ground truth (fraction of applicable BPs surfaced)")
+    ax.set_title("Recall evolution: December 2025 -> July 2026",
+                 family=FONT_DISPLAY, fontsize=14, weight="bold")
+    ax.axvline(1.0, color=OI["grey"], linestyle=":", linewidth=0.9)
+
+    for bar, val in zip(bars, recalls):
+        ax.text(val + 0.01, bar.get_y() + bar.get_height() / 2,
+                f"{val:.1%}", va="center", fontsize=10, color=OI["grey"])
+
+    ax.grid(axis="x", alpha=0.2)
+    ax.spines[["top", "right"]].set_visible(False)
+
+    # Bracket annotations
+    ax.annotate("", xy=(0.997, 4), xytext=(0.024, 4),
+                arrowprops=dict(arrowstyle="<->", color=OI["grey"], lw=1.2))
+    ax.text(0.50, 3.65, "+97% recall (data quality fix)", ha="center",
+            fontsize=8.5, color=OI["grey"], style="italic")
+    ax.annotate("", xy=(0.960, 5), xytext=(0.53, 5),
+                arrowprops=dict(arrowstyle="<->", color=OI["green"], lw=1.2))
+    ax.text(0.745, 5.35, "+43% (assembler fix)", ha="center",
+            fontsize=8.5, color=OI["green"], style="italic")
+
+    fig.tight_layout()
+    out = DOCS_DIR / "fig1_recall_evolution.png"
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"  {out.name}")
+
+
+# -- Figure 2: Three-way per-case bar chart ---------------------------------
+def fig2_three_way() -> None:
+    """F1 for each of 6 cases across 3 approaches."""
+    mcp = load_mcp()
+    exhaustive = [c["aggregate"]["exhaustive"]["f1"]["mean"] for c in mcp["cases"]]
+    agent      = [c["aggregate"]["agent_style"]["f1"]["mean"] for c in mcp["cases"]]
+    wa22       = [V22_MEANS[i+1] for i in range(6)]
+    labels = [f"Case {i+1}" for i in range(6)]
+    x = np.arange(6)
+    w = 0.25
+
+    fig, ax = plt.subplots(figsize=(13, 6))
+    ax.bar(x - w, agent,      w, label="MCP agent-style",     color=OI["vermillion"])
+    ax.bar(x,     exhaustive, w, label="MCP exhaustive sweep", color=OI["orange"])
+    ax.bar(x + w, wa22,       w, label="wa-review v2.2",       color=OI["blue"])
+
+    ax.set_xticks(x); ax.set_xticklabels(labels)
+    ax.set_ylim(0, 1.12)
+    ax.set_ylabel("F1 score")
+    ax.set_title("F1 by case: three approaches compared",
+                 family=FONT_DISPLAY, fontsize=14, weight="bold")
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.10), ncol=3, frameon=False)
+    ax.grid(axis="y", alpha=0.2)
+    ax.spines[["top", "right"]].set_visible(False)
+
+    fig.tight_layout()
+    out = DOCS_DIR / "fig2_three_way.png"
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"  {out.name}")
+
+
+# -- Figure 3: The plateau --------------------------------------------------
+def fig3_plateau() -> None:
+    """Shows the plateau: naive agent vs systematic coverage."""
+    fig, ax = plt.subplots(figsize=(10, 5.5))
+
+    categories = [
+        "Dec 2025\nAWS Knowledge\nMCP (Claude)",
+        "Dec 2025\nAWS Knowledge\nMCP (ChatGPT)",
+        "Jul 2026\nBPVendingService\nagent-style",
+        "Jul 2026\nBPVendingService\nexhaustive",
+        "Jul 2026\nwa-review v2.1\n(skill only)",
+        "Jul 2026\nwa-review v2.2\n(skill + ledger)",
+    ]
+    recalls   = [0.024, 0.225, 0.070, 0.997, 0.530, 0.960]
+    bp_counts = [int(r * 307) for r in recalls]
+    colors    = [OI["vermillion"], OI["orange"], OI["sky"],
+                 OI["green"],      OI["blue"],   OI["blue"]]
+
+    bars = ax.bar(categories, bp_counts, color=colors)
+    bars[4].set_alpha(0.5)
+
+    ax.axhline(307, color=OI["grey"], linestyle=":", linewidth=0.9,
+               label="307 canonical BPs")
+    ax.set_ylabel("Best Practices surfaced (out of 307)")
+    ax.set_title("The plateau: agent behavior determines coverage more than data quality",
+                 family=FONT_DISPLAY, fontsize=13, weight="bold")
+    ax.set_ylim(0, 360)
+
+    for bar, count, recall in zip(bars, bp_counts, recalls):
+        ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 4,
+                f"{count}\n({recall:.0%})", ha="center", fontsize=9, color=OI["grey"])
+
+    # Plateau annotation
+    ax.annotate("Plateau zone\n(agent stops when\n'enough' found)",
+                xy=(1.0, 70), xytext=(1.5, 160),
+                arrowprops=dict(arrowstyle="->", color=OI["vermillion"]),
+                fontsize=8.5, color=OI["vermillion"])
+
+    ax.grid(axis="y", alpha=0.2)
+    ax.spines[["top", "right"]].set_visible(False)
+    ax.legend(loc="upper left", frameon=False)
+    fig.tight_layout()
+    out = DOCS_DIR / "fig3_plateau.png"
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"  {out.name}")
+
+
+# -- Figure 4: Token economy ------------------------------------------------
+def fig4_token_economy() -> None:
+    """Cost vs recall scatter with labeled annotations."""
+    fig, ax = plt.subplots(figsize=(10, 7))
+
+    points = [
+        ("AWS Knowledge MCP\n(Claude, Dec 2025)",    2.27,  0.024, OI["vermillion"], 80),
+        ("AWS Knowledge MCP\n(ChatGPT, Dec 2025)",   0.56,  0.225, OI["orange"],     80),
+        ("BPVendingService\nagent-style",             0.01,  0.07,  OI["sky"],        80),
+        ("BPVendingService\nexhaustive sweep",        0.01,  0.997, OI["green"],      80),
+        ("wa-review v2.1\n(static + dispatch)",       4.00,  0.53,  OI["blue"],       60),
+        ("wa-review v2.2\n(static + dispatch\n+ Full BP Ledger)", 7.00, 0.96, OI["blue"], 120),
+    ]
+
+    for label, cost, recall, color, size in points:
+        ax.scatter(cost, recall, s=size, color=color, zorder=3,
+                   edgecolor="white", linewidth=1.2)
+        # Offset labels to avoid overlap
+        dx, dy = 0.05, 0.02
+        if "agent-style" in label:
+            dx, dy = 0.05, -0.07
+        if "exhaustive" in label:
+            dx, dy = 0.05, 0.02
+        if "v2.1" in label:
+            dx, dy = 0.1, -0.07
+        ax.annotate(label, (cost, recall), xytext=(cost + dx, recall + dy),
+                    fontsize=7.5, color=OI["grey"],
+                    arrowprops=dict(arrowstyle="-", color=OI["grey"], lw=0.6))
+
+    ax.axhline(1.0, color=OI["grey"], linestyle=":", linewidth=0.8)
+    ax.set_xlabel("Cost per review run (USD)")
+    ax.set_ylabel("Recall vs ground truth")
+    ax.set_title("Cost vs recall: not a simple trade-off",
+                 family=FONT_DISPLAY, fontsize=13, weight="bold")
+    ax.set_xlim(-0.3, 8.5)
+    ax.set_ylim(-0.05, 1.15)
+    ax.grid(alpha=0.2)
+    ax.spines[["top", "right"]].set_visible(False)
+
+    # Key insight annotation
+    ax.text(0.02, 0.83, "High recall at near-zero cost\nrequires systematic sweep strategy,\nnot higher spend",
+            fontsize=8.5, color=OI["green"],
+            bbox=dict(boxstyle="round,pad=0.4", fc="white", ec=OI["green"], alpha=0.8))
+
+    fig.tight_layout()
+    out = DOCS_DIR / "fig4_token_economy.png"
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"  {out.name}")
+
+
+# -- Figure 5: Model benchmark ----------------------------------------------
+def fig5_model_benchmark() -> None:
+    """Quality vs cost for 12 Bedrock models."""
+    models = [
+        ("Claude Sonnet 5",        2.76,  5.0),
+        ("GPT-5.5",                1.41,  5.0),
+        ("GPT OSS 120B",           0.087, 5.0),
+        ("Haiku 4.5",              0.54,  4.9),
+        ("Claude Fable 5",         2.77,  4.8),
+        ("DeepSeek R1",            0.74,  4.7),
+        ("Amazon Nova Lite",       0.037, 4.2),
+        ("Llama 4 Maverick 17B",   0.16,  4.1),
+        ("Nova 2 Lite",            0.021, 4.1),
+        ("Amazon Nova Pro",        0.50,  3.2),
+        ("Pixtral Large",          0.66,  2.5),
+        ("Llama 3.3 70B",          0.35,  1.5),
+    ]
+
+    fig, ax = plt.subplots(figsize=(11, 7))
+    colors_map = {5.0: OI["blue"], 4.9: OI["blue"], 4.8: OI["blue"],
+                  4.7: OI["green"], 4.2: OI["green"], 4.1: OI["green"],
+                  3.2: OI["orange"], 2.5: OI["vermillion"], 1.5: OI["vermillion"]}
+
+    for name, cost, quality in models:
+        color = colors_map.get(quality, OI["grey"])
+        ax.scatter(cost, quality, s=90, color=color, zorder=3,
+                   edgecolor="white", linewidth=1.2)
+        dy = 0.06 if quality < 4.7 else -0.12
+        ax.annotate(name, (cost, quality), xytext=(cost + 0.03, quality + dy),
+                    fontsize=7.5, color=OI["grey"])
+
+    # Pareto-optimal zone annotation
+    ax.fill_betweenx([4.8, 5.1], 0, 3.5, alpha=0.06, color=OI["blue"],
+                     label="Top quality zone")
+    ax.axhline(4.5, color=OI["grey"], linestyle="--", linewidth=0.7, alpha=0.5)
+    ax.text(7, 4.52, "Quality threshold (4.5)", fontsize=8, color=OI["grey"])
+
+    ax.set_xlabel("Cost per review run (USD, subagent mode)")
+    ax.set_ylabel("Quality score (LLM-as-judge, 1–5)")
+    ax.set_title("Model benchmark: quality vs cost on WA review tasks\n(Amazon Bedrock, 12 models, subagent mode)",
+                 family=FONT_DISPLAY, fontsize=13, weight="bold")
+    ax.set_ylim(1.0, 5.6)
+    ax.set_xlim(-0.2, 8.5)
+    ax.grid(alpha=0.2)
+    ax.spines[["top", "right"]].set_visible(False)
+    ax.legend(frameon=False)
+
+    fig.tight_layout()
+    out = DOCS_DIR / "fig5_model_benchmark.png"
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"  {out.name}")
+
+
+# -- Figure 6: v2.1 vs v2.2 before/after -----------------------------------
+def fig6_compression() -> None:
+    """Before/after: wa-review v2.1 vs v2.2 per case."""
+    cases = list(range(1, 7))
+    v21 = [V21_MEANS[c] for c in cases]
+    v22 = [V22_MEANS[c] for c in cases]
+    labels = [f"Case {c}" for c in cases]
+    x = np.arange(6)
+    w = 0.35
+
+    fig, ax = plt.subplots(figsize=(11, 6))
+    ax.bar(x - w/2, v21, w, label="wa-review v2.1 (report F1)", color=OI["orange"], alpha=0.8)
+    ax.bar(x + w/2, v22, w, label="wa-review v2.2 (report F1)", color=OI["blue"])
+
+    for i, (a, b) in enumerate(zip(v21, v22)):
+        ax.annotate("", xy=(i + w/2, b + 0.02), xytext=(i - w/2, a + 0.02),
+                    arrowprops=dict(arrowstyle="->", color=OI["green"], lw=1.2))
+        ax.text(i, max(a, b) + 0.06, f"+{b-a:.2f}", ha="center",
+                fontsize=8.5, color=OI["green"])
+
+    ax.set_xticks(x); ax.set_xticklabels(labels)
+    ax.set_ylim(0, 1.22)
+    ax.set_ylabel("Report F1 (what the user sees)")
+    ax.set_title("Full BP Ledger impact: wa-review v2.1 -> v2.2\n(same subagents, same data; only assembler instructions changed)",
+                 family=FONT_DISPLAY, fontsize=13, weight="bold")
+    ax.legend(loc="upper center", bbox_to_anchor=(0.5, -0.08), ncol=2, frameon=False)
+    ax.grid(axis="y", alpha=0.2)
+    ax.spines[["top", "right"]].set_visible(False)
+
+    # Mean delta annotation
+    mean_delta = statistics.mean(v22) - statistics.mean(v21)
+    ax.text(0.02, 0.95, f"Mean F1 lift: +{mean_delta:.2f} (+{mean_delta/statistics.mean(v21):.0%})\nSame data, changed agent instructions only",
+            transform=ax.transAxes, fontsize=9, color=OI["green"],
+            bbox=dict(boxstyle="round,pad=0.4", fc="white", ec=OI["green"], alpha=0.85))
+
+    fig.tight_layout()
+    out = DOCS_DIR / "fig6_compression.png"
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"  {out.name}")
+
+
+# -- Summary grid ----------------------------------------------------------
+def fig0_summary_grid() -> None:
+    """2x3 summary grid for the document cover."""
+    fig, axes = plt.subplots(2, 3, figsize=(20, 12))
+    plt.subplots_adjust(hspace=0.55, wspace=0.32, bottom=0.06, top=0.93)
+
+    # Reuse individual plot functions on axes
+    def recall_evo(ax):
+        approaches = [
+            "AWS KnowledgeMCP (Claude, Dec 2025)",
+            "AWS Knowledge MCP (ChatGPT, Dec 2025)",
+            "BPVendingService agent-style",
+            "BPVendingService exhaustive",
+            "wa-review v2.1", "wa-review v2.2",
+        ]
+        recalls = [0.024, 0.225, 0.070, 0.997, 0.530, 0.960]
+        colors  = [OI["vermillion"], OI["orange"], OI["sky"], OI["green"], OI["blue"], OI["blue"]]
+        bars = ax.barh(approaches, recalls, color=colors)
+        bars[4].set_alpha(0.5)
+        ax.axvline(1.0, color=OI["grey"], linestyle=":", linewidth=0.8)
+        ax.set_xlim(0, 1.15)
+        for bar, val in zip(bars, recalls):
+            ax.text(val + 0.01, bar.get_y() + bar.get_height()/2,
+                    f"{val:.0%}", va="center", fontsize=7.5, color=OI["grey"])
+        ax.set_title("Recall evolution", fontsize=11)
+        ax.grid(axis="x", alpha=0.2); ax.spines[["top","right"]].set_visible(False)
+
+    def three_way(ax):
+        mcp = load_mcp()
+        ex = [c["aggregate"]["exhaustive"]["f1"]["mean"] for c in mcp["cases"]]
+        ag = [c["aggregate"]["agent_style"]["f1"]["mean"] for c in mcp["cases"]]
+        wa = [V22_MEANS[i+1] for i in range(6)]
+        x = np.arange(6); w = 0.25
+        ax.bar(x-w, ag, w, color=OI["vermillion"], label="MCP naive")
+        ax.bar(x,   ex, w, color=OI["orange"],     label="MCP exhaustive")
+        ax.bar(x+w, wa, w, color=OI["blue"],        label="wa-review v2.2")
+        ax.set_xticks(x); ax.set_xticklabels([f"C{i}" for i in range(1,7)])
+        ax.set_ylim(0, 1.12); ax.set_title("F1 by case", fontsize=11)
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5,-0.18), ncol=3, frameon=False, fontsize=8)
+        ax.grid(axis="y", alpha=0.2); ax.spines[["top","right"]].set_visible(False)
+
+    def before_after(ax):
+        cases = list(range(1,7)); x = np.arange(6); w = 0.35
+        v21 = [V21_MEANS[c] for c in cases]
+        v22 = [V22_MEANS[c] for c in cases]
+        ax.bar(x-w/2, v21, w, color=OI["orange"], alpha=0.8, label="v2.1")
+        ax.bar(x+w/2, v22, w, color=OI["blue"], label="v2.2")
+        ax.set_xticks(x); ax.set_xticklabels([f"C{i}" for i in range(1,7)])
+        ax.set_ylim(0, 1.2); ax.set_title("v2.1 -> v2.2 (Full BP Ledger)", fontsize=11)
+        ax.legend(loc="upper center", bbox_to_anchor=(0.5,-0.18), ncol=2, frameon=False, fontsize=8)
+        ax.grid(axis="y", alpha=0.2); ax.spines[["top","right"]].set_visible(False)
+
+    def cost_recall(ax):
+        pts = [
+            ("AWS Knwl MCP\n(Claude)", 2.27, 0.024, OI["vermillion"]),
+            ("AWS Knwl MCP\n(GPT)",    0.56, 0.225, OI["orange"]),
+            ("BPV agent",              0.01, 0.07,  OI["sky"]),
+            ("BPV exhaustive",         0.01, 0.997, OI["green"]),
+            ("wa-review v2.1",         4.00, 0.53,  OI["blue"]),
+            ("wa-review v2.2",         7.00, 0.96,  OI["blue"]),
+        ]
+        for name, cost, recall, color in pts:
+            ax.scatter(cost, recall, s=60, color=color, zorder=3, edgecolor="white", linewidth=1)
+            ax.annotate(name, (cost, recall), xytext=(cost+0.1, recall-0.07),
+                        fontsize=6.5, color=OI["grey"])
+        ax.axhline(1.0, color=OI["grey"], linestyle=":", linewidth=0.7)
+        ax.set_xlabel("Cost (USD)"); ax.set_ylabel("Recall")
+        ax.set_title("Cost vs recall", fontsize=11)
+        ax.set_xlim(-0.5, 9); ax.set_ylim(-0.1, 1.2)
+        ax.grid(alpha=0.2); ax.spines[["top","right"]].set_visible(False)
+
+    def model_bench(ax):
+        models_bench = [
+            ("Sonnet 5",    2.76, 5.0), ("GPT-5.5",  1.41, 5.0), ("GPT OSS", 0.09, 5.0),
+            ("Haiku 4.5",   0.54, 4.9), ("Fable 5",  2.77, 4.8), ("R1",      0.74, 4.7),
+            ("Nova Lite",   0.04, 4.2), ("Nova 2 L", 0.02, 4.1), ("Nova Pro",0.50, 3.2),
+        ]
+        for name, cost, q in models_bench:
+            color = OI["blue"] if q >= 4.8 else OI["green"] if q >= 4.5 else OI["orange"] if q >= 3.5 else OI["vermillion"]
+            ax.scatter(cost, q, s=55, color=color, zorder=3, edgecolor="white", linewidth=1)
+            ax.annotate(name, (cost, q), xytext=(cost+0.05, q-0.1), fontsize=6.5, color=OI["grey"])
+        ax.axhline(4.5, color=OI["grey"], linestyle="--", linewidth=0.6, alpha=0.6)
+        ax.set_xlabel("Cost (USD)"); ax.set_ylabel("Quality (1–5)")
+        ax.set_title("Model benchmark", fontsize=11)
+        ax.set_ylim(1, 5.6); ax.set_xlim(-0.2, 3.5)
+        ax.grid(alpha=0.2); ax.spines[["top","right"]].set_visible(False)
+
+    def summary_text(ax):
+        ax.axis("off")
+        text = (
+            "From 2% to 100% Recall\n"
+            f"{'-'*28}\n"
+            "Dec 2025 (AWS Knwl MCP):\n"
+            "  Claude: 2.4% | ChatGPT: 22.5%\n\n"
+            "Jul 2026 — BPVendingService:\n"
+            "  Naive agent: 7% recall\n"
+            "  Exhaustive:  99.7% recall\n\n"
+            "Jul 2026 — wa-review v2.2:\n"
+            "  Report F1:  0.960\n"
+            "  Recall:     1.00\n\n"
+            "Key insight:\n"
+            "  Data quality ≠ recall\n"
+            "  Coverage strategy = recall"
+        )
+        ax.text(0.05, 0.95, text, transform=ax.transAxes, va="top",
+                family="Amazon Ember Mono" if "Amazon Ember Mono" in _AVAILABLE else "monospace",
+                fontsize=9)
+
+    recall_evo(axes[0, 0])
+    three_way(axes[0, 1])
+    before_after(axes[0, 2])
+    cost_recall(axes[1, 0])
+    model_bench(axes[1, 1])
+    summary_text(axes[1, 2])
+
+    fig.suptitle("MCP vs Static Retrieval: AWS Well-Architected Review Quality Study (Jul 2026)",
+                 fontsize=14, weight="bold", family=FONT_DISPLAY, y=0.97)
+    out = DOCS_DIR / "fig0_summary_grid.png"
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print(f"  {out.name}")
+
+
+def main() -> None:
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    print("Generating study visualizations...")
+    fig0_summary_grid()
+    fig1_recall_evolution()
+    fig2_three_way()
+    fig3_plateau()
+    fig4_token_economy()
+    fig5_model_benchmark()
+    fig6_compression()
+    print(f"Done. All charts in {DOCS_DIR.relative_to(REPO_ROOT)}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/pyproject.toml
+++ b/evals/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "boto3>=1.35.0",
     "openai>=1.40.0",
+    "python-docx>=1.2.0",
     "pyyaml>=6.0",
     "requests>=2.31.0",
 ]

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -241,6 +241,68 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -386,6 +448,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +590,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
     { name = "openai" },
+    { name = "python-docx" },
     { name = "pyyaml" },
     { name = "requests" },
 ]
@@ -528,6 +604,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "openai", specifier = ">=1.40.0" },
+    { name = "python-docx", specifier = ">=1.2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
 ]


### PR DESCRIPTION
## Summary

Extends the CLI-effectiveness harness set shipped in v5.2.0 with three new scripts that reproduce the full four-configuration comparison from the MCP vs static retrieval study.

- **`measure_mcp.py`** — simulates structured MCP retrieval locally using Bedrock Titan Embeddings v2 over per-BP markdown files. Two strategies: exhaustive per-pillar sweep (upper bound) and naive agent-style (plateau baseline). Embeddings are cached after the first run, so repeat runs are near-free.
- **`measure_aws_knowledge_mcp.py`** — measures the live `aws-knowledge-mcp-server` via real `claude -p` CLI with `--safe-mode --disable-slash-commands` + MCP config, explicit per-pillar systematic sweep instruction. 18 runs (6 cases × 3 runs).
- **`plot_study.py`** — generates 7 Okabe-Ito colorblind-safe charts: summary grid, recall evolution, three-way F1, plateau, cost vs recall, model benchmark, v2.1→v2.2 before/after. Output to `docs/study/` (gitignored).

`pyproject.toml`: adds matplotlib and pyyaml dependencies.
`.gitignore`: adds study output JSONs and chart directory.

## Reproducing the study

```bash
cd evals

# Structured-MCP retrieval simulation (local, cheap)
uv run python cli_effectiveness/measure_mcp.py

# aws-knowledge-mcp-server live measurement
# Requires AWS credentials with Bedrock access
uv run python cli_effectiveness/measure_aws_knowledge_mcp.py

# Generate charts
uv run python cli_effectiveness/plot_study.py
```

## Test plan

- [ ] `uv sync` resolves without errors (matplotlib, pyyaml added)
- [ ] `measure_mcp.py` runs and produces `mcp_effectiveness.json` with the exhaustive arm clearly ahead of the naive arm
- [ ] `measure_aws_knowledge_mcp.py` starts successfully (first run smoke test sufficient)
- [ ] `plot_study.py` generates 7 PNGs in `docs/study/` without errors
- [ ] No internal data in any committed file

---

_Edited to remove measurement figures. The measurement harnesses ship in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
