### PR TITLE
Load pillar playbooks in full-review subagent dispatch

### DIFF
--- a/skills/wa-review/SKILL.md
+++ b/skills/wa-review/SKILL.md
@@ -164,10 +164,11 @@ If unclear, ask:
 
 ### Coverage strategy — MANIFEST-FIRST, THEN PILLAR FILES
 
-**The purpose of a full review is comprehensive BP-level coverage.** To achieve this reliably, the reference corpus is provided in TWO layers:
+**The purpose of a full review is comprehensive BP-level coverage.** To achieve this reliably, the reference corpus is provided in THREE layers:
 
 1. **`references/manifest.md`** (~24 KB) — Lightweight catalog of every BP ID with 1-line titles. **ALWAYS load this file first** for any full review. It shows you the complete universe of 307 BPs to cite from.
 2. **`references/pillars/{pillar-slug}.md`** (6 files, ~150-580 KB each) — Merged per-pillar reference containing ALL questions and full BP content for one pillar. Load these to get full BP detail (implementation guidance, anti-patterns, resources).
+3. **`references/pillar-playbooks/{pillar}.md`** (6 files, ~3-5 KB each) — Domain-specific evidence-collection guide for one pillar: what resources to examine, what patterns to flag as HIGH RISK, and a pillar-specific report format. Each full-review subagent loads its pillar's playbook (Step 4b) so findings are backed by concrete file:line evidence rather than generic BP restatements.
 
 ### Mandatory loading pattern for a full review
 
@@ -211,27 +212,27 @@ Dispatch all 6 Task calls in a single turn (parallel execution). **Each subagent
 ```
 Task(subagent_type="general-purpose",
      description="Review Operational Excellence",
-     prompt="Read references/pillars/operational-excellence.md, then review the following workload ONLY for the OPS pillar. Enumerate EVERY BP in the pillar file (all 30+ BPs) — do not filter to 'top issues'. Return findings as the mandatory markdown table (columns: BP ID | Status | Severity | Evidence | Recommendation) with one row per BP. Do NOT prepend narrative summary text before the table. Workload: {workload description + code}")
+     prompt="Read references/pillars/operational-excellence.md and references/pillar-playbooks/operational-excellence.md (domain-specific evidence-collection checklist: what to examine and what to flag as HIGH RISK), then review the following workload ONLY for the OPS pillar. Enumerate EVERY BP in the pillar file (all 30+ BPs) — do not filter to 'top issues'. Return findings as the mandatory markdown table (columns: BP ID | Status | Severity | Evidence | Recommendation) with one row per BP. Do NOT prepend narrative summary text before the table. Workload: {workload description + code}")
 
 Task(subagent_type="general-purpose",
      description="Review Security",
-     prompt="Read references/pillars/security.md, then review the workload ONLY for the SEC pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/security.md and references/pillar-playbooks/security.md (domain-specific evidence-collection checklist), then review the workload ONLY for the SEC pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Reliability",
-     prompt="Read references/pillars/reliability.md, then review the workload ONLY for the REL pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/reliability.md and references/pillar-playbooks/reliability.md (domain-specific evidence-collection checklist), then review the workload ONLY for the REL pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Performance Efficiency",
-     prompt="Read references/pillars/performance-efficiency.md, then review the workload ONLY for the PERF pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/performance-efficiency.md and references/pillar-playbooks/performance.md (domain-specific evidence-collection checklist), then review the workload ONLY for the PERF pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Cost Optimization",
-     prompt="Read references/pillars/cost-optimization.md, then review the workload ONLY for the COST pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/cost-optimization.md and references/pillar-playbooks/cost.md (domain-specific evidence-collection checklist), then review the workload ONLY for the COST pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Sustainability",
-     prompt="Read references/pillars/sustainability.md, then review the workload ONLY for the SUS pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/sustainability.md and references/pillar-playbooks/sustainability.md (domain-specific evidence-collection checklist), then review the workload ONLY for the SUS pillar. [same table format, every BP as a row] Workload: {workload}")
 ```
 
 **Total: 6 Task calls in one turn.** Each subagent runs independently with its own context, so each can be exhaustive without stealing from the others. The uniform table format means aggregation is a mechanical concatenation, not an interpretive summary — this prevents ~30-70% recall loss observed with narrative subagent output.


### PR DESCRIPTION
## Background

`skills/wa-review/references/pillar-playbooks/` holds 6 files (one per pillar) with domain-specific discovery guidance — what resources to examine, what patterns to flag as HIGH RISK, and a pillar-specific report format.

## Gap (per #101)

The playbooks were loaded **only** in the pillar-scoped review path (`SKILL.md` line 112). In the **full-review path** (Step 4b), each of the 6 parallel subagents loaded only `references/manifest.md` and `references/pillars/{pillar}.md` — so the playbooks' evidence-collection checklists were never applied to full reviews.

## Change

- Each of the 6 Step 4b dispatch subagents now also reads `references/pillar-playbooks/{pillar}.md` alongside its pillar file.
- The coverage-strategy section now documents the playbooks as a third reference layer.

This is the additive fix proposed in the issue. It's small (~3-5 KB per playbook) and yields better-evidenced, `file:line`-cited findings instead of generic BP restatements. The deeper per-BP examine/flag guidance raised in the follow-up comment is intentionally left out of scope.

Note: playbook filenames intentionally differ from pillar filenames for two pillars (`cost.md` / `performance.md` vs `cost-optimization.md` / `performance-efficiency.md`); the dispatch prompts map each correctly.

Fixes #101