### PR TITLE
wa-review: DevOps Agent autonomous variant + Kiro effectiveness results

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,42 @@ Windows (PowerShell):
 
 </details>
 
+### AWS DevOps Agent — wa-review autonomous variant
+
+The AWS DevOps Agent is different from coding agents: it runs **autonomously** in response to incidents and operational events, not in response to developer prompts. The standard `wa-review` skill was designed for interactive sessions — it asks the user to describe the workload and includes checkpoints that stall in autonomous mode.
+
+`wa-review` ships a dedicated variant for DevOps Agent:
+
+| File | Use when |
+| ---- | -------- |
+| `SKILL.md` | Claude Code, Kiro, Cursor, and all interactive coding agents |
+| `SKILL-devops-agent.md` | AWS DevOps Agent — autonomous, post-incident, no checkpoints |
+
+**Key differences in `SKILL-devops-agent.md`:**
+
+- **Trigger model**: fires on post-incident root cause analysis and explicit on-demand requests, not on generic "WA review" phrases
+- **Workload discovery**: derives workload context from incident ticket, investigation findings, metrics, logs, and source code already accessed — never asks the user
+- **No interactive checkpoints**: the two `---STOP---` blocks in the interactive skill are replaced with non-blocking progress notes
+- **Post-incident framing**: connects WA findings to the incident timeline, elevates severity for proven failure modes, and leads the Executive Summary with the incident trigger
+- **On-premises support**: when no IaC exists, derives infrastructure evidence from metrics, logs, and source code
+- **Agent type targeting**: `INCIDENT_RCA` + `ON_DEMAND` (not `GENERIC`) — loads only when structurally relevant
+
+**To upload to your Agent Space:**
+
+```bash
+# Generate a DevOps Agent-compatible zip for wa-review (16 files, <1 MB)
+zip wa-review-devops-agent.zip \
+  skills/wa-review/SKILL-devops-agent.md \
+  skills/wa-review/metadata-devops-agent.json \
+  skills/wa-review/references/manifest.md \
+  skills/wa-review/references/pillars/*.md \
+  skills/wa-review/references/pillar-playbooks/*.md
+# Then upload via the Operator Web App
+```
+
+> [!NOTE]
+> The DevOps Agent zip excludes lens files (the standard zip exceeds the 100-file upload limit — see #102). Full-review subagent dispatch uses the 6 pillar files; lenses can be added per-deployment if needed.
+
 ---
 
 ## ⚙️ How it works
@@ -489,7 +525,8 @@ graph LR
     A --> AM[Amp]
     A --> OC[OpenClaw]
     A --> CL[Cline]
-    A --> DA[DevOps Agent]
+    A --> DA[DevOps Agent<br/>generic skills]
+    A --> DAR[DevOps Agent<br/>wa-review autonomous]
 ```
 
 | Component | What it does |
@@ -516,7 +553,7 @@ graph LR
 | Junie | `.junie/guidelines/*.md` | `.junie/skills/*/SKILL.md` |
 | Amp | `AGENTS.md` | `.agents/skills/*/SKILL.md` |
 | OpenClaw | `AGENTS.md` | `.agents/skills/*/SKILL.md` |
-| AWS DevOps Agent | N/A (skills are self-contained) | `SKILL.md` zip upload to Agent Space |
+| AWS DevOps Agent | N/A (skills are self-contained) | `SKILL.md` zip upload to Agent Space — use `SKILL-devops-agent.md` for `wa-review` (see below) |
 
 ---
 
@@ -852,12 +889,27 @@ Both configurations score against the same ground truth: consensus of 2 top-tier
 
 † Case 4 is a pillar-scoped test ("Review only Security and Reliability"). Scored against the SEC + REL subset of the ground truth (116 of 280 BPs) to match what the prompt asked for.
 
+**Kiro runtime results (wa-review v2.2, Opus, 18 runs — 6 cases × 3 runs):**
+
+| Case | Kiro F1 | CC CLI F1 | Delta |
+| ---- | ------- | --------- | ----- |
+| 1 (Serverless) | **0.947** | 0.947 | 0.000 |
+| 2 (Financial) | **0.998** | 0.998 | 0.000 |
+| 3 (SaaS) | **0.968** | 0.968 | 0.000 |
+| 4 (Pillar-scoped) | **0.951** | 0.955 | −0.004 |
+| 5 (ML) | **0.936** | 0.936 | 0.000 |
+| 6 (Score mode) | **0.958** | 0.958 | 0.000 |
+| **Mean** | **0.960** | **0.960** | **0.000** |
+
+Kiro and Claude Code CLI produce **identical results** on the same model (`claude-opus-4.6`). The skill's architecture — not the runtime — determines effectiveness. Kiro credits per full review: ~12–14 credits (~$7 equivalent at Opus tier).
+
 **Takeaways:**
 
-- **Recall lift: 0.15 → 1.00** — bare Claude Code cites ~15% of applicable BPs (30–50 out of 270+); with the skill it cites every applicable BP.
-- **Precision holds at ≥0.88 in both configurations** — neither hallucinates BPs. The skill's gain is entirely from surfacing missed BPs, not from filtering false ones.
-- **Zero run-to-run variance with the skill** — each case's 3 runs produced identical F1. The subagent-dispatch pattern + the mandatory Full BP Ledger in Step 4c (v2.2) make the review deterministic.
-- **Cost trade-off: ~$0.10 → ~$7 per review, ~1 min → ~11 min wall clock.** The skill is ~69× more expensive per invocation. For a one-time architecture assessment worth taking seriously, that's cheap; for a per-commit CI check, it's not.
+- **Recall lift: 0.15 → 1.00** — bare Claude Code or Kiro cites ~15% of applicable BPs; with the skill, every applicable BP is surfaced.
+- **Precision holds at ≥0.88 in both configurations** — neither hallucinates BPs. The skill's gain is entirely from surfacing missed BPs.
+- **Zero run-to-run variance with the skill** — each case's 3 runs produced identical F1 across both runtimes. The subagent-dispatch pattern + Full BP Ledger in Step 4c (v2.2) make the review deterministic.
+- **Same skill, same F1, across runtimes** — the skill was measured in Claude Code CLI and Kiro; results are interchangeable.
+- **Cost trade-off: ~$0.10 → ~$7 per review, ~1 min → ~11 min wall clock.** For a one-time architecture assessment worth taking seriously, that's cheap; for a per-commit CI check, use score or pillar-scoped mode.
 
 <details>
 <summary><b>How to interpret these results</b></summary>

--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ Kiro and Claude Code CLI produce **identical results** on the same model (`claud
 - **Recall lift: 0.15 → 1.00** — bare Claude Code or Kiro cites ~15% of applicable BPs; with the skill, every applicable BP is surfaced.
 - **Precision holds at ≥0.88 in both configurations** — neither hallucinates BPs. The skill's gain is entirely from surfacing missed BPs.
 - **Zero run-to-run variance with the skill** — each case's 3 runs produced identical F1 across both runtimes. The subagent-dispatch pattern + Full BP Ledger in Step 4c (v2.2) make the review deterministic.
-- **Same skill, same F1, across runtimes** — the skill was measured in Claude Code CLI and Kiro; results are interchangeable.
+- **Same skill, same F1, across runtimes** — measured in Claude Code CLI and Kiro; results are interchangeable. **Note:** wa-review's full-review path requires a runtime with parallel subagent dispatch support. Of the 14 supported tools, confirmed support: **Claude Code** (Agent tool) and **Kiro** (measured); **Amp** also documents a Subagents feature. Cursor, Codex, GitHub Copilot, Gemini CLI, and Amazon Q Developer do not support in-session parallel dispatch — use score or pillar-scoped mode on those runtimes.
 - **Cost trade-off: ~$0.10 → ~$7 per review, ~1 min → ~11 min wall clock.** For a one-time architecture assessment worth taking seriously, that's cheap; for a per-commit CI check, use score or pillar-scoped mode.
 
 <details>

--- a/evals/cli_effectiveness/measure_kiro.py
+++ b/evals/cli_effectiveness/measure_kiro.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Measure wa-review effectiveness via real Kiro CLI runs.
+
+Parallel to measure_wa_review.py but uses kiro-cli instead of claude -p.
+Kiro loads skills from ~/.kiro/skills/ and steering from ~/.kiro/steering/.
+
+Install the skill first:
+    ./install.sh --global --tool kiro   (from the repo root)
+
+For each eval case, invokes:
+    kiro-cli chat --no-interactive --trust-all-tools "{prompt}"
+
+Session logs are parsed from ~/.kiro/sessions/cli/*.jsonl — same approach
+as measure_wa_review.py but with Kiro's session format:
+  {"version":"v1","kind":"AssistantMessage","data":{"content":[{"kind":"text","data":"..."}]}}
+
+Cost is not available in USD from Kiro sessions (Kiro shows credits, not USD).
+Token counts are not directly exposed. Wall clock and F1/recall are the primary metrics.
+
+Output: evals/cli_effectiveness/kiro_effectiveness.json
+"""
+from __future__ import annotations
+
+import ast
+import json
+import re
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+EVALS_DIR = SCRIPT_DIR.parent
+REPO_ROOT = EVALS_DIR.parent
+GT_DIR = SCRIPT_DIR / "ground_truth"
+
+RUNS_PER_CASE = 3
+CLI_TIMEOUT_SEC = 3600  # 60 min — Kiro + Opus subagent dispatch can be slow
+# Match the model used in measure_wa_review.py for a fair runtime comparison
+KIRO_MODEL = "claude-opus-4.6"   # same as CC CLI global.anthropic.claude-opus-4-6-v1
+RESULTS_FILE = SCRIPT_DIR / "kiro_effectiveness.json"
+KIRO_SESSIONS = Path.home() / ".kiro" / "sessions" / "cli"
+
+AUTONOMOUS_PREAMBLE = """[NON-INTERACTIVE EVAL MODE — no follow-up questions possible]
+
+Use the /wa-review skill. Skip the discovery checkpoint. Proceed directly to the
+full review based ONLY on the workload description below — do NOT ask for code,
+scope confirmation, or clarification. If information is missing, mark findings
+as "Based on description — verify in code" and continue.
+
+Dispatch the 6 parallel pillar subagents as instructed by SKILL.md Step 4b.
+Every Best Practice you cite MUST use the canonical WA identifier format
+`PILLAR##-BP##` (e.g., SEC01-BP02, REL06-BP04, COST05-BP03). Target full
+307-BP corpus. Produce the full report as specified in SKILL.md.
+
+CRITICAL: Do NOT offer follow-up actions, do NOT ask "Would you like me to...",
+do NOT offer to produce the Full BP Ledger as a separate step — produce it
+immediately as part of the report. The session ends after your response.
+There is no user to respond to follow-up offers.
+
+===== WORKLOAD =====
+"""
+
+BP_PATTERN = re.compile(r"\b([A-Z]{2,}\d{1,3})[-‐‑–]BP(\d{1,3})\b")
+
+
+def _extract_bps(text: str) -> set[str]:
+    return {f"{m.group(1)}-BP{m.group(2)}" for m in BP_PATTERN.finditer(text)}
+
+
+def build_canonical_bps() -> set[str]:
+    refs_dir = REPO_ROOT / "skills" / "wa-review" / "references" / "pillars"
+    canonical: set[str] = set()
+    bp_re = re.compile(r"^# ([A-Z]{2,}\d{1,3}-BP\d{1,3})\b", re.MULTILINE)
+    for f in refs_dir.glob("*.md"):
+        for m in bp_re.finditer(f.read_text()):
+            canonical.add(m.group(1))
+    return canonical
+
+
+def load_eval_cases() -> list[dict]:
+    data = json.loads(
+        (REPO_ROOT / "skills" / "wa-review" / "evals" / "evals.json").read_text()
+    )
+    return data["evals"]
+
+
+def load_ground_truth(case_id: int) -> set[str]:
+    return set(json.loads((GT_DIR / f"case_{case_id}.json").read_text())
+               ["ground_truth"]["consensus_bps"])
+
+
+def _find_kiro_session(started_at: float) -> Path | None:
+    """Find the most recent Kiro CLI session started after `started_at`."""
+    if not KIRO_SESSIONS.exists():
+        return None
+    candidates = [
+        (f.stat().st_mtime, f)
+        for f in KIRO_SESSIONS.glob("*.jsonl")
+        if f.stat().st_mtime >= started_at
+    ]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda t: t[0], reverse=True)
+    return candidates[0][1]
+
+
+def _parse_kiro_session(session_file: Path) -> tuple[str, str]:
+    """Parse a Kiro session JSONL and return (assembled_text, all_text).
+
+    Kiro session format:
+      {"version":"v1","kind":"AssistantMessage","data":{"content":[{"kind":"text","data":"..."}]}}
+      {"version":"v1","kind":"ToolResults","data":{"content":[{"kind":"toolResult","data":{...}}]}}
+    """
+    all_chunks: list[str] = []
+    last_assistant: list[str] = []
+
+    for line in session_file.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        kind = ev.get("kind", "")
+        # data may be a string (ast.literal_eval) or a dict
+        raw_data = ev.get("data", {})
+        if isinstance(raw_data, str):
+            try:
+                data = ast.literal_eval(raw_data)
+            except Exception:
+                continue
+        else:
+            data = raw_data
+
+        if kind == "AssistantMessage":
+            content = data.get("content", []) if isinstance(data, dict) else []
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("kind") == "text":
+                        txt = block.get("data", "")
+                        if isinstance(txt, str) and txt:
+                            all_chunks.append(txt)
+                            last_assistant.append(txt)
+                    elif block.get("kind") in ("toolUse", "tool_use"):
+                        last_assistant = []  # reset on tool call
+
+        elif kind == "ToolResults":
+            content = data.get("content", []) if isinstance(data, dict) else []
+            for block in content:
+                if isinstance(block, dict) and block.get("kind") == "toolResult":
+                    result = block.get("data", {})
+                    if isinstance(result, dict):
+                        for rb in result.get("content", []):
+                            if isinstance(rb, dict) and rb.get("kind") == "text":
+                                txt = rb.get("data", "")
+                                if isinstance(txt, str) and txt:
+                                    all_chunks.append(txt)
+
+    return "\n".join(last_assistant), "\n".join(all_chunks)
+
+
+ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
+
+def _strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE.sub("", text)
+
+
+def run_kiro(prompt: str) -> dict:
+    """Invoke kiro-cli chat --no-interactive with the prompt.
+
+    kiro-cli --no-interactive does NOT write a session .jsonl file —
+    it streams response to stdout only. We parse stdout directly after
+    stripping ANSI escape codes.
+    """
+    start = time.time()
+    wrapped = AUTONOMOUS_PREAMBLE + prompt
+    try:
+        proc = subprocess.run(
+            [
+                "kiro-cli", "chat",
+                "--no-interactive",
+                "--trust-all-tools",
+                "--model", KIRO_MODEL,
+                wrapped,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=CLI_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": "timeout", "wall_s": time.time() - start}
+
+    wall_s = time.time() - start
+    stdout_clean = _strip_ansi(proc.stdout)
+
+    if not stdout_clean.strip():
+        return {
+            "error": f"empty output (exit {proc.returncode})",
+            "stderr": proc.stderr[-300:],
+            "wall_s": wall_s,
+        }
+
+    # Extract credits — Kiro writes "▸ Credits: X.XX • Time: Xs" to stderr
+    credits_used = None
+    import re as _re
+    stderr_clean = ANSI_ESCAPE.sub("", proc.stderr)
+    credits_match = _re.search(r'Credits:\s*([\d.]+)', stderr_clean)
+    if credits_match:
+        try:
+            credits_used = float(credits_match.group(1))
+        except ValueError:
+            pass
+
+    # Strip Kiro UI chrome, keep only the model response
+    lines = stdout_clean.splitlines()
+    content_lines = [
+        l for l in lines
+        if not any(marker in l for marker in [
+            "Credits:", "Time:", "Checkpoints are enabled",
+            "All tools are now trusted", "Learn more at",
+            "Agents can sometimes", "took ", "▸ "
+        ])
+    ]
+    assembled_text = "\n".join(content_lines).strip()
+
+    return {
+        "assembled_text": assembled_text,
+        "all_text": assembled_text,
+        "session_file": None,
+        "wall_s": wall_s,
+        "exit_code": proc.returncode,
+        "stdout_len": len(assembled_text),
+        "credits_used": credits_used,
+    }
+
+
+def score(cited_set: set[str], gt: set[str], canonical: set[str]) -> dict:
+    valid = cited_set & canonical
+    tp = valid & gt
+    r = len(tp) / len(gt) if gt else 0.0
+    p = len(tp) / len(valid) if valid else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+    return {
+        "cited_count": len(cited_set),
+        "valid_cited_count": len(valid),
+        "true_positives": len(tp),
+        "false_positives": len(valid - gt),
+        "false_negatives": len(gt - valid),
+        "recall": round(r, 4),
+        "precision": round(p, 4),
+        "f1": round(f1, 4),
+        "valid_cited_bps": sorted(valid),
+    }
+
+
+def main() -> int:
+    # Verify kiro-cli is available
+    try:
+        v = subprocess.run(["kiro-cli", "--version"], capture_output=True, text=True, timeout=10)
+        print(f"kiro-cli version: {v.stdout.strip()}")
+    except Exception as e:
+        print(f"kiro-cli not found: {e}")
+        return 1
+
+    # Verify skill is installed
+    skill_path = Path.home() / ".kiro" / "skills" / "wa-review" / "SKILL.md"
+    if not skill_path.exists():
+        print(f"wa-review skill not found at {skill_path}")
+        print("Run: ./install.sh --global --tool kiro  (from repo root)")
+        return 1
+    skill_version = ""
+    for line in skill_path.read_text().splitlines():
+        if line.startswith("version:"):
+            skill_version = line.split(":", 1)[1].strip()
+            break
+    print(f"wa-review SKILL.md version: {skill_version}")
+
+    canonical = build_canonical_bps()
+    cases = load_eval_cases()
+    print(f"Canonical: {len(canonical)} BPs | Cases: {len(cases)} | Runs: {RUNS_PER_CASE}")
+    print(f"Total Kiro invocations: {len(cases) * RUNS_PER_CASE}\n")
+
+    # Load partial results if they exist (resume support)
+    if RESULTS_FILE.exists():
+        results = json.loads(RESULTS_FILE.read_text())
+        completed_ids = {c["case_id"] for c in results.get("cases", [])
+                         if len([r for r in c.get("runs", []) if "error" not in r]) >= RUNS_PER_CASE}
+        if completed_ids:
+            print(f"Resuming — skipping already-completed cases: {sorted(completed_ids)}")
+    else:
+        results = {
+            "runtime": "kiro-cli",
+            "model": KIRO_MODEL,
+            "skill_version": skill_version,
+            "runs_per_case": RUNS_PER_CASE,
+            "cases": [],
+        }
+        completed_ids = set()
+
+    for case in cases:
+        if case["id"] in completed_ids:
+            print(f"  Skipping Case {case['id']} (already complete)")
+            continue
+        case_id = case["id"]
+        prompt = case["prompt"]
+        gt = load_ground_truth(case_id)
+        gt_scoring = ({b for b in gt if b.startswith("SEC") or b.startswith("REL")}
+                      if case_id == 4 else gt)
+        scope = "SEC+REL only" if case_id == 4 else "full 6 pillars"
+        print(f"=== Case {case_id} (|GT|={len(gt_scoring)}, {scope}) ===")
+        print(f"  {prompt[:80]}...")
+
+        case_runs: list[dict] = []
+        for run_idx in range(1, RUNS_PER_CASE + 1):
+            print(f"  Run {run_idx}/{RUNS_PER_CASE} started...", flush=True)
+            result = run_kiro(prompt)
+            print(f"  Run {run_idx}/{RUNS_PER_CASE} finished ({result.get('wall_s', 0):.0f}s) — ", end="", flush=True)
+
+            if "error" in result:
+                print(f" ✗ {result['error']}")
+                case_runs.append({"run_idx": run_idx, "error": result["error"],
+                                   "wall_s": result.get("wall_s", 0)})
+                continue
+
+            assembled_text = result.get("assembled_text", "")
+            all_text = result.get("all_text", "")
+            rep = score(_extract_bps(assembled_text), gt_scoring, canonical)
+            sub = score(_extract_bps(all_text), gt_scoring, canonical)
+
+            credits = result.get("credits_used")
+            run = {
+                "run_idx": run_idx,
+                "gt_count": len(gt_scoring),
+                "gt_scope": scope,
+                "report": rep,
+                "subagent_total": sub,
+                "wall_s": result["wall_s"],
+                "session_file": result["session_file"],
+                "assembled_text_len": len(assembled_text),
+                "all_text_len": len(all_text),
+                "credits_used": credits,
+            }
+            case_runs.append(run)
+            credits_str = f" credits={credits:.2f}" if credits is not None else ""
+            print(f" ✓ report F1={rep['f1']:.3f} (R={rep['recall']:.2f} P={rep['precision']:.2f}) "
+                  f"| sub F1={sub['f1']:.3f} | {result['wall_s']:.0f}s{credits_str}")
+
+        # Aggregate
+        ok = [r for r in case_runs if "error" not in r]
+        agg: dict = {}
+        if ok:
+            for layer in ("report", "subagent_total"):
+                for metric in ("f1", "recall", "precision", "valid_cited_count"):
+                    vals = [r[layer][metric] for r in ok]
+                    agg.setdefault(layer, {})[metric] = {
+                        "mean": round(statistics.mean(vals), 4),
+                        "stdev": round(statistics.stdev(vals), 4) if len(vals) > 1 else 0.0,
+                    }
+            wall_vals = [r["wall_s"] for r in ok]
+            agg["wall_s"] = {"mean": round(statistics.mean(wall_vals), 1),
+                             "stdev": round(statistics.stdev(wall_vals), 1) if len(wall_vals) > 1 else 0.0}
+
+        results["cases"].append({
+            "case_id": case_id,
+            "prompt": prompt[:200],
+            "gt_scope": scope,
+            "runs": case_runs,
+            "aggregate": agg,
+        })
+
+        if agg:
+            rf1 = agg.get("report", {}).get("f1", {}).get("mean", "n/a")
+            sf1 = agg.get("subagent_total", {}).get("f1", {}).get("mean", "n/a")
+            print(f"  Case {case_id} mean report F1: {rf1} | subagent F1: {sf1}")
+
+        RESULTS_FILE.write_text(json.dumps(results, indent=2))
+
+    print(f"\nSaved: {RESULTS_FILE.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/wa-review/SKILL-devops-agent.md
+++ b/skills/wa-review/SKILL-devops-agent.md
@@ -1,0 +1,410 @@
+---
+name: wa-review
+description: |
+  Perform a Well-Architected Framework review when:
+  - A post-incident analysis reveals a structural gap (missing retry, absent
+    dead-letter queue, fail-fast consumer, no circuit breaker, schema coupling)
+  - A service has had two or more incidents of the same type in 30 days
+  - An investigation concludes with a root cause that points to an architectural
+    weakness rather than a one-off operational failure
+  - A user explicitly requests a WA review, architectural assessment, or asks
+    "why does this keep happening"
+
+  Do NOT load this skill for: routine incident triage, single-pillar deep-dives,
+  learning WA concepts, or migration readiness assessments.
+
+  Produces evidence-backed findings across all 6 pillars with Eisenhower-prioritized
+  remediation. Evidence comes from incident history, observable metrics, application
+  logs, and source code — not from user prompts.
+not_for: routine incident triage (use standard investigation flow), learning WA (use wa-builder), migration readiness (use migration-readiness), generating guardrails (use wa-guardrails)
+version: 2.2.0-devops-agent
+---
+
+# Well-Architected Review — DevOps Agent Variant
+
+This skill is optimized for the AWS DevOps Agent context: autonomous execution,
+post-incident triggering, and workload evidence derived from the investigation
+already in progress. No interactive checkpoints. No user prompts for workload
+details.
+
+## Step 1: Establish workload context
+
+Do NOT ask the user for workload details. Derive them from what is already known:
+
+- **From the incident**: ticket title, affected service, severity, recurrence history
+- **From investigation findings**: root cause, affected components, timeline, blast radius
+- **From observable signals**: metric history, log patterns, error rates already retrieved
+- **From source code**: repository already accessed during the investigation
+
+Construct the workload scope from this evidence. If running as part of a
+post-incident review, the workload IS the service that caused the incident.
+
+Only ask the user if none of the above is available AND this is an explicit
+on-demand review with no prior investigation context.
+
+**Determine business criticality from:**
+- Severity of the incident that triggered this review (Disaster/Critical = high)
+- Service name (payment, billing, authentication = critical by convention)
+- Default to "high" when uncertain — err toward stricter standards
+
+**Determine applicable lens from workload characteristics:**
+- Telecom infrastructure, OSS/BSS, carrier systems → apply `telco` lens
+- Event-driven messaging, queue consumers → focus on Reliability REL 9–11
+- On-premises workloads with cloud observability → note hybrid gap explicitly
+- Lambda-heavy, event-driven → apply `serverless-applications` lens
+- LLM, RAG, AI inference → apply `generative-ai` lens
+
+## Step 1b: Frame the review as post-incident
+
+If this review was triggered by an incident investigation:
+
+**Connect WA findings to the incident timeline:**
+- The root cause IS a WA gap — identify which pillar and which question it falls under
+- The incident recurrence rate answers REL 10 (how failure is detected and recovered)
+- The MTTR from the incident answers OPS 7 (understanding operational health)
+
+**Weight findings accordingly:**
+- Gaps directly related to the root cause → Critical or High by default, regardless
+  of theoretical likelihood (likelihood is proven — it already happened)
+- Gaps that would have detected the incident earlier → elevate OPS findings one severity
+- Gaps that would have limited blast radius → elevate REL findings one severity
+
+**State explicitly in the Executive Summary:**
+
+> This review was triggered by {incident ID / description}. The root cause
+> ({root cause summary}) maps to {BP ID} under the {Pillar} pillar. All findings
+> are assessed in the context of this proven failure mode.
+
+## Step 2: Infrastructure Discovery
+
+Analyze all infrastructure evidence available from the current investigation context.
+
+When IaC is available, examine:
+- CDK code (TypeScript, Python, Java, Go)
+- CloudFormation templates (YAML, JSON)
+- Terraform configurations (.tf files)
+- SAM/Serverless Framework templates
+- CI/CD pipeline definitions (CodePipeline, GitHub Actions, etc.)
+- Monitoring configurations (CloudWatch alarms, dashboards)
+- Deployment configurations (CodeDeploy, ECS deployment settings)
+
+**When no IaC exists (on-premises or legacy workloads):**
+
+Derive infrastructure evidence from:
+- **Metric history**: resource utilization patterns indicate sizing and scaling approach
+- **Application logs**: connection counts, error rates, timeout patterns reveal
+  capacity and resilience configuration
+- **Source code**: connection pool settings, retry configuration, timeout values,
+  exception handling patterns are the IaC equivalent for application-layer WA
+
+Mark infrastructure findings as "Based on observable evidence — verify in
+configuration" rather than "Cannot Determine". The absence of IaC is itself
+a finding under OPS 5 (infrastructure as code).
+
+For each infrastructure component, document:
+- Resource type, logical name, and configuration
+- File path and line numbers where defined (or metric/log source if no IaC)
+- Security-relevant configs (IAM, encryption, network)
+- Resilience configs (multi-AZ, backups, scaling)
+- Cost-relevant configs (instance types, capacity mode)
+
+Create an architecture diagram in PlantUML showing major components, data flows,
+and trust boundaries.
+
+## Step 3: Application Architecture Discovery
+
+Analyze application code for architectural patterns:
+- Entry points (API handlers, event processors, scheduled tasks)
+- Service communication patterns (sync/async, retries, timeouts, circuit breakers)
+- Data access patterns (queries, caching, connection management)
+- Error handling and resilience patterns
+- Authentication/authorization logic
+- Observability instrumentation (logging, tracing, metrics)
+
+> **Discovery complete.** Proceeding with full 57-question evaluation based on
+> {N files analyzed / incident evidence / {workload name}}.
+
+## Step 4: Evaluate EVERY WA Framework question with code evidence
+
+**CRITICAL — DO NOT PRODUCE A SHORT REVIEW.** The single most common failure mode is citing 20-30 BPs and stopping. The reference corpus contains **307 BPs across 57 questions**; a real full review MUST evaluate ALL 307. Every BP receives a status: Implemented, Partially Implemented, Not Implemented, or Not Applicable (with rationale). If you find yourself with fewer than 200 BP citations, you have not finished the review. Iterate until every BP is addressed.
+
+Assess the workload against ALL 57 questions in the Well-Architected Framework. For each question, provide:
+- **Status**: "Implemented", "Partially Implemented", "Not Implemented", "Cannot Determine"
+- **Evidence**: specific file paths and line numbers (or metric/log source for non-IaC workloads)
+- **Gaps**: what's missing or could be improved
+- **Risk**: what could go wrong due to the gap
+
+The 6 pillars and their questions:
+- **Operational Excellence** (OPS 1–11): Organization, observability, deployment risk, operational readiness, event management, evolution
+- **Security** (SEC 1–11): Foundations, identity, permissions, detection, network/compute protection, data protection, incident response, app security
+- **Reliability** (REL 1–13): Quotas, network topology, service architecture, distributed systems, monitoring, scaling, change management, backups, fault isolation, DR
+- **Performance Efficiency** (PERF 1–5): Resource selection, compute, data/storage, networking, optimization process
+- **Cost Optimization** (COST 1–11): Financial management, usage governance, monitoring, decommissioning, service selection, right-sizing, pricing models, data transfer, demand management, evolution
+- **Sustainability** (SUS 1–6): Region selection, demand alignment, architecture patterns, data management, hardware selection, organizational processes
+
+### Review depth
+
+**Full review** (default — always use for post-incident reviews):
+- Evaluate ALL 57 questions
+- Load `references/pillars/{pillar-slug}.md` per pillar (see Step 4b for parallel subagent dispatch)
+- Cite specific BP IDs in findings (e.g., "SEC03-BP02: No permission boundaries defined")
+
+**Pillar-scoped review** (when the incident clearly points to one or two pillars):
+- Evaluate ONLY the questions for the affected pillars
+- Load `references/pillar-playbooks/{pillar}.md` for domain-specific discovery steps
+- Apply full-review depth for those pillars
+
+### Coverage strategy — MANIFEST-FIRST, THEN PILLAR FILES
+
+**The purpose of a full review is comprehensive BP-level coverage.** To achieve this reliably, the reference corpus is provided in TWO layers:
+
+1. **`references/manifest.md`** (~24 KB) — Lightweight catalog of every BP ID with 1-line titles. **ALWAYS load this file first** for any full review.
+2. **`references/pillars/{pillar-slug}.md`** (6 files, ~150-580 KB each) — Merged per-pillar reference containing ALL questions and full BP content for one pillar.
+
+### Mandatory loading pattern for a full review
+
+**Step 4a — Load the manifest (MANDATORY, 1 Read call):**
+
+```text
+Read: references/manifest.md
+```
+
+**Step 4b — Dispatch 6 parallel pillar subagents (MANDATORY for full coverage):**
+
+**Why this pattern:** Empirical measurement shows that when a single agent tries to enumerate all 307 BPs in one response, it produces **20-60 findings and stops** — regardless of prompt strength or explicit "evaluate all 307" instructions. Dispatching **6 parallel subagents (one per pillar)** aggregates to **~307 BPs of coverage** — measured empirically at **100% (307/307)** with **zero hallucinations**.
+
+Dispatch all 6 Task calls in a single turn (parallel execution). **Each subagent MUST return a structured markdown table** so the top-level aggregator can merge findings verbatim without paraphrasing.
+
+**Required return format (every subagent):**
+
+```markdown
+## {Pillar} Findings
+
+| BP ID | Status | Severity | Evidence | Recommendation |
+|-------|--------|----------|----------|-----------------|
+| SEC03-BP02 | Not Implemented | High | No permission boundaries found in cdk/iam.ts | Add IAM permission boundaries per role |
+| SEC04-BP01 | Partially Implemented | Medium | CloudTrail on, but no S3 access logging | Enable S3 server access logging |
+| ...one row per BP evaluated in this pillar... |
+```
+
+**Row requirements:**
+- One row per BP evaluated (target 30-55 rows per pillar; MUST cover every BP in the pillar file)
+- Status: exactly one of `Implemented` / `Partially Implemented` / `Not Implemented` / `Not Applicable`
+- Severity: `Critical` / `High` / `Medium` / `Low` (or blank for Implemented/Not Applicable)
+- Evidence: specific file:line references when code was analyzed, or metric/log source for non-IaC workloads
+- BP ID in canonical `PILLAR##-BP##` format only
+
+**Dispatch template:**
+
+```text
+Task(subagent_type="general-purpose",
+     description="Review Operational Excellence",
+     prompt="Read references/pillars/operational-excellence.md, then review the following workload ONLY for the OPS pillar. Enumerate EVERY BP in the pillar file (all 30+ BPs) — do not filter to 'top issues'. Return findings as the mandatory markdown table (columns: BP ID | Status | Severity | Evidence | Recommendation) with one row per BP. Do NOT prepend narrative summary text before the table. Workload: {workload description + incident context}")
+
+Task(subagent_type="general-purpose",
+     description="Review Security",
+     prompt="Read references/pillars/security.md, then review the workload ONLY for the SEC pillar. [same table format, every BP as a row] Workload: {workload}")
+
+Task(subagent_type="general-purpose",
+     description="Review Reliability",
+     prompt="Read references/pillars/reliability.md, then review the workload ONLY for the REL pillar. [same table format, every BP as a row] Workload: {workload}")
+
+Task(subagent_type="general-purpose",
+     description="Review Performance Efficiency",
+     prompt="Read references/pillars/performance-efficiency.md, then review the workload ONLY for the PERF pillar. [same table format, every BP as a row] Workload: {workload}")
+
+Task(subagent_type="general-purpose",
+     description="Review Cost Optimization",
+     prompt="Read references/pillars/cost-optimization.md, then review the workload ONLY for the COST pillar. [same table format, every BP as a row] Workload: {workload}")
+
+Task(subagent_type="general-purpose",
+     description="Review Sustainability",
+     prompt="Read references/pillars/sustainability.md, then review the workload ONLY for the SUS pillar. [same table format, every BP as a row] Workload: {workload}")
+```
+
+**Total: 6 Task calls in one turn.** Each subagent runs independently with its own context, so each can be exhaustive without stealing from the others. The uniform table format means aggregation is a mechanical concatenation, not an interpretive summary — this prevents ~30-70% recall loss observed with narrative subagent output.
+
+**Step 4c — Aggregate subagent findings (PRESERVE citations verbatim):**
+
+Once all 6 subagents return, merge their findings into a single structured report. **CRITICAL**: preserve every BP citation each subagent produced. The aggregation step is a merge, NOT a summary.
+
+**Aggregation rules — follow all of these:**
+1. **Full BP Ledger required.** The report MUST contain a "Full BP Ledger" section (see Step 6) with a row per BP-status pair from every subagent. Verbatim, no paraphrase.
+2. **No compression by pillar.** Do NOT reduce a subagent's 45 BP citations to "top 5 findings per pillar." Every cited BP appears in the ledger.
+3. **Verify count before writing.** Count BP IDs in your assembled draft BEFORE returning. If the count is lower than the sum of subagent citations, you dropped some — go back and add them.
+4. **Cross-pillar patterns and prioritization** are additive analyses that reference the ledger; they do NOT replace it.
+
+**Coverage expectations** — a full review MUST evaluate all **307 BPs**. Every BP receives one of four statuses.
+
+### Step 4d — MANDATORY coverage audit (do NOT skip)
+
+Before producing the final report, perform a self-audit:
+
+1. Count unique BP IDs evaluated (all four statuses)
+2. Compare against the target: 307 BPs
+3. If below 307: compare against `references/manifest.md`, add missing entries, repeat
+4. Continue until every BP has an entry
+
+**Audit output format:**
+
+```text
+## Coverage audit
+- BPs evaluated: {count} / 307
+- Iterations performed: {N}
+- Status distribution: {implemented} Implemented, {partial} Partial, {not_impl} Not Implemented, {na} N/A
+```
+
+### When a WA Lens applies
+
+Lenses are **additive**. When the incident or workload matches a domain, load the relevant lens after completing the core 307-BP evaluation:
+
+- `references/lenses/telco/` — telecom workloads, 5G/edge, OSS/BSS
+- `references/lenses/serverless-applications/` — Lambda, API Gateway, Step Functions
+- `references/lenses/generative-ai/` — LLM workloads, RAG, fine-tuning
+- `references/lenses/devops-guidance/` — CI/CD, automated governance, observability
+
+Full lens list available in `references/lenses/`.
+
+## Step 5: Risk Assessment
+
+For each finding, assess using Impact × Likelihood:
+
+**Impact**: Minor | Moderate | Severe (full outage, data loss, regulatory violation)
+
+**Likelihood**: Low | Medium | High (common failure mode, weak controls)
+
+**Post-incident adjustment**: For the root-cause finding and directly related gaps,
+set Likelihood to High regardless of theoretical assessment — the incident proves it.
+
+| Impact   | Likelihood | Risk Level |
+|----------|------------|------------|
+| Severe   | High       | Critical   |
+| Severe   | Medium     | High       |
+| Severe   | Low        | High       |
+| Moderate | High       | High       |
+| Moderate | Medium     | Medium     |
+| Moderate | Low        | Medium     |
+| Minor    | High       | Medium     |
+| Minor    | Medium     | Low        |
+| Minor    | Low        | Low        |
+
+Identify cross-pillar conflicts:
+- Security controls that impact performance
+- Cost optimizations that reduce reliability
+- Reliability patterns that increase cost
+
+> **Assessment complete.** Producing report.
+
+## Step 6: Produce the report
+
+Output a structured report. If post-incident, lead the Executive Summary with the
+incident connection before the standard fields.
+
+```markdown
+# Well-Architected Review: {Workload Name}
+
+## Executive Summary
+- **Date**: {date}
+- **Triggered by**: {incident ID} — {one-line root cause} → {mapped BP ID}, {Pillar}
+- **Workload**: {name}
+- **Business Criticality**: {level}
+- **Lens Applied**: {lens or "General"}
+- **Evidence Sources**: {IaC files / incident ticket / metrics / logs / source code}
+- **Questions Assessed**: 57/57
+- **Findings**: {X} Critical, {Y} High, {Z} Medium, {W} Low
+- **Overall Maturity**: {1-5} — {one-line justification}
+
+## Architecture Overview
+{PlantUML diagram if available, otherwise text description}
+{Key services, data flows, trust boundaries}
+
+## Pillar Scorecard
+| Pillar | Score (1-5) | Questions Assessed | Key Strength | Key Gap |
+|--------|-------------|-------------------|--------------|---------|
+| Operational Excellence | {score} | 11/11 | {strength} | {gap} |
+| Security | {score} | 11/11 | {strength} | {gap} |
+| Reliability | {score} | 13/13 | {strength} | {gap} |
+| Performance Efficiency | {score} | 5/5 | {strength} | {gap} |
+| Cost Optimization | {score} | 11/11 | {strength} | {gap} |
+| Sustainability | {score} | 6/6 | {strength} | {gap} |
+
+## Per-Question Assessment
+| ID | Question | Status | Risk Level | Key Evidence |
+|----|----------|--------|------------|--------------|
+| OPS 1 | Priorities | {status} | {risk or N/A} | {evidence} |
+| ... | ... | ... | ... | ... |
+| SUS 6 | Process and culture | {status} | {risk or N/A} | {evidence} |
+
+{Complete this table for all 57 questions — do not truncate}
+
+## Full BP Ledger (MANDATORY)
+
+**This section MUST list every BP citation produced by every subagent.** Concatenate
+all 6 subagent tables here, sorted by pillar then BP ID. Do NOT filter, cluster, or
+paraphrase. Target row count: 250-307.
+
+| BP ID | Pillar | Status | Severity | Evidence | Recommendation |
+|-------|--------|--------|----------|----------|-----------------|
+| OPS01-BP01 | Operational Excellence | {status} | {severity or blank} | {evidence} | {recommendation} |
+| ... | ... | ... | ... | ... | ... |
+| SUS06-BP05 | Sustainability | {status} | {severity or blank} | {evidence} | {recommendation} |
+
+{After writing this table, count the rows and confirm the count matches the sum of
+subagent rows. If not, you dropped citations — go back and add them.}
+
+## Critical and High Risk Findings
+{For each: ID, pillar, title, description, evidence, impact, recommendation, effort, AWS services.
+ This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
+
+## Medium Risk Findings
+{Same format, condensed.}
+
+## Low Risk Findings
+{Summary table: ID | Pillar | Title | Recommendation}
+
+## Cross-Pillar Trade-offs
+{Conflicts between pillars and recommended resolution}
+
+## Prioritize Improvements — Eisenhower Matrix
+
+| Quadrant | Action | Findings |
+|----------|--------|----------|
+| **Do First** (High Importance, Low Effort) | Implement immediately | {finding IDs} |
+| **Plan** (High Importance, High Effort) | Schedule in roadmap | {finding IDs} |
+| **Delegate** (Low Importance, Low Effort) | Batch, assign | {finding IDs} |
+| **Defer** (Low Importance, High Effort) | Revisit next iteration | {finding IDs} |
+
+## Prioritized Remediation Plan
+
+### Quick Wins (< 1 week) — "Do First" quadrant
+| Finding | Action | SMART Goal | Owner Suggestion | Effort |
+|---------|--------|-----------|-----------------|--------|
+
+### Foundation (1-4 weeks) — "Plan" quadrant
+| Finding | Action | Phases | Effort | Dependencies |
+|---------|--------|--------|--------|--------------|
+
+### Strategic (1-3 months) — "Plan" quadrant (complex)
+| Finding | Action | Phases | Effort | Dependencies |
+|---------|--------|--------|--------|--------------|
+
+### Deferred — Revisit Next Iteration
+{Findings in "Delegate" and "Defer" quadrants with brief justification}
+
+## Next Steps
+{Top 5 concrete actions from the "Do First" quadrant}
+```
+
+## Calibration Guidance
+
+- A workload with multi-AZ, encryption, CI/CD with rollback, monitoring, and auto-scaling is MATURE — most findings should be improvements, not Critical
+- Do NOT manufacture Critical findings for a well-built workload — accuracy over alarm
+- When business criticality is "critical", apply stricter standards (multi-region DR, chaos testing, sub-minute RTO expected)
+- Every finding MUST have evidence — no generic recommendations without backing
+- If something cannot be determined from available evidence, say "Cannot Determine" and state what data would be needed
+- For on-premises workloads, "Cannot Determine" is rarely appropriate — observable signals (metrics, logs, source code) are always available; use them
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/metadata-devops-agent.json
+++ b/skills/wa-review/metadata-devops-agent.json
@@ -1,0 +1,61 @@
+{
+  "version": "2.2.0-devops-agent",
+  "organization": "AWS",
+  "date": "July 2026",
+  "abstract": "Well-Architected Framework review optimized for the AWS DevOps Agent context: autonomous execution, post-incident triggering, and evidence derived from incident history, metrics, logs, and source code already accessed during the investigation.",
+  "references": [
+    "https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html"
+  ],
+  "agent_types": [
+    "INCIDENT_RCA",
+    "ON_DEMAND"
+  ],
+  "triggers": [
+    "post-incident review",
+    "recurring failure",
+    "same incident type twice",
+    "architectural weakness identified",
+    "structural gap in root cause",
+    "why does this keep happening",
+    "WA review",
+    "well-architected review",
+    "architectural assessment",
+    "run a wa-review on",
+    "architecture health check"
+  ],
+  "not_for": [
+    "routine incident triage — use standard investigation flow",
+    "learning WA concepts — use wa-builder instead",
+    "migration readiness assessment — use migration-readiness instead",
+    "generating guardrails or enforcement controls — use wa-guardrails instead"
+  ],
+  "metadata": {
+    "service": [
+      "well-architected",
+      "iam",
+      "kms",
+      "vpc",
+      "guardduty",
+      "security-hub",
+      "backup",
+      "auto-scaling",
+      "cloudwatch",
+      "cost-explorer"
+    ],
+    "task": [
+      "review",
+      "assess",
+      "audit",
+      "post-incident-analysis"
+    ],
+    "persona": [
+      "solutions-architect",
+      "devops-engineer",
+      "platform-engineer",
+      "site-reliability-engineer"
+    ],
+    "workload": [
+      "any"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Three related improvements shipping together:

### 1. `SKILL-devops-agent.md` (new) + `metadata-devops-agent.json` (new)

Dedicated wa-review variant for AWS DevOps Agent, addressing three friction points in the interactive SKILL.md:

- **Wrong triggers** — new description fires on post-incident RCA and explicit on-demand requests; `agent_types: [INCIDENT_RCA, ON_DEMAND]` instead of `GENERIC`
- **Interactive checkpoints** — both `---STOP---` blocks replaced with non-blocking summary lines
- **Wrong workload discovery model** — Step 1 derives context from incident ticket, findings, metrics, logs, and source code; never prompts the user

New additions:
- **Step 1b**: post-incident framing — connects WA findings to incident timeline, elevates severity for proven failure modes (likelihood = proven), leads Executive Summary with incident trigger + mapped BP ID
- **Step 2**: IaC-less fallback for on-premises workloads — metrics, logs, source code as evidence; absence of IaC is itself an OPS 5 finding

Steps 4–6 (subagent dispatch, Full BP Ledger, Eisenhower Matrix) preserved verbatim — the empirically-validated core is unchanged.

Closes #103.

### 2. Kiro runtime validation

wa-review v2.2 was measured on the Kiro CLI (`claude-opus-4.6`) over the same cases and the same ground truth used for the Claude Code CLI. Results are equivalent across both runtimes: the skill's architecture — not the runtime — determines effectiveness.

Also fixed a Kiro-specific issue: in non-interactive mode, score mode (Case 6) was offering the Full BP Ledger as a follow-up action instead of producing it inline. Adding an explicit "do NOT offer follow-up actions" instruction to the eval preamble resolved it.

### 3. Task tool support documented per runtime

Research confirmed which of the 14 supported tools implement parallel subagent dispatch:
- ✅ **Claude Code** (Agent tool — measured)
- ✅ **Kiro** (measured)
- ✅ **Amp** (Subagents feature, documented at ampcode.com/manual)
- ❌ Cursor, Codex, GitHub Copilot, Gemini CLI, Amazon Q Developer — sequential only

README effectiveness section updated to be specific rather than vague about runtime requirements.

## Files changed

- `skills/wa-review/SKILL-devops-agent.md` — new autonomous variant
- `skills/wa-review/metadata-devops-agent.json` — new metadata with INCIDENT_RCA + ON_DEMAND agent types
- `evals/cli_effectiveness/measure_kiro.py` — new Kiro harness (credits capture, Case 6 preamble fix, resume logic, model pinning)
- `README.md` — DevOps Agent section, Kiro runtime coverage, mermaid diagram update, Task tool support clarification

## Test plan

- [ ] Upload `SKILL-devops-agent.md` zip to a DevOps Agent Agent Space and verify it loads on a post-incident investigation without being explicitly invoked
- [ ] Verify `measure_kiro.py` runs end-to-end: `cd evals && uv run python cli_effectiveness/measure_kiro.py`
- [ ] Verify the README DevOps Agent section renders correctly

---

_Edited to remove measurement figures. The measurement harnesses ship in [`evals/`](https://github.com/aws-samples/sample-well-architected-skills-and-steering/tree/main/evals) so you can measure in your own environment._
