### PR TITLE
fix: invalid frontmatter YAML in wa-builder SKILL.md

### DIFF
--- a/skills/wa-builder/SKILL.md
+++ b/skills/wa-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wa-builder
-description: "Learn then Build" — help developers understand AWS Well-Architected best practices for their specific workload, then produce actionable visual artifacts (architecture diagrams with WA annotations, decision trees, improvement roadmaps) they can commit and use. Adapts explanations for beginners and generates artifacts faster for experienced builders. Use when the user wants to understand WA for their project, create architecture diagrams with pillar health overlays, get guided decision flows for architectural choices, or generate a visual improvement roadmap.
+description: '"Learn then Build" — help developers understand AWS Well-Architected best practices for their specific workload, then produce actionable visual artifacts (architecture diagrams with WA annotations, decision trees, improvement roadmaps) they can commit and use. Adapts explanations for beginners and generates artifacts faster for experienced builders. Use when the user wants to understand WA for their project, create architecture diagrams with pillar health overlays, get guided decision flows for architectural choices, or generate a visual improvement roadmap.'
 not_for: assessments or reviews that produce findings (use wa-review), migration planning (use migration-readiness), generating guardrails (use wa-guardrails), facilitating a WAFR (use wafr-facilitator)
 version: 1.0.0
 ---


### PR DESCRIPTION
## Summary

Fix invalid YAML frontmatter in `skills/wa-builder/SKILL.md`.

```yaml
Error in user YAML: (<unknown>): did not find expected key while parsing a block mapping at line 1 column 1
```

<img width="1471" height="714" alt="image" src="https://github.com/user-attachments/assets/ea2dd546-5cba-403c-ab3e-f39f0f1aa72d" />

The `description` value starts with a literal double quote:

```yaml
description: "Learn then Build" — help developers understand ...
```

In YAML, a value beginning with `"` is parsed as a double-quoted flow scalar, which terminates at the closing quote after `Learn then Build`. Everything after it (` — help developers...`) is trailing content, which is a parse error in any strict YAML parser (reproducible with `yq`: `line 1, column 33: did not find expected key` — column 33 is immediately after the closing quote). Agents that parse frontmatter leniently fall back to the H1 title as the skill description, so auto-triggering is degraded even when the files are copied into place manually.

The fix wraps the entire `description` value in single quotes. The value contains no single quotes, so no escaping is needed and the description text is unchanged byte-for-byte.

## Eval results (required for skill changes)

Not run — this is a metadata-only quoting fix with no behavioral surface:

- The skill instructions (everything below the frontmatter) are untouched.
- The description text is byte-identical; only two surrounding `'` characters are added.
- The eval harness injects `SKILL.md` verbatim into the system prompt (`load_skill` / `run_skill_evals` in `evals/run.py`), so the only prompt-level difference is those two quote characters.

## Test plan

- `gh skill install <fork>/sample-well-architected-skills-and-steering wa-builder@fix/wa-builder-frontmatter-yaml` succeeds end-to-end against this branch (on `main` the same command fails at the metadata-injection step with the error above).

```bash
gh skill install denvernine/sample-well-architected-skills-and-steering wa-builder@fix/wa-builder-frontmatter-yaml
Using ref fix/wa-builder-frontmatter-yaml (279c52a3)

! Skills are not verified by GitHub and may contain prompt injections, hidden instructions, or malicious scripts. Always review skill contents before use.


? Select target agent(s): Claude Code
? Installation scope: Project: denvernine/sample-well-architected-skills-and-steering (recommended)
✓ Installed wa-builder (from denvernine/sample-well-architected-skills-and-steering@fix/wa-builder-frontmatter-yaml) in .claude/skills

  wa-builder/
  ├── SKILL.md
  ├── evals/
  │   ├── evals.json
  │   └── triggering.json
  ├── metadata.json
  └── references/
      └── diagram-templates.md

! Skills may contain prompt injections or malicious scripts.
  Review installed content before use:

    gh skill preview denvernine/sample-well-architected-skills-and-steering wa-builder@279c52a35c13107ca51cae556533c40b6a2040a5
```

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
