### PR TITLE
Add MiniMax benchmark transport

### DIFF
--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -2,9 +2,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 """
-Model Benchmark — Compare Bedrock models on wa-review quality, cost, and latency.
+Model Benchmark — Compare configured models on wa-review quality, cost, and latency.
 
-Sends the same WA review prompt to multiple models via the Converse API,
+Sends the same WA review prompt to multiple models via Bedrock Converse or
+OpenAI-compatible chat endpoints,
 capturing: output text, input/output token counts, wall-clock latency,
 and (optionally) LLM-as-judge quality scores.
 
@@ -17,6 +18,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -59,6 +61,122 @@ MANTLE_RESPONSES_MODELS = {"openai.gpt-5.5", "openai.gpt-5.4"}
 def _is_mantle_model(model_id: str) -> bool:
     """Check if a model requires the bedrock-mantle endpoint."""
     return model_id in MANTLE_CHAT_MODELS or model_id in MANTLE_RESPONSES_MODELS
+
+
+def _openai_provider_for_model(config: dict, model_id: str) -> tuple[str, dict] | None:
+    """Return the configured OpenAI-compatible provider for a model, if any."""
+    for provider_name, provider in config.get("openai_compatible_providers", {}).items():
+        if model_id in provider.get("models", {}):
+            return provider_name, provider
+    return None
+
+
+def _to_openai_messages(messages: list[dict], system: str | None = None) -> list[dict]:
+    """Convert the benchmark's content-block messages to plain OpenAI messages."""
+    oai_messages = []
+    if system:
+        oai_messages.append({"role": "system", "content": system})
+    for msg in messages:
+        content = msg["content"]
+        if isinstance(content, list):
+            content = "".join(
+                block.get("text", "") for block in content if isinstance(block, dict)
+            )
+        oai_messages.append({"role": msg["role"], "content": content})
+    return oai_messages
+
+
+def _openai_compatible_request(endpoint: str, body: dict, api_key: str, timeout: int = 300):
+    """Send a bearer-authenticated request to an OpenAI-compatible endpoint."""
+    import requests as req
+
+    response = req.post(
+        endpoint,
+        json=body,
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def call_openai_compatible_model(config: dict, model_id: str, messages: list[dict],
+                                 system: str | None = None, max_tokens: int = 4096,
+                                 temperature: float = 0) -> dict:
+    """Call a configured model through its OpenAI-compatible chat endpoint."""
+    start = time.time()
+    provider_match = _openai_provider_for_model(config, model_id)
+    if provider_match is None:
+        return {
+            "model_id": model_id,
+            "error": "no OpenAI-compatible provider configured",
+            "latency_s": 0,
+        }
+
+    provider_name, provider = provider_match
+    api_key_env = provider["api_key_env"]
+    api_key = os.getenv(api_key_env)
+    if not api_key:
+        return {
+            "model_id": model_id,
+            "error": f"{api_key_env} is not set",
+            "latency_s": 0,
+        }
+
+    try:
+        endpoint_region = provider.get("endpoint_region", "global_en")
+        base_url = provider["endpoints"][endpoint_region].rstrip("/")
+        body = {
+            "model": model_id,
+            "messages": _to_openai_messages(messages, system=system),
+            "max_tokens": max_tokens,
+        }
+        if temperature is not None:
+            body["temperature"] = temperature
+
+        data = _openai_compatible_request(
+            f"{base_url}/chat/completions", body, api_key
+        )
+        choice = data.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        output_text = message.get("content") or ""
+        if isinstance(output_text, list):
+            output_text = "".join(
+                part.get("text", "") for part in output_text if isinstance(part, dict)
+            )
+        usage = data.get("usage") or {}
+        input_tokens = usage.get("prompt_tokens", 0) or 0
+        output_tokens = usage.get("completion_tokens", 0) or 0
+        cached_input_tokens = (
+            (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0) or 0
+        )
+    except Exception as e:
+        return {
+            "model_id": model_id,
+            "error": str(e),
+            "latency_s": time.time() - start,
+        }
+
+    latency = time.time() - start
+    if not output_text:
+        return {
+            "model_id": model_id,
+            "error": f"empty response from {provider_name}",
+            "latency_s": round(latency, 2),
+        }
+
+    return {
+        "model_id": model_id,
+        "output": output_text,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": usage.get("total_tokens", input_tokens + output_tokens),
+        "cached_input_tokens": cached_input_tokens,
+        "latency_s": round(latency, 2),
+        "stop_reason": choice.get("finish_reason", "unknown"),
+        "provider": provider_name,
+        "endpoint_region": endpoint_region,
+    }
 
 
 def _mantle_request(endpoint: str, body: dict, region: str, timeout: int = 300):
@@ -234,8 +352,9 @@ def _load_pillar_content() -> dict[str, str]:
 
 def call_model_subagent(client, model_id: str, workload_prompt: str,
                         system: str | None = None, max_tokens: int = 4096,
-                        temperature: float = 0, region: str = "us-east-1") -> dict:
-    """Subagent-pattern review: 6 parallel Converse calls (one per pillar) with
+                        temperature: float = 0, region: str = "us-east-1",
+                        config: dict | None = None) -> dict:
+    """Subagent-pattern review: 6 parallel model calls (one per pillar) with
     pre-loaded pillar references. Aggregates cost/latency/output.
 
     This measures what real users experience when following the shipped skill's
@@ -274,6 +393,11 @@ they are reviewed in separate subagent invocations."""
 
         messages = [{"role": "user", "content": [{"text": pillar_prompt}]}]
 
+        if config and _openai_provider_for_model(config, model_id):
+            return call_openai_compatible_model(
+                config, model_id, messages, system=system,
+                max_tokens=max_tokens, temperature=temperature,
+            )
         if _is_mantle_model(model_id):
             return call_mantle_model(model_id, messages, system=system,
                                      max_tokens=max_tokens, temperature=temperature,
@@ -382,7 +506,14 @@ def compute_cost(result: dict, pricing: dict) -> float | None:
     if model_id not in pricing or "error" in result:
         return None
     rates = pricing[model_id]
-    input_cost = (result["input_tokens"] / 1_000_000) * rates["input"]
+    cached_input_tokens = max(
+        0, min(result.get("cached_input_tokens", 0), result["input_tokens"])
+    )
+    uncached_input_tokens = result["input_tokens"] - cached_input_tokens
+    input_cost = (uncached_input_tokens / 1_000_000) * rates["input"]
+    input_cost += (cached_input_tokens / 1_000_000) * rates.get(
+        "cache_read", rates["input"]
+    )
     output_cost = (result["output_tokens"] / 1_000_000) * rates["output"]
     return round(input_cost + output_cost, 6)
 
@@ -473,7 +604,13 @@ def run_benchmark(config: dict, models: list[str], grade: bool = False) -> dict:
                 result = call_model_subagent(client, model_id, user_prompt,
                                              system=system_prompt,
                                              max_tokens=max_tokens,
-                                             temperature=temperature, region=region)
+                                             temperature=temperature, region=region,
+                                             config=config)
+            elif _openai_provider_for_model(config, model_id):
+                result = call_openai_compatible_model(
+                    config, model_id, messages, system=system_prompt,
+                    max_tokens=max_tokens, temperature=temperature,
+                )
             elif _is_mantle_model(model_id):
                 result = call_mantle_model(model_id, messages, system=system_prompt,
                                            max_tokens=max_tokens, temperature=temperature, region=region)
@@ -514,6 +651,8 @@ def run_benchmark(config: dict, models: list[str], grade: bool = False) -> dict:
 
         def _model_family(model_id: str) -> str:
             """Extract provider family for self-grading exclusion."""
+            if "minimax" in model_id.lower():
+                return "minimax"
             if "anthropic" in model_id:
                 return "anthropic"
             if "openai" in model_id or "gpt" in model_id:
@@ -543,8 +682,8 @@ def run_benchmark(config: dict, models: list[str], grade: bool = False) -> dict:
             judge_scores = []
             for judge in eligible_judges:
                 print(f"  {r['model_id']} ← judged by {judge}...")
-                if _is_mantle_model(judge):
-                    # Use mantle for grading (Chat Completions format)
+                if _is_mantle_model(judge) or _openai_provider_for_model(config, judge):
+                    # Use the configured OpenAI-compatible transport for grading.
                     grading_prompt = f"""You are an expert evaluator for AWS Well-Architected reviews.
 
 Score the following model output against each criterion on a 1-5 scale:
@@ -567,13 +706,21 @@ Respond with ONLY a JSON object:
   }},
   "overall": <1-5 average rounded to 1 decimal>
 }}"""
-                    mantle_result = call_mantle_model(
-                        judge,
-                        [{"role": "user", "content": [{"text": grading_prompt}]}],
-                        max_tokens=2048, temperature=0, region=region,
-                    )
-                    if "error" not in mantle_result:
-                        text = mantle_result["output"]
+                    if _is_mantle_model(judge):
+                        transport_result = call_mantle_model(
+                            judge,
+                            [{"role": "user", "content": [{"text": grading_prompt}]}],
+                            max_tokens=2048, temperature=0, region=region,
+                        )
+                    else:
+                        transport_result = call_openai_compatible_model(
+                            config,
+                            judge,
+                            [{"role": "user", "content": [{"text": grading_prompt}]}],
+                            max_tokens=2048, temperature=0,
+                        )
+                    if "error" not in transport_result:
+                        text = transport_result["output"]
                         try:
                             start_idx = text.find("{")
                             end_idx = text.rfind("}") + 1
@@ -644,7 +791,7 @@ def print_summary(benchmark: dict):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Benchmark Bedrock models on WA review tasks")
+    parser = argparse.ArgumentParser(description="Benchmark configured models on WA review tasks")
     parser.add_argument("--config", type=Path, default=CONFIG_PATH, help="Config file path")
     parser.add_argument("--models", nargs="+", help="Override model list from config")
     parser.add_argument("--grade", action="store_true", help="Run LLM-as-judge quality grading")

--- a/evals/benchmark_config.yaml
+++ b/evals/benchmark_config.yaml
@@ -25,6 +25,9 @@ models:
   # OpenAI (bedrock-mantle endpoint)
   - openai.gpt-oss-120b
   - openai.gpt-5.5
+  # MiniMax (OpenAI-compatible endpoint)
+  - MiniMax-M3
+  - MiniMax-M2.7
 
 # Generation settings
 max_tokens: 4096
@@ -33,6 +36,25 @@ max_tokens: 4096
 # temperature anyway. Use --temperature to override for real-world comparison.
 temperature: 0
 concurrency: 4
+
+# OpenAI-compatible provider configuration. Set MINIMAX_API_KEY before invoking
+# the MiniMax models. Change endpoint_region to cn_zh for the China endpoint.
+openai_compatible_providers:
+  MiniMax:
+    api_key_env: MINIMAX_API_KEY
+    endpoint_region: global_en
+    endpoints:
+      global_en: https://api.minimax.io/v1
+      cn_zh: https://api.minimaxi.com/v1
+    models:
+      MiniMax-M3:
+        context_window: 1000000
+        input_modalities: [text, image, video]
+        thinking: [adaptive, disabled]
+      MiniMax-M2.7:
+        context_window: 204800
+        input_modalities: [text]
+        thinking: [always_on]
 
 # Prompt: a realistic WA review question with code context
 prompt:
@@ -140,15 +162,26 @@ pricing:
   openai.gpt-oss-120b:
     input: 0.1545
     output: 0.6180
+  MiniMax-M3:
+    input: 0.60
+    output: 2.40
+    cache_read: 0.12
+    cache_write: null
+  MiniMax-M2.7:
+    input: 0.30
+    output: 1.20
+    cache_read: 0.06
+    cache_write: 0.375
 
 # Quality grading (used with --grade flag)
-# Multi-model judge panel: 3 judges, no self-grading (a model never judges itself).
+# Multi-model judge panel: 4 judges, no self-grading (a model never judges itself).
 # Final score = average across all eligible judges for each model.
 grading:
   panel:
     - us.anthropic.claude-sonnet-4-6
     - us.deepseek.r1-v1:0
     - openai.gpt-oss-120b
+    - MiniMax-M3
   criteria:
     - "Covers all 6 WA pillars (Operational Excellence, Security, Reliability, Performance Efficiency, Cost Optimization, Sustainability)"
     - "Identifies the single-AZ ECS deployment as a reliability risk"

--- a/evals/tests/test_benchmark.py
+++ b/evals/tests/test_benchmark.py
@@ -1,0 +1,181 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for the benchmark transport and model configuration."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from benchmark import (  # noqa: E402
+    _openai_provider_for_model,
+    call_openai_compatible_model,
+    compute_cost,
+    load_config,
+    run_benchmark,
+)
+
+
+def _response():
+    return {
+        "choices": [{
+            "message": {"content": "test response"},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 4,
+            "total_tokens": 14,
+            "prompt_tokens_details": {"cached_tokens": 2},
+        },
+    }
+
+
+def test_minimax_config_contains_current_models_and_metadata():
+    config = load_config()
+    provider = config["openai_compatible_providers"]["MiniMax"]
+
+    assert config["models"][-2:] == ["MiniMax-M3", "MiniMax-M2.7"]
+    assert provider["endpoint_region"] == "global_en"
+    assert provider["endpoints"] == {
+        "global_en": "https://api.minimax.io/v1",
+        "cn_zh": "https://api.minimaxi.com/v1",
+    }
+    assert provider["models"]["MiniMax-M3"] == {
+        "context_window": 1000000,
+        "input_modalities": ["text", "image", "video"],
+        "thinking": ["adaptive", "disabled"],
+    }
+    assert provider["models"]["MiniMax-M2.7"] == {
+        "context_window": 204800,
+        "input_modalities": ["text"],
+        "thinking": ["always_on"],
+    }
+    assert config["pricing"]["MiniMax-M3"] == {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_read": 0.12,
+        "cache_write": None,
+    }
+    assert config["pricing"]["MiniMax-M2.7"] == {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_read": 0.06,
+        "cache_write": 0.375,
+    }
+    assert "MiniMax-M3" in config["grading"]["panel"]
+
+
+@pytest.mark.parametrize(
+    ("endpoint_region", "endpoint"),
+    [
+        ("global_en", "https://api.minimax.io/v1/chat/completions"),
+        ("cn_zh", "https://api.minimaxi.com/v1/chat/completions"),
+    ],
+)
+def test_openai_compatible_call_uses_configured_region(
+    monkeypatch, endpoint_region, endpoint
+):
+    config = load_config()
+    config["openai_compatible_providers"]["MiniMax"]["endpoint_region"] = endpoint_region
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    messages = [{"role": "user", "content": [{"text": "hello"}]}]
+
+    with patch("benchmark._openai_compatible_request", return_value=_response()) as request:
+        result = call_openai_compatible_model(
+            config,
+            "MiniMax-M3",
+            messages,
+            system="system prompt",
+            max_tokens=128,
+            temperature=0,
+        )
+
+    request.assert_called_once()
+    request_endpoint, body, api_key = request.call_args.args
+    assert request_endpoint == endpoint
+    assert api_key == "test-key"
+    assert body == {
+        "model": "MiniMax-M3",
+        "messages": [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "hello"},
+        ],
+        "max_tokens": 128,
+        "temperature": 0,
+    }
+    assert result["output"] == "test response"
+    assert result["input_tokens"] == 10
+    assert result["output_tokens"] == 4
+    assert result["cached_input_tokens"] == 2
+    assert result["endpoint_region"] == endpoint_region
+
+
+def test_openai_compatible_call_reports_missing_api_key(monkeypatch):
+    config = load_config()
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+
+    with patch("benchmark._openai_compatible_request") as request:
+        result = call_openai_compatible_model(
+            config,
+            "MiniMax-M2.7",
+            [{"role": "user", "content": [{"text": "hello"}]}],
+        )
+
+    assert result["error"] == "MINIMAX_API_KEY is not set"
+    request.assert_not_called()
+
+
+def test_run_benchmark_routes_minimax_to_openai_compatible_transport():
+    config = load_config()
+    config["prompt"] = {"user": "test prompt"}
+    config["concurrency"] = 1
+    result = {
+        "model_id": "MiniMax-M3",
+        "output": "test response",
+        "input_tokens": 10,
+        "output_tokens": 4,
+        "total_tokens": 14,
+        "latency_s": 0.1,
+    }
+
+    with (
+        patch("benchmark.boto3.client"),
+        patch("benchmark.call_openai_compatible_model", return_value=result) as call,
+    ):
+        benchmark = run_benchmark(config, ["MiniMax-M3"])
+
+    call.assert_called_once()
+    assert call.call_args.args[0] is config
+    assert call.call_args.args[1] == "MiniMax-M3"
+    assert benchmark["results"][0]["model_id"] == "MiniMax-M3"
+
+
+def test_compute_cost_accounts_for_cached_input_tokens():
+    result = {
+        "model_id": "MiniMax-M3",
+        "input_tokens": 1000,
+        "cached_input_tokens": 400,
+        "output_tokens": 500,
+    }
+    pricing = {
+        "MiniMax-M3": {
+            "input": 0.6,
+            "output": 2.4,
+            "cache_read": 0.12,
+        }
+    }
+
+    assert compute_cost(result, pricing) == 0.001608
+
+
+def test_openai_provider_lookup_is_model_specific():
+    config = load_config()
+
+    provider = _openai_provider_for_model(config, "MiniMax-M2.7")
+
+    assert provider is not None
+    assert provider[0] == "MiniMax"


### PR DESCRIPTION
Reason: Add MiniMax global and China OpenAI-compatible benchmark invocation with current model metadata.

Added a config-driven MiniMax transport with selectable global and China endpoints, registered the current model metadata and pricing, and routed benchmark generation, subagent, and grading calls through the configured transport. Added mocked regional routing, dispatch, usage, and cost tests.

Checks:
- `uv run pytest tests/test_benchmark.py tests/test_run.py tests/test_grade.py -q` (23 passed)
- `uv run python -m compileall -q benchmark.py tests/test_benchmark.py`
- `uv run python benchmark.py --help`
- `git diff --check`
- Secret scan passed.
- Full `uv run pytest -q` has one unrelated existing fixture failure in `tests/test_triggering.py::test_triggering_minimum_counts` because `wa-review` has 7 negative prompts while the test requires 8.
