### PR TITLE
fix(wa-review): add 8th negative triggering prompt to satisfy minimum count

### DIFF
--- a/skills/wa-review/evals/triggering.json
+++ b/skills/wa-review/evals/triggering.json
@@ -28,6 +28,7 @@
     {"text": "generate a WA improvement roadmap diagram", "should_trigger": false},
     {"text": "help me facilitate a WAFR with my customer", "should_trigger": false},
     {"text": "generate guardrails and Config rules for our account", "should_trigger": false},
-    {"text": "prepare conversational questions for a WA review session", "should_trigger": false}
+    {"text": "prepare conversational questions for a WA review session", "should_trigger": false},
+    {"text": "build a decision tree to help us choose between architecture options", "should_trigger": false}
   ]
 }


### PR DESCRIPTION
## Problem

`tests/test_triggering.py::test_triggering_minimum_counts` fails on a clean checkout of `main`:

```
AssertionError: wa-review: only 7 negative prompts (need ≥8)
```

The test requires every skill to ship at least 8 positive and 8 negative triggering prompts. `skills/wa-review/evals/triggering.json` had 8 positives but only 7 negatives, so `uv run pytest -q` is red out of the box.

## Why it matters

A red test suite on `main` breaks every contributor's baseline and any CI gate that runs the full suite — unrelated PRs (e.g. #111) inherit the failure.

## Fix (symptom → root cause → change)

- **Symptom:** minimum-count assertion fails for wa-review's negatives.
- **Root cause:** the file ships 7 negatives; the contract is ≥8.
- **Change:** add one *discriminative* negative — `"build a decision tree to help us choose between architecture options"` — which should route to **wa-builder**, not wa-review. Keeping the negative adjacent to WA review (rather than trivially off-topic) preserves the discriminative value of the triggering set.

## Tests

`cd evals && uv run pytest tests/test_triggering.py -q` → **4 passed**. The previously-failing `test_triggering_minimum_counts` now passes; format and no-duplicate tests remain green.

## Manual verification

N/A — the triggering test suite is the authoritative check for this file.

Fixes #112
