### PR TITLE
feat(wa-review): load pillar playbooks in devops-agent subagent dispatch

### DIFF
--- a/skills/wa-review/SKILL-devops-agent.md
+++ b/skills/wa-review/SKILL-devops-agent.md
@@ -199,27 +199,27 @@ Dispatch all 6 Task calls in a single turn (parallel execution). **Each subagent
 ```text
 Task(subagent_type="general-purpose",
      description="Review Operational Excellence",
-     prompt="Read references/pillars/operational-excellence.md, then review the following workload ONLY for the OPS pillar. Enumerate EVERY BP in the pillar file (all 30+ BPs) — do not filter to 'top issues'. Return findings as the mandatory markdown table (columns: BP ID | Status | Severity | Evidence | Recommendation) with one row per BP. Do NOT prepend narrative summary text before the table. Workload: {workload description + incident context}")
+     prompt="Read references/pillars/operational-excellence.md and references/pillar-playbooks/operational-excellence.md (domain-specific evidence-collection checklist: what to examine and what to flag as HIGH RISK), then review the following workload ONLY for the OPS pillar. Enumerate EVERY BP in the pillar file (all 30+ BPs) — do not filter to 'top issues'. Return findings as the mandatory markdown table (columns: BP ID | Status | Severity | Evidence | Recommendation) with one row per BP. Do NOT prepend narrative summary text before the table. Workload: {workload description + incident context}")
 
 Task(subagent_type="general-purpose",
      description="Review Security",
-     prompt="Read references/pillars/security.md, then review the workload ONLY for the SEC pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/security.md and references/pillar-playbooks/security.md (domain-specific evidence-collection checklist), then review the workload ONLY for the SEC pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Reliability",
-     prompt="Read references/pillars/reliability.md, then review the workload ONLY for the REL pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/reliability.md and references/pillar-playbooks/reliability.md (domain-specific evidence-collection checklist), then review the workload ONLY for the REL pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Performance Efficiency",
-     prompt="Read references/pillars/performance-efficiency.md, then review the workload ONLY for the PERF pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/performance-efficiency.md and references/pillar-playbooks/performance-efficiency.md (domain-specific evidence-collection checklist), then review the workload ONLY for the PERF pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Cost Optimization",
-     prompt="Read references/pillars/cost-optimization.md, then review the workload ONLY for the COST pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/cost-optimization.md and references/pillar-playbooks/cost-optimization.md (domain-specific evidence-collection checklist), then review the workload ONLY for the COST pillar. [same table format, every BP as a row] Workload: {workload}")
 
 Task(subagent_type="general-purpose",
      description="Review Sustainability",
-     prompt="Read references/pillars/sustainability.md, then review the workload ONLY for the SUS pillar. [same table format, every BP as a row] Workload: {workload}")
+     prompt="Read references/pillars/sustainability.md and references/pillar-playbooks/sustainability.md (domain-specific evidence-collection checklist), then review the workload ONLY for the SUS pillar. [same table format, every BP as a row] Workload: {workload}")
 ```
 
 **Total: 6 Task calls in one turn.** Each subagent runs independently with its own context, so each can be exhaustive without stealing from the others. The uniform table format means aggregation is a mechanical concatenation, not an interpretive summary — this prevents ~30-70% recall loss observed with narrative subagent output.


### PR DESCRIPTION
## Problem

PR #104 added pillar-playbook loading to the 6 Step 4b subagent dispatch prompts in `SKILL.md`. `SKILL-devops-agent.md` (shipped in #105) has identical Step 4b Task-dispatch templates but was never updated — its 6 prompts read only `references/pillars/{pillar}.md` and skip the domain-specific evidence-collection checklist that #104 introduced.

## Why it matters

The devops-agent variant's per-pillar subagents run without the playbook's "what to examine / what to flag as HIGH RISK" guidance, so their evidence collection is less targeted than the interactive `SKILL.md` path. The two files are meant to stay in lockstep on the dispatch pattern.

## Fix (symptom → root cause → change)

- **Symptom:** devops-agent subagents don't load pillar playbooks.
- **Root cause:** the 6 dispatch prompts were copied from pre-#104 `SKILL.md` and never received the follow-up.
- **Change:** each of the 6 Task prompts now also reads `references/pillar-playbooks/{pillar}.md`, matching `SKILL.md` exactly (6 lines changed).

**Note on the filename mapping:** issue #107 lists `pillar-playbooks/performance.md` and `pillar-playbooks/cost.md`, but the actual files (and what #104 used in `SKILL.md`) are **`performance-efficiency.md`** and **`cost-optimization.md`**. I followed the real files / SKILL.md pattern so every referenced path resolves — the mapping in the issue text is inaccurate for PERF and COST.

## Tests

No automated test covers prompt prose. Verified structurally: all 6 referenced `references/pillar-playbooks/*.md` files exist on `main`, and the resulting prompts are byte-aligned with `SKILL.md`'s equivalents.

## Manual verification

- `grep -c pillar-playbooks SKILL-devops-agent.md` → 7 (6 dispatch prompts + 1 pre-existing supporting-file line).
- Confirmed each of the 6 referenced playbook files resolves under `references/pillar-playbooks/`.
- Diff is exactly 6 insertions / 6 deletions in one file — no unrelated content.

Closes #107
