### PR TITLE
feat(wa-review): add Cannot Determine evidence-sufficiency gate + eval harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ evals/cli_effectiveness/wa_review_baseline.json
 evals/cli_effectiveness/mcp_effectiveness.json
 evals/cli_effectiveness/bp_embeddings.json
 evals/cli_effectiveness/aws_knowledge_mcp_effectiveness.json
+evals/cli_effectiveness/codex_effectiveness.json
+evals/cli_effectiveness/kiro_effectiveness.json
+evals/cli_effectiveness/review_quality_results.json
+evals/cli_effectiveness/review_artifacts/
 
 # Generated study charts
 docs/study/

--- a/evals/cli_effectiveness/README.md
+++ b/evals/cli_effectiveness/README.md
@@ -12,6 +12,7 @@ This directory ships the real-measurement harness we used to validate `wa-review
 - `measure_baseline.py` — paired baseline: `claude -p --safe-mode --disable-slash-commands` from a scratch workdir (no skill, no CLAUDE.md, no plugins). Same prompts, same ground truth. The delta between the two is the honest measure of what the skill adds.
 - `generate_ground_truth.py` — regenerates the ground truth. Not needed for the shipped v1 data (already in `ground_truth/`), but useful if you want to re-derive against different consensus rules or additional models.
 - `ground_truth/case_N.json` — six frozen consensus datasets, one per eval case. Each JSON contains the consensus applicable-BP list and per-model per-run citation frequencies.
+- `review_quality.py` — evaluation-only blind and adversarial review of captured reports. It measures evidence, status, severity, recommendation, and uncertainty quality without changing the skill.
 
 ## When to use this vs `evals/run.py`
 
@@ -50,6 +51,100 @@ Each configuration runs 18 CLI invocations (6 cases × 3 runs). Results are save
 
 Both files are gitignored — they're your local measurements.
 
+## Blind and adversarial quality review
+
+Citation F1 measures coverage, not whether findings are supported or correctly
+calibrated. The quality harness adds two independent, anonymous pillar reviewers
+and a third-family adversarial adjudicator. Reviewers receive the workload,
+candidate ledger, and public WA reference, but not the candidate model, runtime,
+skill/baseline condition, cost, or existing scores.
+
+Generate fresh effectiveness output first; current harnesses retain the full
+assembled report in their gitignored result JSON. Then run the two-case pilot:
+
+```bash
+cd evals
+uv run python cli_effectiveness/measure_wa_review.py
+uv run python cli_effectiveness/review_quality.py --pilot
+```
+
+The pilot selects one successful run each for cases 2 and 3. To review selected
+cases or more runs:
+
+```bash
+uv run python cli_effectiveness/review_quality.py --cases 1 2 3 --runs 2
+```
+
+Generate a fresh single-case candidate without launching the default 18 calls:
+
+```bash
+uv run python cli_effectiveness/measure_wa_review.py \
+  --cases 2 --runs 1 --model opus \
+  --output cli_effectiveness/review_artifacts/e2e-v221/candidate_results.json
+```
+
+Then run its blind and adversarial review with isolated raw artifacts:
+
+```bash
+uv run python cli_effectiveness/review_quality.py \
+  --results cli_effectiveness/review_artifacts/e2e-v221/candidate_results.json \
+  --cases 2 --runs 1 \
+  --output cli_effectiveness/review_artifacts/e2e-v221-schema-v3/quality_results.json \
+  --artifacts-dir cli_effectiveness/review_artifacts/e2e-v221-schema-v3/responses \
+  --chunk-size 5 --concurrency 2 --retries 1
+```
+
+The output, `cli_effectiveness/review_quality_results.json`, reports status and
+severity agreement, weighted kappa, evidence availability, assertion precision,
+uncertainty recall, over-conservatism, Critical/High precision, recommendation
+quality, adversarial overturns, tokens, cost, and latency. Candidate reports
+remain in the gitignored effectiveness JSON; raw reviewer responses remain
+under the gitignored `cli_effectiveness/review_artifacts/` directory. An
+incomplete model response is recorded as incomplete and is never averaged into
+a quality score.
+
+Schema v3 parses candidate status and severity directly from the captured
+ledger. Reviewers cannot override those fields. Every independent conclusion
+must include a provenance kind and, for determinate or inconclusive conclusions,
+an evidence ID from a deterministic catalog of exact workload spans. The
+harness resolves that ID to the source quote, avoiding model paraphrases while
+preserving exact provenance. Omitted details require `Cannot Determine`;
+`authoritative_absence` is rejected for these verbal-only eval cases. The
+adversary can select only a complete status/evidence tuple supplied by one of
+the blind reviewers and receives no ground-truth status ledger.
+
+Uncertainty is reported as both a rate and explicit counts
+(`uncertainty_aligned_count / uncertainty_items`). The harness separately
+reports over-conservatism, determinate and negative assertion precision,
+legitimate unknowns, and evidence availability. These rates use global
+numerators and denominators rather than unweighted averages of pillar rates.
+
+Reviewer and adversary calls are scoped to 20 BPs by default. Valid rows are
+retained and only unresolved rows are retried once; full-pillar completeness is
+still required before metrics are included. Adjust with `--chunk-size` and
+`--retries` when testing model-specific output limits.
+
+If a model throttles or a chunk remains malformed, rerun against the same output
+with a smaller chunk and `--resume`. Completed rows and their cost metadata are
+reused:
+
+```bash
+uv run python cli_effectiveness/review_quality.py \
+  --results cli_effectiveness/review_artifacts/e2e-v221/candidate_results.json \
+  --cases 2 --runs 1 \
+  --output cli_effectiveness/review_artifacts/e2e-v221-schema-v3/quality_results.json \
+  --artifacts-dir cli_effectiveness/review_artifacts/e2e-v221-schema-v3/responses \
+  --chunk-size 5 --concurrency 2 --resume
+```
+
+Resume files must use the current quality-output schema version. When evaluator
+invariants change, start a fresh quality output rather than reusing older rows.
+
+By default the panel uses OpenAI and Amazon models as blind reviewers and a
+DeepSeek model as adversary. Candidate-family self-grading and same-family
+reviewer panels are rejected. Override model IDs with `--reviewers` and
+`--adversary` when evaluating a different candidate family.
+
 **Expected results (v2.2 wa-review, Opus tier):**
 
 | Configuration | Mean report F1 | Mean recall | Cost/run | Wall/run |
@@ -66,13 +161,19 @@ If your numbers land far below this (say, report F1 < 0.85 with skill), likely c
 
 ## Ground truth methodology
 
-For each of the 6 eval cases, we ran a consensus panel:
+For each of the 6 eval cases, we ran a workload-only consensus panel:
 
 - **2 top-tier models**: Claude Sonnet 5 and OpenAI GPT OSS 120B, both via Amazon Bedrock
 - **5 independent runs per model** with subagent-per-pillar dispatch (`call_model_subagent` from `evals/benchmark.py`) — 60 runs total per case
 - **Consensus rule**: a BP is "applicable" only if cited by **both models** in **≥3 of their 5 runs**
 
 This yields 270–306 applicable BPs per case out of the 307-BP canonical corpus — a defensible set of "what a strong review should catch" that neither model alone could have hallucinated into existence.
+
+Newly generated ground truth also includes a structured reference ledger with
+consensus applicability, expected status, acceptable severity, evidence basis,
+confidence, and model votes. Raw panel responses are written only to the
+gitignored review-artifact directory; tracked ground truth contains derived
+consensus.
 
 The two-model panel was chosen after Claude Fable 5 (originally the third judge) was heavily throttled on both `bedrock-runtime` and `bedrock-mantle` endpoints, producing zero successful runs. Sonnet 5 and GPT OSS 120B both scored 5.0/5 in our earlier per-question quality benchmark, so their intersection is a strong signal.
 
@@ -97,4 +198,5 @@ Cost: ~$40, ~30 min. Not needed unless you're deliberately re-deriving the groun
 - **Six cases is a small sample.** The variance we measure (zero in v2.2, moderate in baseline) is within-configuration; between-workload generalization is a separate question.
 - **Consensus ground truth is not oracle truth.** Two models agreeing on a BP doesn't guarantee it's actually applicable; it means two strong models thought so. Case 3's slightly weaker consensus (4.2% borderline BPs vs 1.3% for Case 2) hints at this.
 - **F1 is not the whole story.** A review that hits F1 = 1.00 by enumerating every BP is not automatically useful — the *severity* assignment and *recommendation* content matter too. This harness measures citation coverage only.
+- **Model review is not human adjudication.** Blind and adversarial scores expose disagreement and unsupported claims, but shared model bias remains possible. Preserve unresolved outcomes instead of treating the panel as an oracle.
 - **Opus tier is expensive.** ~$7 per with-skill run × 18 runs = ~$125 to reproduce the full effectiveness measurement. The baseline is ~$2 total.

--- a/evals/cli_effectiveness/generate_ground_truth.py
+++ b/evals/cli_effectiveness/generate_ground_truth.py
@@ -4,7 +4,9 @@
 """Generate ground-truth applicable-BP sets for wa-review eval cases.
 
 Uses the subagent-per-pillar pattern (call_model_subagent from benchmark.py)
-against 2 top-tier models × 5 runs × 6 eval cases = 60 total runs.
+against 2 top-tier models × 5 runs × 6 eval cases = 60 total runs. Each model
+produces a structured workload-only reference ledger before any candidate
+report is revealed.
 
 Ground-truth criteria (both-models consensus):
   - A BP is "applicable" if cited by BOTH models in ≥3 of 5 runs each.
@@ -22,6 +24,7 @@ import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any
 
 import boto3
 from botocore.config import Config as BotoConfig
@@ -30,9 +33,15 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 EVALS_DIR = SCRIPT_DIR.parent
 REPO_ROOT = EVALS_DIR.parent
 GT_DIR = SCRIPT_DIR / "ground_truth"
+RAW_ARTIFACTS_DIR = SCRIPT_DIR / "review_artifacts" / "ground_truth"
 
 sys.path.insert(0, str(EVALS_DIR))
 from benchmark import call_model_subagent  # noqa: E402
+sys.path.insert(0, str(SCRIPT_DIR))
+from review_quality import (  # noqa: E402
+    normalize_reference_row,
+    parse_model_rows,
+)
 
 MODELS = [
     "us.anthropic.claude-sonnet-5",
@@ -43,25 +52,13 @@ MODELS = [
 ]
 
 RUNS_PER_MODEL = 5
-# Accept ASCII hyphen (-, U+002D), non-breaking hyphen (‑, U+2011),
-# hyphen-minus (‐, U+2010), and em-dash lookalike (—) — models produce all these.
-BP_PATTERN = re.compile(r"\b([A-Z]{2,}\d{1,3})[-‐‑–]BP(\d{1,3})\b")
 
+SYSTEM_PROMPT = """You are an AWS Well-Architected expert creating an independent
+workload-only reference ledger for evaluation.
 
-def _normalize_bp(match: re.Match) -> str:
-    """Return a canonical BP ID (ASCII hyphen) from a regex match."""
-    return f"{match.group(1)}-BP{match.group(2)}"
-
-
-def _extract_bps(text: str) -> set[str]:
-    """Extract BP IDs from text, normalizing any Unicode-hyphen variants."""
-    return {_normalize_bp(m) for m in BP_PATTERN.finditer(text)}
-
-SYSTEM_PROMPT = """You are an AWS Well-Architected expert performing a comprehensive review.
-
-Analyze the workload described and produce findings grouped by pillar (Operational
-Excellence, Security, Reliability, Performance Efficiency, Cost Optimization,
-Sustainability). This is a research protocol — coverage matters.
+Analyze only the workload description and authoritative pillar reference. You
+will not receive a candidate report. This is a research protocol: evidence
+fidelity and complete coverage matter.
 
 MANDATORY citation format: cite every Best Practice using the canonical WA
 identifier `PILLAR##-BP##`, for example:
@@ -70,9 +67,29 @@ identifier `PILLAR##-BP##`, for example:
 Do NOT use shorthand ("SEC-1", "REL 2") or severity-based numbering ("CRITICAL-01").
 Do NOT invent BP IDs. Cite the canonical form only.
 
-Enumerate every BP that applies to the workload — target 30-55 BPs per pillar for
-a comprehensive review. Include "Not Implemented" findings for absent controls
-and "Not Applicable" for genuinely inapplicable BPs (with brief rationale)."""
+Do not treat information omitted from a short workload description as proof that
+a control is not implemented. Use Cannot Determine when the evidence is
+insufficient."""
+
+STRUCTURED_PILLAR_TASK = """Review the workload ONLY for the {pillar_name} pillar.
+Enumerate every canonical BP in the supplied pillar reference, including BPs
+that are not applicable or cannot be determined.
+
+Return ONLY one JSON object:
+{{"rows":[{{"bp_id":"SEC01-BP01","applicability":"applicable",
+"expected_status":"Cannot Determine","expected_severity":null,
+"evidence_basis":"The workload description does not provide account governance evidence.",
+"confidence":"high"}}]}}
+
+Allowed applicability values: applicable, not_applicable, uncertain.
+Allowed status values: Implemented, Partially Implemented, Not Implemented,
+Not Applicable, Cannot Determine. Allowed severity values: Critical, High,
+Medium, Low, or null. Confidence must be high, medium, or low.
+Use null severity for Implemented, Not Applicable, and Cannot Determine. Assign
+severity only to an evidenced gap. Keep evidence_basis to one concise sentence.
+
+The rows array must contain exactly one unique row for every BP in this pillar.
+Do not include markdown or narrative outside the JSON."""
 
 
 def load_eval_cases() -> list[dict]:
@@ -84,7 +101,7 @@ def load_eval_cases() -> list[dict]:
 
 def build_canonical_bps() -> set[str]:
     """Extract the 307 canonical BPs from the corpus (H1 headings)."""
-    refs_dir = REPO_ROOT / "skills" / "wa-review" / "references" / "questions"
+    refs_dir = REPO_ROOT / "skills" / "wa-review" / "references" / "pillars"
     canonical: set[str] = set()
     canonical_re = re.compile(r"^# ([A-Z]{2,}\d{1,3}-BP\d{1,3})\b", re.MULTILINE)
     for f in refs_dir.glob("*.md"):
@@ -94,12 +111,14 @@ def build_canonical_bps() -> set[str]:
 
 
 def run_one(client, model_id: str, prompt: str, canonical: set[str]) -> dict:
-    """Run a single subagent-mode call and extract valid BP citations."""
+    """Run a workload-only panel call and parse its structured BP ledger."""
     start = time.time()
     try:
         result = call_model_subagent(client, model_id, prompt,
-                                     system=SYSTEM_PROMPT, max_tokens=4096,
-                                     temperature=0, region="us-east-1")
+                                     system=SYSTEM_PROMPT, max_tokens=16384,
+                                     temperature=0, region="us-east-1",
+                                     pillar_task=STRUCTURED_PILLAR_TASK,
+                                     include_reasoning=False)
     except Exception as e:
         return {"model": model_id, "error": str(e), "latency_s": time.time() - start}
 
@@ -108,25 +127,172 @@ def run_one(client, model_id: str, prompt: str, canonical: set[str]) -> dict:
                 "latency_s": result.get("latency_s", 0)}
 
     output = result.get("output", "")
-    cited = _extract_bps(output)
-    valid = cited & canonical
+    assessment = parse_model_rows(output, canonical, normalize_reference_row)
+    if not assessment["complete"]:
+        return {
+            "model": model_id,
+            "error": (
+                "incomplete structured ledger: "
+                f"{len(assessment['missing_ids'])} missing, "
+                f"{len(assessment['invalid_rows'])} invalid"
+            ),
+            "raw_output": output,
+            "latency_s": result.get("latency_s", 0),
+        }
+    rows = assessment["rows"]
+    valid = {
+        bp_id
+        for bp_id, row in rows.items()
+        if row["applicability"] == "applicable"
+    }
     return {
         "model": model_id,
-        "cited_count": len(cited),
+        "cited_count": len(rows),
         "valid_count": len(valid),
         "valid_bps": sorted(valid),
+        "assessments": rows,
+        "raw_output": output,
         "output_tokens": result.get("output_tokens", 0),
         "input_tokens": result.get("input_tokens", 0),
         "latency_s": result.get("latency_s", 0),
     }
 
 
-def compute_ground_truth(runs: list[dict]) -> dict:
-    """Consensus rule: BP is 'applicable' if ≥2 of 3 models cited it in ≥3 of 5 runs each.
+def _stable_model_value(
+    model_runs: list[dict],
+    bp_id: str,
+    field: str,
+) -> tuple[Any | None, int]:
+    frequencies: dict[Any, int] = defaultdict(int)
+    for run in model_runs:
+        row = run.get("assessments", {}).get(bp_id)
+        if row is not None:
+            frequencies[row.get(field)] += 1
+    if not frequencies:
+        return None, 0
+    value, count = max(frequencies.items(), key=lambda item: (item[1], str(item[0])))
+    return (value, count) if count >= 3 else (None, count)
 
-    Also compute weaker signals for the output:
-      - critical_high_bps: reserved for future work (needs severity extraction, not just IDs)
-      - all_cited: union across all runs (upper bound of "applicable")
+
+def _reference_ledger(runs: list[dict], canonical: set[str]) -> dict[str, dict]:
+    successful = [run for run in runs if "error" not in run]
+    by_model = {
+        model: [run for run in successful if run["model"] == model]
+        for model in sorted({run["model"] for run in successful})
+    }
+    ledger: dict[str, dict] = {}
+    severity_order = {"Low": 1, "Medium": 2, "High": 3, "Critical": 4}
+
+    for bp_id in sorted(canonical):
+        votes: dict[str, dict[str, Any]] = {}
+        evidence_basis: list[str] = []
+        for model, model_runs in by_model.items():
+            applicability, applicability_count = _stable_model_value(
+                model_runs, bp_id, "applicability"
+            )
+            status, status_count = _stable_model_value(
+                model_runs, bp_id, "expected_status"
+            )
+            severity, severity_count = _stable_model_value(
+                model_runs, bp_id, "expected_severity"
+            )
+            votes[model] = {
+                "applicability": applicability,
+                "applicability_votes": applicability_count,
+                "expected_status": status,
+                "status_votes": status_count,
+                "expected_severity": severity,
+                "severity_votes": severity_count,
+            }
+            for run in model_runs:
+                row = run.get("assessments", {}).get(bp_id)
+                if (
+                    row
+                    and row["applicability"] == applicability
+                    and row["expected_status"] == status
+                    and row["evidence_basis"] not in evidence_basis
+                ):
+                    evidence_basis.append(row["evidence_basis"])
+                    break
+
+        applicability_values = {
+            vote["applicability"] for vote in votes.values()
+            if vote["applicability"] is not None
+        }
+        status_values = {
+            vote["expected_status"] for vote in votes.values()
+            if vote["expected_status"] is not None
+        }
+        severity_values = {
+            vote["expected_severity"] for vote in votes.values()
+            if vote["expected_severity"] is not None
+        }
+        all_models_stable = len(votes) == len(MODELS)
+        applicability_stable = all_models_stable and all(
+            vote["applicability"] is not None for vote in votes.values()
+        )
+        status_stable = all_models_stable and all(
+            vote["expected_status"] is not None for vote in votes.values()
+        )
+        severity_signatures = {
+            vote["expected_severity"] for vote in votes.values()
+            if vote["severity_votes"] >= 3
+        }
+        severity_stable = all_models_stable and all(
+            vote["severity_votes"] >= 3 for vote in votes.values()
+        )
+        applicability = (
+            next(iter(applicability_values))
+            if applicability_stable and len(applicability_values) == 1
+            else "disputed"
+        )
+        expected_status = (
+            next(iter(status_values))
+            if status_stable and len(status_values) == 1
+            else "disputed"
+        )
+        acceptable_severities = sorted(
+            severity_values,
+            key=lambda value: severity_order[value],
+        )
+        severity_span = (
+            max(severity_order[value] for value in severity_values)
+            - min(severity_order[value] for value in severity_values)
+            if severity_values else 0
+        )
+        if (
+            applicability != "disputed"
+            and expected_status != "disputed"
+            and severity_stable
+            and len(severity_signatures) == 1
+        ):
+            confidence = "high"
+        elif (
+            applicability != "disputed"
+            and expected_status != "disputed"
+            and severity_stable
+            and severity_span <= 1
+        ):
+            confidence = "medium"
+        else:
+            confidence = "low"
+
+        ledger[bp_id] = {
+            "applicability": applicability,
+            "expected_status": expected_status,
+            "acceptable_severities": acceptable_severities,
+            "evidence_basis": evidence_basis[:2],
+            "confidence": confidence,
+            "model_votes": votes,
+        }
+    return ledger
+
+
+def compute_ground_truth(runs: list[dict], canonical: set[str]) -> dict:
+    """Consensus rule: a BP is applicable when both models vote for it in ≥3/5 runs.
+
+    The structured reference ledger separately records consensus status,
+    acceptable severity values, evidence bases, and uncertainty.
     """
     per_model_bp_freq: dict[str, dict[str, int]] = {}
     for r in runs:
@@ -147,21 +313,32 @@ def compute_ground_truth(runs: list[dict]) -> dict:
     # Consensus rule: BP must be cited by BOTH models in ≥3/5 of their runs each.
     # bp_model_votes counts how many models cited it 3+ times; require == number of successful models.
     successful_models = len(per_model_bp_freq)
-    consensus_bps = sorted(bp for bp, votes in bp_model_votes.items() if votes >= successful_models)
+    consensus_bps = sorted(
+        bp for bp, votes in bp_model_votes.items()
+        if successful_models == len(MODELS) and votes >= successful_models
+    )
     all_cited = sorted(set().union(*(r.get("valid_bps", []) for r in runs
                                       if "error" not in r)))
+    ledger = _reference_ledger(runs, canonical)
+    critical_high = sorted(
+        bp_id
+        for bp_id, row in ledger.items()
+        if set(row["acceptable_severities"]) & {"Critical", "High"}
+    )
 
     return {
         "consensus_bps": consensus_bps,
         "consensus_bp_count": len(consensus_bps),
+        "critical_high_bps": critical_high,
         "all_cited_bps": all_cited,
         "all_cited_count": len(all_cited),
         "per_model_bp_frequency": {m: dict(f) for m, f in per_model_bp_freq.items()},
+        "reference_ledger": ledger,
     }
 
 
 def process_case(case: dict, canonical: set[str], client) -> dict:
-    """Process one eval case: 3 models × RUNS_PER_MODEL runs, then consensus."""
+    """Process one eval case: 2 models × RUNS_PER_MODEL runs, then consensus."""
     case_id = case["id"]
     prompt = case["prompt"]
     print(f"\n=== Case {case_id} ===")
@@ -178,6 +355,16 @@ def process_case(case: dict, canonical: set[str], client) -> dict:
             try:
                 r = fut.result()
                 r["run_idx"] = run_idx
+                raw_output = r.pop("raw_output", "")
+                if raw_output:
+                    safe_model = re.sub(r"[^a-zA-Z0-9._-]+", "-", model)
+                    artifact = (
+                        RAW_ARTIFACTS_DIR
+                        / f"case-{case_id}-{safe_model}-run-{run_idx}.txt"
+                    )
+                    artifact.parent.mkdir(parents=True, exist_ok=True)
+                    artifact.write_text(raw_output)
+                    r["raw_artifact"] = str(artifact.relative_to(REPO_ROOT))
                 runs.append(r)
                 if "error" in r:
                     print(f"  ✗ {model} run {run_idx}: {r['error'][:80]}")
@@ -188,15 +375,23 @@ def process_case(case: dict, canonical: set[str], client) -> dict:
                 print(f"  ✗ {model} run {run_idx}: EXCEPTION {e}")
                 runs.append({"model": model, "run_idx": run_idx, "error": str(e)})
 
-    gt = compute_ground_truth(runs)
+    gt = compute_ground_truth(runs, canonical)
+    stored_runs = []
+    for run in runs:
+        stored_runs.append({
+            key: value
+            for key, value in run.items()
+            if key not in {"assessment", "assessments", "raw_artifact"}
+        })
     return {
+        "schema_version": 2,
         "case_id": case_id,
         "prompt": prompt,
         "models": MODELS,
         "runs_per_model": RUNS_PER_MODEL,
         "canonical_corpus_size": len(canonical),
         "ground_truth": gt,
-        "raw_runs": runs,
+        "panel_runs": stored_runs,
     }
 
 
@@ -220,7 +415,7 @@ def main() -> int:
         out_file = GT_DIR / f"case_{gt_result['case_id']}.json"
         out_file.write_text(json.dumps(gt_result, indent=2))
         print(f"  Saved: {out_file.relative_to(REPO_ROOT)}")
-        print(f"  Consensus (≥2/3 models, ≥3/5 runs each): "
+        print(f"  Consensus (both models, ≥3/5 runs each): "
               f"{gt_result['ground_truth']['consensus_bp_count']} BPs")
 
     return 0

--- a/evals/cli_effectiveness/measure_baseline.py
+++ b/evals/cli_effectiveness/measure_baseline.py
@@ -147,6 +147,7 @@ def score_baseline_run(cli_result: dict, gt_bps: set[str], canonical: set[str]) 
         "stop_reason": final.get("stop_reason"),
         "assembled_text_len": len(assembled_text),
         "all_text_len": len(all_text),
+        "assembled_text": assembled_text,
     }
 
 

--- a/evals/cli_effectiveness/measure_codex.py
+++ b/evals/cli_effectiveness/measure_codex.py
@@ -245,6 +245,7 @@ def main() -> int:
                     "ttft_ms": r.get("ttft_ms"),
                     "session_file": r.get("session_file"),
                     "stdout_len": r.get("stdout_len"),
+                    "assembled_text": assembled,
                 }
                 print(f"  Run {run_idx} ✓ "
                       f"F1={s_rep['f1']:.3f} R={s_rep['recall']:.2f} "

--- a/evals/cli_effectiveness/measure_kiro.py
+++ b/evals/cli_effectiveness/measure_kiro.py
@@ -345,6 +345,7 @@ def main() -> int:
                 "session_file": result["session_file"],
                 "assembled_text_len": len(assembled_text),
                 "all_text_len": len(all_text),
+                "assembled_text": assembled_text,
                 "credits_used": credits,
             }
             case_runs.append(run)

--- a/evals/cli_effectiveness/measure_wa_review.py
+++ b/evals/cli_effectiveness/measure_wa_review.py
@@ -20,6 +20,7 @@ Output: evals/cli_effectiveness/wa_review_effectiveness.json
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import statistics
@@ -36,6 +37,7 @@ GT_DIR = SCRIPT_DIR / "ground_truth"
 MODEL = "sonnet"
 RUNS_PER_CASE = 3
 CLI_TIMEOUT_SEC = 900  # subagent dispatch is 6-way parallel; each pillar ~30-90s
+DEFAULT_OUTPUT = SCRIPT_DIR / "wa_review_effectiveness.json"
 
 # Autonomous-mode preamble: the skill has a discovery checkpoint that requires user
 # confirmation. In non-interactive eval mode we authorize the full review upfront and
@@ -44,8 +46,11 @@ AUTONOMOUS_PREAMBLE = """[NON-INTERACTIVE EVAL MODE — no follow-up questions p
 
 Use the wa-review skill. Skip the discovery checkpoint. Proceed directly to the
 full review based ONLY on the workload description below — do NOT ask for code,
-scope confirmation, or clarification. If information is missing, mark those
-findings as "Based on description — verify in code" and continue.
+scope confirmation, or clarification. Treat omitted or inconclusive details as
+unknown, not as evidence that a control is absent. Mark each such BP `Cannot
+Determine`, leave severity blank, and state the specific artifact, metric,
+configuration, or interview answer needed to decide. Use `Not Implemented` only
+when the workload explicitly says a control is absent.
 
 Dispatch the 6 parallel pillar subagents as instructed by SKILL.md Step 4b.
 Every Best Practice you cite MUST use the canonical WA identifier format
@@ -167,7 +172,7 @@ def _parse_session(session_file: Path) -> tuple[str, str]:
     return "\n".join(last_assistant_text), "\n".join(all_text_chunks)
 
 
-def run_claude_cli(prompt: str) -> dict:
+def run_claude_cli(prompt: str, model: str = MODEL) -> dict:
     """Invoke `claude -p --output-format json` (small stdout for cost/latency
     metrics), then parse the CC session .jsonl file for the full transcript.
 
@@ -191,7 +196,7 @@ def run_claude_cli(prompt: str) -> dict:
                 "claude",
                 "-p",
                 "--output-format", "json",
-                "--model", MODEL,
+                "--model", model,
                 "--allowedTools", "Task", "Read", "Grep", "Glob", "Bash",
                 "--dangerously-skip-permissions",
             ],
@@ -298,6 +303,9 @@ def score_run(cli_result: dict, gt_bps: set[str], canonical: set[str]) -> dict:
         "assembled_text_len": len(assembled_text),
         "all_text_len": len(all_text),
         "assembled_head": assembled_text[:400],
+        # Raw reports are required by the blind quality-review harness. The
+        # containing effectiveness JSON is gitignored as sensitive eval data.
+        "assembled_text": assembled_text,
     }
 
 
@@ -348,15 +356,71 @@ def aggregate(runs: list[dict]) -> dict:
     }
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Measure wa-review citation effectiveness with Claude Code.",
+    )
+    parser.add_argument(
+        "--cases",
+        type=int,
+        nargs="+",
+        help="Evaluate only the selected case IDs (default: all cases).",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=RUNS_PER_CASE,
+        help=f"Runs per selected case (default: {RUNS_PER_CASE}).",
+    )
+    parser.add_argument(
+        "--model",
+        default=MODEL,
+        help=f"Claude Code model name or alias (default: {MODEL}).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Result JSON path.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.runs < 1:
+        parser.error("--runs must be at least 1")
+
     canonical = build_canonical_bps()
     cases = load_eval_cases()
-    print(f"Canonical corpus: {len(canonical)} BPs")
-    print(f"Eval cases: {len(cases)}")
-    print(f"Model: {MODEL}, runs per case: {RUNS_PER_CASE}")
-    print(f"Total CLI invocations: {len(cases) * RUNS_PER_CASE}")
+    available_case_ids = {int(case["id"]) for case in cases}
+    if args.cases:
+        selected_case_ids = set(args.cases)
+        unknown_case_ids = selected_case_ids - available_case_ids
+        if unknown_case_ids:
+            parser.error(
+                "unknown case IDs: "
+                + ", ".join(str(case_id) for case_id in sorted(unknown_case_ids))
+            )
+        cases = [
+            case for case in cases
+            if int(case["id"]) in selected_case_ids
+        ]
 
-    results = {"model": MODEL, "runs_per_case": RUNS_PER_CASE, "cases": []}
+    output_path = args.output.expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Canonical corpus: {len(canonical)} BPs")
+    print(f"Eval cases: {', '.join(str(case['id']) for case in cases)}")
+    print(f"Model: {args.model}, runs per case: {args.runs}")
+    print(f"Total CLI invocations: {len(cases) * args.runs}")
+
+    results = {
+        "model": args.model,
+        "mode": "wa-review",
+        "runs_per_case": args.runs,
+        "cases": [],
+    }
 
     for case in cases:
         case_id = case["id"]
@@ -366,9 +430,9 @@ def main() -> int:
 
         case_runs: list[dict] = []
         wrapped = AUTONOMOUS_PREAMBLE + prompt
-        for run_idx in range(1, RUNS_PER_CASE + 1):
-            print(f"  Run {run_idx}/{RUNS_PER_CASE}...", end="", flush=True)
-            cli_result = run_claude_cli(wrapped)
+        for run_idx in range(1, args.runs + 1):
+            print(f"  Run {run_idx}/{args.runs}...", end="", flush=True)
+            cli_result = run_claude_cli(wrapped, args.model)
             scored = score_run(cli_result, gt, canonical)
             scored["run_idx"] = run_idx
             case_runs.append(scored)
@@ -395,10 +459,9 @@ def main() -> int:
               f"subagent F1: {sf1.get('mean') if sf1 else 'n/a'}")
 
         # Save incrementally so partial data survives a crash
-        out_file = SCRIPT_DIR / "wa_review_effectiveness.json"
-        out_file.write_text(json.dumps(results, indent=2))
+        output_path.write_text(json.dumps(results, indent=2))
 
-    print(f"\nSaved: {out_file.relative_to(REPO_ROOT)}")
+    print(f"\nSaved: {output_path}")
     return 0
 
 

--- a/evals/cli_effectiveness/review_quality.py
+++ b/evals/cli_effectiveness/review_quality.py
@@ -1,0 +1,2390 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Blind and adversarial quality evaluation for captured wa-review reports.
+
+The existing effectiveness harness measures Best Practice citation coverage.
+This module adds an evaluation-only quality layer for evidence, status,
+severity, recommendations, and uncertainty. Candidate identity and existing
+scores are deliberately excluded from all reviewer prompts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+import random
+import re
+import statistics
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+import boto3
+from botocore.config import Config as BotoConfig
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+EVALS_DIR = SCRIPT_DIR.parent
+REPO_ROOT = EVALS_DIR.parent
+REFERENCES_DIR = REPO_ROOT / "skills" / "wa-review" / "references" / "pillars"
+ARTIFACTS_DIR = SCRIPT_DIR / "review_artifacts"
+DEFAULT_RESULTS = SCRIPT_DIR / "wa_review_effectiveness.json"
+DEFAULT_OUTPUT = SCRIPT_DIR / "review_quality_results.json"
+
+sys.path.insert(0, str(EVALS_DIR))
+from benchmark import (  # noqa: E402
+    _is_mantle_model,
+    call_mantle_model,
+    call_model,
+    compute_cost,
+    load_config as load_benchmark_config,
+)
+
+SCHEMA_VERSION = 3
+DEFAULT_REVIEWERS = (
+    "openai.gpt-oss-120b",
+    "us.amazon.nova-pro-v1:0",
+)
+DEFAULT_ADVERSARY = "us.deepseek.r1-v1:0"
+DEFAULT_REGION = "us-east-1"
+DEFAULT_MAX_TOKENS = 16_384
+DEFAULT_CHUNK_SIZE = 20
+DEFAULT_RETRIES = 1
+MODEL_OUTPUT_LIMITS = {
+    "amazon": 9_999,
+}
+
+BP_PATTERN = re.compile(r"\b([A-Z]{2,}\d{1,3})[-‐‑–]BP(\d{1,3})\b")
+CANONICAL_HEADING_PATTERN = re.compile(
+    r"^# ([A-Z]{2,}\d{1,3}-BP\d{1,3})\b",
+    re.MULTILINE,
+)
+EVIDENCE_SEGMENT_PATTERN = re.compile(
+    r"(?:\r?\n)+|(?<=[.!?])\s+|[,;]\s+"
+)
+
+STATUSES = (
+    "Implemented",
+    "Partially Implemented",
+    "Not Implemented",
+    "Not Applicable",
+    "Cannot Determine",
+    "Missing",
+)
+APPLICABILITY = ("applicable", "not_applicable", "uncertain")
+SEVERITIES = ("Low", "Medium", "High", "Critical")
+EVIDENCE_KINDS = (
+    "explicit_presence",
+    "explicit_absence",
+    "explicit_partial",
+    "authoritative_absence",
+    "omitted",
+    "inconclusive",
+    "not_applicable",
+)
+CONFIDENCE_LEVELS = ("low", "medium", "high")
+DISPOSITIONS = (
+    "uphold_candidate",
+    "accept_challenge",
+    "insufficient_evidence",
+)
+REVIEWER_ASSESSMENTS = (
+    "both_hold",
+    "reviewer_a_stronger",
+    "reviewer_b_stronger",
+    "both_weak",
+)
+
+NULL_SEVERITY_STATUSES = {
+    "Implemented",
+    "Not Applicable",
+    "Cannot Determine",
+}
+DETERMINATE_STATUSES = {
+    "Implemented",
+    "Partially Implemented",
+    "Not Implemented",
+}
+EVIDENCE_KIND_STATUSES = {
+    "explicit_presence": {"Implemented"},
+    "explicit_absence": {"Not Implemented"},
+    "explicit_partial": {"Partially Implemented"},
+    "authoritative_absence": {"Not Implemented"},
+    "omitted": {"Cannot Determine"},
+    "inconclusive": {"Cannot Determine"},
+    "not_applicable": {"Not Applicable"},
+}
+
+PILLARS = (
+    ("operational-excellence", "Operational Excellence", "OPS"),
+    ("security", "Security", "SEC"),
+    ("reliability", "Reliability", "REL"),
+    ("performance-efficiency", "Performance Efficiency", "PERF"),
+    ("cost-optimization", "Cost Optimization", "COST"),
+    ("sustainability", "Sustainability", "SUS"),
+)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    candidate_id: str
+    case_id: int
+    run_idx: int
+    workload: str
+    report: str
+    source_model: str | None
+    source_mode: str | None
+    citation_metrics: dict[str, Any] | None = None
+    generation_usage: dict[str, Any] | None = None
+
+
+def normalize_bp_id(value: str) -> str:
+    """Normalize common Unicode hyphens in a canonical BP identifier."""
+    match = BP_PATTERN.search(value.upper())
+    if not match:
+        raise ValueError(f"invalid BP ID: {value!r}")
+    return f"{match.group(1)}-BP{match.group(2)}"
+
+
+def _normalize_choice(value: Any, choices: Iterable[str], field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    by_key = {choice.lower().replace("_", " "): choice for choice in choices}
+    key = value.strip().lower().replace("_", " ")
+    if key not in by_key:
+        raise ValueError(f"invalid {field}: {value!r}")
+    return by_key[key]
+
+
+def normalize_status(value: Any) -> str:
+    return _normalize_choice(value, STATUSES, "status")
+
+
+def normalize_severity(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    return _normalize_choice(value, SEVERITIES, "severity")
+
+
+def normalize_evidence_kind(value: Any) -> str:
+    return _normalize_choice(value, EVIDENCE_KINDS, "evidence_kind")
+
+
+def normalize_confidence(value: Any) -> str:
+    """Treat omitted model confidence conservatively without losing the row."""
+    if value is None or value == "":
+        return "low"
+    return _normalize_choice(value, CONFIDENCE_LEVELS, "confidence")
+
+
+def validate_status_severity(
+    status: str,
+    severity: str | None,
+    *,
+    status_field: str,
+    severity_field: str,
+) -> None:
+    if status in NULL_SEVERITY_STATUSES and severity is not None:
+        raise ValueError(f"{severity_field} must be null for {status}")
+
+
+def _normalized_text(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def normalize_evidence_quote(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise ValueError("evidence_quote must be a string or null")
+    quote = " ".join(value.split())
+    if not quote:
+        return None
+    return quote
+
+
+def build_evidence_catalog(workload: str) -> dict[str, str]:
+    """Create stable IDs for exact, atomic spans from the workload."""
+    catalog: dict[str, str] = {}
+    seen: set[str] = set()
+    for segment in EVIDENCE_SEGMENT_PATTERN.split(workload):
+        quote = normalize_evidence_quote(segment)
+        if quote is None:
+            continue
+        normalized = _normalized_text(quote)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        catalog[f"W{len(catalog) + 1:03d}"] = quote
+    if not catalog:
+        raise ValueError("workload has no evidence spans")
+    return catalog
+
+
+def format_evidence_catalog(workload: str) -> str:
+    return "\n".join(
+        f"{quote_id}: {json.dumps(quote)}"
+        for quote_id, quote in build_evidence_catalog(workload).items()
+    )
+
+
+def resolve_reviewer_evidence_quote(
+    row: dict[str, Any],
+    workload: str,
+) -> tuple[str | None, str | None]:
+    """Resolve a model-selected catalog ID while accepting legacy exact quotes."""
+    quote_id_value = row.get("evidence_quote_id")
+    supplied_quote = normalize_evidence_quote(row.get("evidence_quote"))
+    if quote_id_value is None or quote_id_value == "":
+        return supplied_quote, None
+    if not isinstance(quote_id_value, str):
+        raise ValueError("evidence_quote_id must be a string or null")
+
+    quote_id = quote_id_value.strip().upper()
+    catalog = build_evidence_catalog(workload)
+    if quote_id not in catalog:
+        raise ValueError(f"invalid evidence_quote_id: {quote_id_value!r}")
+    resolved_quote = catalog[quote_id]
+    if (
+        supplied_quote is not None
+        and _normalized_text(supplied_quote) != _normalized_text(resolved_quote)
+    ):
+        raise ValueError(
+            "evidence_quote conflicts with the selected evidence_quote_id"
+        )
+    return resolved_quote, quote_id
+
+
+def validate_evidence_provenance(
+    status: str,
+    severity: str | None,
+    evidence_kind: str,
+    evidence_quote: str | None,
+    workload: str,
+    *,
+    status_field: str,
+    severity_field: str,
+    allow_authoritative_absence: bool = False,
+) -> None:
+    validate_status_severity(
+        status,
+        severity,
+        status_field=status_field,
+        severity_field=severity_field,
+    )
+    if status == "Missing":
+        raise ValueError(f"{status_field} cannot be Missing")
+    allowed_statuses = EVIDENCE_KIND_STATUSES[evidence_kind]
+    if status not in allowed_statuses:
+        raise ValueError(
+            f"{status_field} {status!r} is incompatible with "
+            f"evidence_kind {evidence_kind!r}"
+        )
+    if evidence_kind == "authoritative_absence" and not allow_authoritative_absence:
+        raise ValueError(
+            "authoritative_absence is not allowed for a verbal-only workload"
+        )
+    quote_required = evidence_kind in {
+        "explicit_presence",
+        "explicit_absence",
+        "explicit_partial",
+        "inconclusive",
+    }
+    if quote_required and evidence_quote is None:
+        raise ValueError(f"evidence_quote is required for {evidence_kind}")
+    if evidence_kind in {"omitted", "not_applicable"} and evidence_quote is not None:
+        raise ValueError(f"evidence_quote must be null for {evidence_kind}")
+    if evidence_quote is not None:
+        normalized_quote = _normalized_text(evidence_quote)
+        if normalized_quote not in _normalized_text(workload):
+            raise ValueError(
+                f"evidence_quote is not an exact workload quote: {evidence_quote!r}"
+            )
+
+
+def _clean_markdown_cell(value: str) -> str:
+    return value.strip().strip("`*_").strip()
+
+
+def parse_candidate_ledger(report: str) -> dict[str, dict[str, Any]]:
+    """Parse canonical BP status/severity cells from the candidate Markdown."""
+    rows: dict[str, dict[str, Any]] = {}
+    duplicates: set[str] = set()
+    for line in report.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [_clean_markdown_cell(cell) for cell in stripped.strip("|").split("|")]
+        if len(cells) < 3 or not BP_PATTERN.fullmatch(cells[0].upper()):
+            continue
+        bp_id = normalize_bp_id(cells[0])
+        try:
+            status = normalize_status(cells[1])
+        except ValueError:
+            continue
+        severity_cell = cells[2]
+        severity = normalize_severity(
+            None
+            if severity_cell in {"", "-", "—", "N/A", "n/a"}
+            else severity_cell
+        )
+        validate_status_severity(
+            status,
+            severity,
+            status_field=f"{bp_id}.candidate_status",
+            severity_field=f"{bp_id}.candidate_severity",
+        )
+        if bp_id in rows:
+            duplicates.add(bp_id)
+            continue
+        rows[bp_id] = {
+            "bp_id": bp_id,
+            "candidate_status": status,
+            "candidate_severity": severity,
+        }
+    if duplicates:
+        raise ValueError(
+            "candidate ledger has duplicate BP rows: "
+            + ", ".join(sorted(duplicates))
+        )
+    if not rows:
+        raise ValueError("candidate report has no parseable canonical BP ledger rows")
+    return rows
+
+
+def normalize_reference_row(row: dict[str, Any]) -> dict[str, Any]:
+    evidence_basis = row.get("evidence_basis")
+    if not isinstance(evidence_basis, str) or not evidence_basis.strip():
+        raise ValueError("evidence_basis must be a non-empty string")
+    return {
+        "bp_id": normalize_bp_id(str(row.get("bp_id", ""))),
+        "applicability": _normalize_choice(
+            row.get("applicability"),
+            APPLICABILITY,
+            "applicability",
+        ),
+        "expected_status": normalize_status(row.get("expected_status")),
+        "expected_severity": normalize_severity(row.get("expected_severity")),
+        "evidence_basis": evidence_basis.strip(),
+        "confidence": normalize_confidence(row.get("confidence")),
+    }
+
+
+def decode_json_values(text: str) -> list[Any]:
+    """Decode JSON values from plain or fenced model output."""
+    decoder = json.JSONDecoder()
+    values: list[Any] = []
+    cursor = 0
+    while cursor < len(text):
+        starts = [idx for idx in (text.find("{", cursor), text.find("[", cursor)) if idx >= 0]
+        if not starts:
+            break
+        start = min(starts)
+        try:
+            value, end = decoder.raw_decode(text[start:])
+        except json.JSONDecodeError:
+            cursor = start + 1
+            continue
+        values.append(value)
+        cursor = start + end
+    return values
+
+
+def _rows_from_json_values(values: Iterable[Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for value in values:
+        if isinstance(value, dict) and isinstance(value.get("rows"), list):
+            rows.extend(row for row in value["rows"] if isinstance(row, dict))
+        elif isinstance(value, list):
+            rows.extend(row for row in value if isinstance(row, dict))
+    return rows
+
+
+def normalize_reviewer_row(
+    row: dict[str, Any],
+    *,
+    workload: str,
+    candidate_rows: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    bp_id = normalize_bp_id(str(row.get("bp_id", "")))
+    if bp_id not in candidate_rows:
+        raise ValueError(f"candidate ledger is missing {bp_id}")
+    score = row.get("recommendation_score")
+    if score is not None:
+        if not isinstance(score, int) or not 1 <= score <= 5:
+            raise ValueError("recommendation_score must be an integer from 1 to 5")
+    challenge = row.get("challenge")
+    if challenge is not None and not isinstance(challenge, str):
+        raise ValueError("challenge must be a string or null")
+    rationale = row.get("evidence_rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise ValueError("evidence_rationale must be a non-empty string")
+    reference_status = normalize_status(row.get("reference_status"))
+    reference_severity = normalize_severity(row.get("reference_severity"))
+    evidence_kind = normalize_evidence_kind(row.get("evidence_kind"))
+    evidence_quote, evidence_quote_id = resolve_reviewer_evidence_quote(
+        row,
+        workload,
+    )
+    validate_evidence_provenance(
+        reference_status,
+        reference_severity,
+        evidence_kind,
+        evidence_quote,
+        workload,
+        status_field="reference_status",
+        severity_field="reference_severity",
+    )
+    candidate = candidate_rows[bp_id]
+    return {
+        "bp_id": bp_id,
+        "candidate_status": candidate["candidate_status"],
+        "reference_status": reference_status,
+        "evidence_kind": evidence_kind,
+        "evidence_quote": evidence_quote,
+        "evidence_quote_id": evidence_quote_id,
+        "evidence_rationale": rationale.strip(),
+        "candidate_severity": candidate["candidate_severity"],
+        "reference_severity": reference_severity,
+        "recommendation_score": score,
+        "challenge": challenge,
+        "confidence": normalize_confidence(row.get("confidence")),
+    }
+
+
+def normalize_adversary_row(
+    row: dict[str, Any],
+    *,
+    workload: str,
+    reviewer_a: dict[str, dict[str, Any]],
+    reviewer_b: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    bp_id = normalize_bp_id(str(row.get("bp_id", "")))
+    if bp_id not in reviewer_a or bp_id not in reviewer_b:
+        raise ValueError(f"review material is missing {bp_id}")
+    rationale = row.get("rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise ValueError("rationale must be a non-empty string")
+    final_status = normalize_status(row.get("final_status"))
+    final_severity = normalize_severity(row.get("final_severity"))
+    evidence_kind = normalize_evidence_kind(row.get("evidence_kind"))
+    evidence_quote = normalize_evidence_quote(row.get("evidence_quote"))
+    validate_evidence_provenance(
+        final_status,
+        final_severity,
+        evidence_kind,
+        evidence_quote,
+        workload,
+        status_field="final_status",
+        severity_field="final_severity",
+    )
+    allowed_conclusions = {
+        (
+            reviewer["reference_status"],
+            reviewer["evidence_kind"],
+            _normalized_text(reviewer["evidence_quote"])
+            if reviewer["evidence_quote"] is not None
+            else None,
+        )
+        for reviewer in (reviewer_a[bp_id], reviewer_b[bp_id])
+    }
+    final_conclusion = (
+        final_status,
+        evidence_kind,
+        _normalized_text(evidence_quote) if evidence_quote is not None else None,
+    )
+    if final_conclusion not in allowed_conclusions:
+        raise ValueError(
+            "final conclusion must use a status and evidence pair supplied "
+            "by a blind reviewer"
+        )
+    disposition = _normalize_choice(
+        row.get("disposition"),
+        DISPOSITIONS,
+        "disposition",
+    )
+    candidate_status = reviewer_a[bp_id]["candidate_status"]
+    if reviewer_b[bp_id]["candidate_status"] != candidate_status:
+        raise ValueError("blind reviewers have inconsistent candidate status")
+    if disposition == "uphold_candidate" and final_status != candidate_status:
+        raise ValueError("uphold_candidate requires final_status to match candidate")
+    if disposition == "insufficient_evidence" and final_status != "Cannot Determine":
+        raise ValueError(
+            "insufficient_evidence requires final_status Cannot Determine"
+        )
+    return {
+        "bp_id": bp_id,
+        "disposition": disposition,
+        "final_status": final_status,
+        "final_severity": final_severity,
+        "evidence_kind": evidence_kind,
+        "evidence_quote": evidence_quote,
+        "reviewer_assessment": _normalize_choice(
+            row.get("reviewer_assessment"),
+            REVIEWER_ASSESSMENTS,
+            "reviewer_assessment",
+        ),
+        "rationale": rationale.strip(),
+        "confidence": normalize_confidence(row.get("confidence")),
+    }
+
+
+def parse_model_rows(
+    text: str,
+    expected_ids: Iterable[str],
+    normalizer,
+) -> dict[str, Any]:
+    """Parse and validate a model's per-BP JSON response."""
+    expected = set(expected_ids)
+    parsed: dict[str, dict[str, Any]] = {}
+    invalid: list[str] = []
+    duplicates: list[str] = []
+
+    for raw_row in _rows_from_json_values(decode_json_values(text)):
+        try:
+            row = normalizer(raw_row)
+        except ValueError as exc:
+            raw_id = raw_row.get("bp_id", "(unknown BP)")
+            invalid.append(f"{raw_id}: {exc}")
+            continue
+        bp_id = row["bp_id"]
+        if bp_id in parsed:
+            duplicates.append(bp_id)
+            continue
+        parsed[bp_id] = row
+
+    actual = set(parsed)
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    complete = (
+        bool(expected)
+        and not missing
+        and not unexpected
+        and not duplicates
+        and not invalid
+    )
+    return {
+        "complete": complete,
+        "rows": {bp_id: parsed[bp_id] for bp_id in sorted(parsed) if bp_id in expected},
+        "missing_ids": missing,
+        "unexpected_ids": unexpected,
+        "duplicate_ids": sorted(set(duplicates)),
+        "invalid_rows": invalid,
+    }
+
+
+def canonical_ids(reference: str, prefix: str) -> list[str]:
+    return sorted(
+        bp_id
+        for bp_id in CANONICAL_HEADING_PATTERN.findall(reference)
+        if bp_id.startswith(prefix)
+    )
+
+
+def chunk_values(values: Sequence[str], chunk_size: int) -> list[list[str]]:
+    """Split an ordered sequence into stable, non-empty chunks."""
+    if chunk_size < 1:
+        raise ValueError("chunk_size must be at least 1")
+    return [
+        list(values[index:index + chunk_size])
+        for index in range(0, len(values), chunk_size)
+    ]
+
+
+def extract_reference_subset(reference: str, selected_ids: Iterable[str]) -> str:
+    """Return only the canonical BP sections needed for a review chunk."""
+    selected = set(selected_ids)
+    matches = list(CANONICAL_HEADING_PATTERN.finditer(reference))
+    sections: list[str] = []
+    found: set[str] = set()
+    for index, match in enumerate(matches):
+        bp_id = match.group(1)
+        if bp_id not in selected:
+            continue
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(reference)
+        sections.append(reference[match.start():end].strip())
+        found.add(bp_id)
+    missing = selected - found
+    if missing:
+        raise ValueError(
+            "reference is missing selected BP IDs: "
+            + ", ".join(sorted(missing))
+        )
+    return "\n\n".join(sections)
+
+
+def extract_pillar_excerpt(
+    report: str,
+    prefix: str,
+    selected_ids: Iterable[str] | None = None,
+) -> str:
+    """Extract candidate lines containing the requested canonical BP IDs."""
+    selected = set(selected_ids) if selected_ids is not None else None
+    lines: list[str] = []
+    seen: set[str] = set()
+    for line in report.splitlines():
+        ids = {
+            normalize_bp_id(match.group(0))
+            for match in BP_PATTERN.finditer(line)
+            if match.group(1).startswith(prefix)
+        }
+        if selected is not None:
+            ids &= selected
+        if ids and line not in seen:
+            seen.add(line)
+            lines.append(line)
+    return "\n".join(lines) if lines else "(No candidate rows found for these BPs.)"
+
+
+def build_blind_prompt(
+    workload: str,
+    candidate_excerpt: str,
+    reference: str,
+    pillar_name: str,
+    expected_count: int,
+    selected_ids: Sequence[str] | None = None,
+) -> str:
+    """Build a prompt with no candidate runtime, model, or condition metadata."""
+    ids = (
+        list(selected_ids)
+        if selected_ids is not None
+        else CANONICAL_HEADING_PATTERN.findall(reference)
+    )
+    id_list = ", ".join(ids) if ids else "(IDs are the canonical headings below)"
+    return f"""You are an independent AWS Well-Architected quality reviewer.
+
+Review the candidate ledger for the {pillar_name} pillar. You are not told which
+system produced it. Use only the workload and authoritative pillar reference
+below. Evaluate exactly these {expected_count} Best Practices, including
+candidate omissions:
+{id_list}
+
+Do not infer an absent control as Not Implemented when the supplied evidence
+only supports Cannot Determine. `reference_status` is your independent
+implementation-status judgment from workload evidence. It is NEVER a documented
+risk level. Low, Medium, High, and Critical belong only in severity fields.
+
+For each BP return:
+- reference_status: Implemented, Partially Implemented, Not Implemented,
+  Not Applicable, or Cannot Determine
+- reference_severity: Critical, High, Medium, Low, or null
+- evidence_kind: exactly one of explicit_presence, explicit_absence,
+  explicit_partial, omitted, inconclusive, or not_applicable
+- evidence_quote_id: an exact W### identifier from WORKLOAD EVIDENCE CATALOG,
+  or null; the harness resolves it to an exact contiguous quote from WORKLOAD
+- evidence_rationale: a concise explanation of how that evidence maps to the BP
+- recommendation_score: integer 1-5, or null when no recommendation applies
+- challenge: correction of at most 12 words, or null when the candidate is correct
+- confidence: high, medium, or low
+
+Return ONLY one JSON object with this shape:
+{{"rows":[{{"bp_id":"SEC01-BP01",
+"reference_status":"Cannot Determine","reference_severity":null,
+"evidence_kind":"omitted","evidence_quote_id":null,
+"evidence_rationale":"The workload does not describe this control.",
+"recommendation_score":null,"challenge":"Candidate omitted this BP.",
+"confidence":"high"}}]}}
+
+The rows array must contain exactly one unique row for every canonical BP in the
+list above. Return minified JSON without indentation or narrative.
+The harness parses candidate status and severity itself; do not return either.
+Apply these mandatory mappings:
+- explicit_presence -> Implemented, with a non-null workload evidence ID
+- explicit_partial -> Partially Implemented, with a non-null workload evidence ID
+- explicit_absence -> Not Implemented, with a non-null workload evidence ID
+- omitted or inconclusive -> Cannot Determine
+- not_applicable -> Not Applicable
+
+Never write or paraphrase quote text and do not return an evidence_quote field;
+select its catalog ID. For omitted and not_applicable evidence,
+evidence_quote_id MUST be null. For inconclusive evidence, select the exact
+inconclusive workload span. `authoritative_absence` is forbidden because this
+is a verbal-only workload. Use null reference_severity for Implemented, Not
+Applicable, and Cannot Determine. The candidate ledger and pillar reference are
+not evidence of workload implementation. In particular, phrases such as "not
+described", "no documentation provided", and "no evidence of" mean omitted and
+Cannot Determine, not explicit_absence.
+
+===== WORKLOAD =====
+{workload}
+
+===== WORKLOAD EVIDENCE CATALOG =====
+{format_evidence_catalog(workload)}
+
+===== CANDIDATE PILLAR LEDGER =====
+{candidate_excerpt}
+
+===== AUTHORITATIVE PILLAR REFERENCE =====
+{reference}
+"""
+
+
+def build_adversary_prompt(
+    workload: str,
+    candidate_excerpt: str,
+    reference: str,
+    reviewer_a: dict[str, dict[str, Any]],
+    reviewer_b: dict[str, dict[str, Any]],
+    selected_ids: list[str],
+    pillar_name: str,
+) -> str:
+    items = []
+    for bp_id in selected_ids:
+        items.append({
+            "bp_id": bp_id,
+            "reviewer_a": reviewer_a[bp_id],
+            "reviewer_b": reviewer_b[bp_id],
+        })
+    return f"""You are the adversarial adjudicator for an AWS Well-Architected
+evaluation. Challenge both the candidate and the two anonymous reviewers for the
+{pillar_name} pillar. Look for anchoring, shared unsupported assumptions,
+severity inflation or understatement, contradictory evidence, and generic
+recommendations.
+
+Adjudicate every supplied BP. Return ONLY:
+{{"rows":[{{"bp_id":"SEC01-BP01",
+"disposition":"insufficient_evidence",
+"final_status":"Cannot Determine","final_severity":null,
+"evidence_kind":"omitted","evidence_quote":null,
+"reviewer_assessment":"both_hold",
+"rationale":"The workload omits the implementation detail.",
+"confidence":"high"}}]}}
+
+Allowed dispositions: uphold_candidate, accept_challenge, insufficient_evidence.
+Allowed reviewer assessments: both_hold, reviewer_a_stronger,
+reviewer_b_stronger, both_weak. Include exactly one unique row for each selected
+BP and no narrative outside the JSON.
+
+You MUST select a complete (final_status, evidence_kind, evidence_quote) tuple
+already supplied by reviewer A or reviewer B. Do not introduce a new quote,
+reinterpret omitted information as absence, or use the candidate/reference as
+implementation evidence. If both reviewers use omitted evidence, final_status
+must be Cannot Determine. `authoritative_absence` is forbidden for this
+verbal-only workload. Implemented, Not Applicable, and Cannot Determine require
+null final_severity. `uphold_candidate` requires final_status to match the
+parsed candidate status. `insufficient_evidence` requires Cannot Determine.
+
+===== WORKLOAD =====
+{workload}
+
+===== CANDIDATE PILLAR LEDGER =====
+{candidate_excerpt}
+
+===== ANONYMOUS REVIEW MATERIAL =====
+{json.dumps(items, indent=2)}
+
+===== AUTHORITATIVE PILLAR REFERENCE =====
+{reference}
+"""
+
+
+def model_family(model_id: str | None) -> str:
+    value = (model_id or "").lower()
+    if (
+        "anthropic" in value
+        or "claude" in value
+        or any(name in value for name in ("sonnet", "opus", "haiku", "fable"))
+    ):
+        return "anthropic"
+    if "openai" in value or "gpt" in value:
+        return "openai"
+    if "amazon" in value or "nova" in value:
+        return "amazon"
+    if "deepseek" in value:
+        return "deepseek"
+    if "meta" in value or "llama" in value:
+        return "meta"
+    if "mistral" in value:
+        return "mistral"
+    return value.split(".")[0]
+
+
+def validate_panel(
+    source_models: Iterable[str | None],
+    reviewers: Iterable[str],
+    adversary: str,
+) -> None:
+    reviewer_list = list(reviewers)
+    reviewer_families = [model_family(model) for model in reviewer_list]
+    if len(reviewer_list) != 2:
+        raise ValueError("exactly two blind reviewer models are required")
+    if len(set(reviewer_families)) != 2:
+        raise ValueError("blind reviewers must come from different model families")
+    source_families = {model_family(model) for model in source_models if model}
+    overlap = source_families & set(reviewer_families)
+    if overlap:
+        raise ValueError(
+            "candidate-family self-grading is not allowed; replace reviewer "
+            f"families: {', '.join(sorted(overlap))}"
+        )
+    adversary_family = model_family(adversary)
+    if adversary_family in set(reviewer_families) | source_families:
+        raise ValueError("the adversary must use a third, non-candidate model family")
+
+
+def load_candidates(
+    results_path: Path,
+    selected_cases: set[int] | None,
+    runs_per_case: int,
+    seed: int,
+) -> list[Candidate]:
+    data = json.loads(results_path.read_text())
+    eval_cases = {
+        int(case["id"]): case["prompt"]
+        for case in json.loads(
+            (REPO_ROOT / "skills" / "wa-review" / "evals" / "evals.json").read_text()
+        )["evals"]
+    }
+    pending: list[dict[str, Any]] = []
+    for case in data.get("cases", []):
+        case_id = int(case["case_id"])
+        if selected_cases is not None and case_id not in selected_cases:
+            continue
+        successful = [
+            run
+            for run in case.get("runs", [])
+            if "error" not in run and isinstance(run.get("assembled_text"), str)
+            and run["assembled_text"].strip()
+        ]
+        for run in successful[:runs_per_case]:
+            report_metrics = run.get("report", {})
+            pending.append({
+                "case_id": case_id,
+                "run_idx": int(run.get("run_idx", 0)),
+                "workload": eval_cases[case_id],
+                "report": run["assembled_text"],
+                "source_model": data.get("model"),
+                "source_mode": data.get("mode") or data.get("runtime"),
+                "citation_metrics": {
+                    key: report_metrics.get(key)
+                    for key in (
+                        "cited_count",
+                        "valid_cited_count",
+                        "true_positives",
+                        "false_positives",
+                        "false_negatives",
+                        "recall",
+                        "precision",
+                        "f1",
+                    )
+                },
+                "generation_usage": {
+                    "ground_truth_count": run.get("gt_count"),
+                    "cost_usd": run.get("total_cost_usd"),
+                    "wall_s": run.get("wall_s"),
+                    "input_tokens": run.get("input_tokens"),
+                    "output_tokens": run.get("output_tokens"),
+                },
+            })
+    if not pending:
+        raise ValueError(
+            "no captured candidate reports found; regenerate effectiveness "
+            "results with a harness that stores assembled_text"
+        )
+
+    random.Random(seed).shuffle(pending)
+    return [
+        Candidate(candidate_id=f"candidate-{index:03d}", **candidate)
+        for index, candidate in enumerate(pending, start=1)
+    ]
+
+
+def scoped_prefixes(case_id: int) -> set[str]:
+    return {"SEC", "REL"} if case_id == 4 else {prefix for _, _, prefix in PILLARS}
+
+
+def _invoke_model(
+    client,
+    model_id: str,
+    prompt: str,
+    region: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    effective_max_tokens = min(
+        max_tokens,
+        MODEL_OUTPUT_LIMITS.get(model_family(model_id), max_tokens),
+    )
+    messages = [{"role": "user", "content": [{"text": prompt}]}]
+    if _is_mantle_model(model_id):
+        result = call_mantle_model(
+            model_id,
+            messages,
+            max_tokens=effective_max_tokens,
+            temperature=0,
+            region=region,
+        )
+    else:
+        result = call_model(
+            client,
+            model_id,
+            messages,
+            max_tokens=effective_max_tokens,
+            temperature=0,
+            include_reasoning=False,
+        )
+    result["requested_max_tokens"] = max_tokens
+    result["effective_max_tokens"] = effective_max_tokens
+    return result
+
+
+def _artifact_name(
+    candidate_id: str,
+    pillar_slug: str,
+    role: str,
+    model: str,
+    artifacts_dir: Path | None = None,
+) -> Path:
+    safe_model = re.sub(r"[^a-zA-Z0-9._-]+", "-", model)
+    root = (artifacts_dir or ARTIFACTS_DIR).expanduser().resolve()
+    return root / candidate_id / f"{pillar_slug}-{role}-{safe_model}.txt"
+
+
+def _write_raw_artifact(
+    candidate_id: str,
+    pillar_slug: str,
+    role: str,
+    model: str,
+    text: str,
+    artifacts_dir: Path | None = None,
+) -> str:
+    path = _artifact_name(
+        candidate_id,
+        pillar_slug,
+        role,
+        model,
+        artifacts_dir,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def select_adversarial_ids(
+    reviewer_a: dict[str, dict[str, Any]],
+    reviewer_b: dict[str, dict[str, Any]],
+    seed: int,
+    sample_rate: float = 0.10,
+) -> list[str]:
+    selected: set[str] = set()
+    agreements: list[str] = []
+    compared_fields = (
+        "reference_status",
+        "reference_severity",
+        "evidence_kind",
+        "evidence_quote",
+    )
+    for bp_id in sorted(set(reviewer_a) & set(reviewer_b)):
+        a = reviewer_a[bp_id]
+        b = reviewer_b[bp_id]
+        disagrees = any(a[field] != b[field] for field in compared_fields)
+        recommendation_gap = (
+            a["recommendation_score"] is not None
+            and b["recommendation_score"] is not None
+            and abs(a["recommendation_score"] - b["recommendation_score"]) >= 2
+        )
+        high_risk = (
+            a["candidate_severity"] in {"Critical", "High"}
+            or b["candidate_severity"] in {"Critical", "High"}
+        )
+        challenged = (
+            a["candidate_status"] != a["reference_status"]
+            or b["candidate_status"] != b["reference_status"]
+            or a["candidate_severity"] != a["reference_severity"]
+            or b["candidate_severity"] != b["reference_severity"]
+        )
+        if disagrees or recommendation_gap or high_risk or challenged:
+            selected.add(bp_id)
+        else:
+            agreements.append(bp_id)
+
+    if agreements and sample_rate > 0:
+        sample_size = max(1, math.ceil(len(agreements) * sample_rate))
+        selected.update(random.Random(seed).sample(agreements, min(sample_size, len(agreements))))
+    return sorted(selected)
+
+
+def agreement_rate(values_a: list[Any], values_b: list[Any]) -> float | None:
+    if not values_a or len(values_a) != len(values_b):
+        return None
+    return round(sum(a == b for a, b in zip(values_a, values_b)) / len(values_a), 4)
+
+
+def cohen_kappa(
+    values_a: list[Any],
+    values_b: list[Any],
+    ordered_categories: list[Any] | None = None,
+) -> float | None:
+    """Compute unweighted or quadratic-weighted Cohen's kappa."""
+    if not values_a or len(values_a) != len(values_b):
+        return None
+    categories = ordered_categories or sorted(set(values_a) | set(values_b))
+    if len(categories) == 1:
+        return 1.0
+    indexes = {value: index for index, value in enumerate(categories)}
+    count = len(values_a)
+    marginal_a = [0] * len(categories)
+    marginal_b = [0] * len(categories)
+
+    def weight(left: Any, right: Any) -> float:
+        if ordered_categories is None:
+            return 1.0 if left == right else 0.0
+        distance = abs(indexes[left] - indexes[right]) / (len(categories) - 1)
+        return 1.0 - distance**2
+
+    observed = 0.0
+    for left, right in zip(values_a, values_b):
+        marginal_a[indexes[left]] += 1
+        marginal_b[indexes[right]] += 1
+        observed += weight(left, right)
+    observed /= count
+
+    expected = 0.0
+    for left in categories:
+        for right in categories:
+            expected += (
+                marginal_a[indexes[left]]
+                * marginal_b[indexes[right]]
+                * weight(left, right)
+            )
+    expected /= count**2
+    if expected == 1:
+        return 1.0
+    return round((observed - expected) / (1 - expected), 4)
+
+
+def severity_within_one(values_a: list[str], values_b: list[str]) -> float | None:
+    if not values_a or len(values_a) != len(values_b):
+        return None
+    levels = {severity: index for index, severity in enumerate(SEVERITIES)}
+    return round(
+        sum(abs(levels[a] - levels[b]) <= 1 for a, b in zip(values_a, values_b))
+        / len(values_a),
+        4,
+    )
+
+
+def compute_quality_metrics(
+    reviewer_a: dict[str, dict[str, Any]],
+    reviewer_b: dict[str, dict[str, Any]],
+    adversary: dict[str, dict[str, Any]],
+    selected_ids: Iterable[str],
+    candidate_rows: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    common_ids = sorted(set(reviewer_a) & set(reviewer_b) & set(candidate_rows))
+    statuses_a = [reviewer_a[bp_id]["reference_status"] for bp_id in common_ids]
+    statuses_b = [reviewer_b[bp_id]["reference_status"] for bp_id in common_ids]
+    severity_ids = [
+        bp_id for bp_id in common_ids
+        if reviewer_a[bp_id]["reference_severity"] is not None
+        and reviewer_b[bp_id]["reference_severity"] is not None
+    ]
+    severities_a = [reviewer_a[bp_id]["reference_severity"] for bp_id in severity_ids]
+    severities_b = [reviewer_b[bp_id]["reference_severity"] for bp_id in severity_ids]
+
+    recommendation_scores = [
+        score
+        for bp_id in common_ids
+        for score in (
+            reviewer_a[bp_id]["recommendation_score"],
+            reviewer_b[bp_id]["recommendation_score"],
+        )
+        if score is not None
+    ]
+
+    selected = set(selected_ids)
+    final_rows: dict[str, dict[str, Any]] = {}
+    unresolved_ids: list[str] = []
+    for bp_id in common_ids:
+        if bp_id in selected:
+            adjudication = adversary.get(bp_id)
+            if adjudication is None:
+                unresolved_ids.append(bp_id)
+                continue
+            final_rows[bp_id] = {
+                "status": adjudication["final_status"],
+                "severity": adjudication["final_severity"],
+                "evidence_kind": adjudication["evidence_kind"],
+                "evidence_quote": adjudication["evidence_quote"],
+            }
+        elif (
+            reviewer_a[bp_id]["reference_status"] == reviewer_b[bp_id]["reference_status"]
+            and reviewer_a[bp_id]["reference_severity"]
+            == reviewer_b[bp_id]["reference_severity"]
+            and reviewer_a[bp_id]["evidence_kind"]
+            == reviewer_b[bp_id]["evidence_kind"]
+            and reviewer_a[bp_id]["evidence_quote"]
+            == reviewer_b[bp_id]["evidence_quote"]
+        ):
+            final_rows[bp_id] = {
+                "status": reviewer_a[bp_id]["reference_status"],
+                "severity": reviewer_a[bp_id]["reference_severity"],
+                "evidence_kind": reviewer_a[bp_id]["evidence_kind"],
+                "evidence_quote": reviewer_a[bp_id]["evidence_quote"],
+            }
+        else:
+            unresolved_ids.append(bp_id)
+
+    finalized_ids = set(final_rows)
+    evidence_assessed_ids = {
+        bp_id
+        for bp_id, row in final_rows.items()
+        if row["status"] != "Not Applicable"
+    }
+    final_determinate_ids = {
+        bp_id
+        for bp_id, row in final_rows.items()
+        if row["status"] in DETERMINATE_STATUSES
+    }
+    legitimate_unknown_ids = {
+        bp_id
+        for bp_id, row in final_rows.items()
+        if (
+            row["status"] == "Cannot Determine"
+            and row["evidence_kind"] in {"omitted", "inconclusive"}
+        )
+    }
+
+    candidate_status_correct_ids = {
+        bp_id
+        for bp_id, row in final_rows.items()
+        if candidate_rows[bp_id]["candidate_status"] == row["status"]
+    }
+    candidate_uncertainty_ids = {
+        bp_id
+        for bp_id in finalized_ids
+        if candidate_rows[bp_id]["candidate_status"] == "Cannot Determine"
+    }
+    uncertainty_ids = {
+        bp_id
+        for bp_id, row in final_rows.items()
+        if row["status"] == "Cannot Determine"
+    }
+    uncertainty_aligned_ids = uncertainty_ids & candidate_uncertainty_ids
+    overconservative_ids = {
+        bp_id
+        for bp_id in candidate_uncertainty_ids
+        if final_rows[bp_id]["status"] in DETERMINATE_STATUSES
+    }
+    determinate_assertion_ids = {
+        bp_id
+        for bp_id in finalized_ids
+        if candidate_rows[bp_id]["candidate_status"] in DETERMINATE_STATUSES
+    }
+    aligned_determinate_ids = {
+        bp_id
+        for bp_id in determinate_assertion_ids
+        if candidate_rows[bp_id]["candidate_status"] == final_rows[bp_id]["status"]
+    }
+    unsupported_determinate_ids = determinate_assertion_ids & uncertainty_ids
+    negative_assertion_ids = {
+        bp_id
+        for bp_id in finalized_ids
+        if candidate_rows[bp_id]["candidate_status"] == "Not Implemented"
+    }
+    aligned_negative_ids = {
+        bp_id
+        for bp_id in negative_assertion_ids
+        if final_rows[bp_id]["status"] == "Not Implemented"
+    }
+    unsupported_negative_ids = negative_assertion_ids & uncertainty_ids
+
+    high_risk_ids = [
+        bp_id
+        for bp_id in finalized_ids
+        if candidate_rows[bp_id]["candidate_severity"] in {"Critical", "High"}
+    ]
+    defensible_high_risk = sum(
+        candidate_rows[bp_id]["candidate_status"] == final_rows[bp_id]["status"]
+        and final_rows[bp_id]["severity"] in {"Critical", "High"}
+        for bp_id in high_risk_ids
+    )
+
+    adjudicated = [adversary[bp_id] for bp_id in selected if bp_id in adversary]
+    candidate_overturns = sum(
+        row["disposition"] == "accept_challenge" for row in adjudicated
+    )
+    consensus_overturns = 0
+    consensus_items = 0
+    for bp_id in selected:
+        if bp_id not in adversary:
+            continue
+        a = reviewer_a[bp_id]
+        b = reviewer_b[bp_id]
+        agreed = (
+            a["reference_status"] == b["reference_status"]
+            and a["reference_severity"] == b["reference_severity"]
+            and a["evidence_kind"] == b["evidence_kind"]
+            and a["evidence_quote"] == b["evidence_quote"]
+        )
+        if agreed:
+            consensus_items += 1
+            if adversary[bp_id]["reviewer_assessment"] == "both_weak":
+                consensus_overturns += 1
+
+    adjudication_abstentions = sum(
+        row["disposition"] == "insufficient_evidence"
+        for row in adjudicated
+    )
+
+    def ratio(numerator: int, denominator: int) -> float | None:
+        return round(numerator / denominator, 4) if denominator else None
+
+    return {
+        "bps_reviewed": len(common_ids),
+        "status_exact_agreement": agreement_rate(statuses_a, statuses_b),
+        "status_kappa": cohen_kappa(statuses_a, statuses_b),
+        "severity_pairs": len(severity_ids),
+        "severity_exact_agreement": agreement_rate(severities_a, severities_b),
+        "severity_within_one_agreement": severity_within_one(severities_a, severities_b),
+        "severity_weighted_kappa": cohen_kappa(
+            severities_a,
+            severities_b,
+            list(SEVERITIES),
+        ),
+        "evidence_availability_rate": ratio(
+            len(final_determinate_ids),
+            len(evidence_assessed_ids),
+        ),
+        "determinate_evidence_count": len(final_determinate_ids),
+        "evidence_assessed_count": len(evidence_assessed_ids),
+        "legitimate_unknown_count": len(legitimate_unknown_ids),
+        "legitimate_unknown_ids": sorted(legitimate_unknown_ids),
+        "critical_high_precision": ratio(
+            defensible_high_risk,
+            len(high_risk_ids),
+        ),
+        "defensible_high_risk_count": defensible_high_risk,
+        "high_risk_count": len(high_risk_ids),
+        "candidate_status_accuracy": ratio(
+            len(candidate_status_correct_ids),
+            len(finalized_ids),
+        ),
+        "candidate_status_correct_count": len(candidate_status_correct_ids),
+        "candidate_status_assessed_count": len(finalized_ids),
+        "uncertainty_recall": ratio(
+            len(uncertainty_aligned_ids),
+            len(uncertainty_ids),
+        ),
+        "uncertainty_handling_rate": ratio(
+            len(uncertainty_aligned_ids),
+            len(uncertainty_ids),
+        ),
+        "uncertainty_aligned_count": len(uncertainty_aligned_ids),
+        "uncertainty_items": len(uncertainty_ids),
+        "uncertainty_ids": sorted(uncertainty_ids),
+        "uncertainty_aligned_ids": sorted(uncertainty_aligned_ids),
+        "candidate_uncertainty_count": len(candidate_uncertainty_ids),
+        "overconservative_count": len(overconservative_ids),
+        "overconservative_ids": sorted(overconservative_ids),
+        "overconservative_rate": ratio(
+            len(overconservative_ids),
+            len(candidate_uncertainty_ids),
+        ),
+        "determinate_assertion_count": len(determinate_assertion_ids),
+        "aligned_determinate_assertion_count": len(aligned_determinate_ids),
+        "determinate_status_precision": ratio(
+            len(aligned_determinate_ids),
+            len(determinate_assertion_ids),
+        ),
+        "unsupported_determinate_assertion_count": len(
+            unsupported_determinate_ids
+        ),
+        "unsupported_determinate_assertion_ids": sorted(
+            unsupported_determinate_ids
+        ),
+        "unsupported_determinate_assertion_rate": ratio(
+            len(unsupported_determinate_ids),
+            len(determinate_assertion_ids),
+        ),
+        "negative_assertion_count": len(negative_assertion_ids),
+        "aligned_negative_assertion_count": len(aligned_negative_ids),
+        "negative_assertion_precision": ratio(
+            len(aligned_negative_ids),
+            len(negative_assertion_ids),
+        ),
+        "unsupported_negative_assertion_count": len(unsupported_negative_ids),
+        "unsupported_negative_assertion_ids": sorted(unsupported_negative_ids),
+        "unsupported_negative_assertion_rate": ratio(
+            len(unsupported_negative_ids),
+            len(negative_assertion_ids),
+        ),
+        "recommendation_quality_mean": round(statistics.mean(recommendation_scores), 4)
+        if recommendation_scores else None,
+        "recommendation_score_count": len(recommendation_scores),
+        "recommendation_score_total": round(sum(recommendation_scores), 4),
+        "adversarial_items": len(selected),
+        "adjudicated_count": len(adjudicated),
+        "candidate_overturn_count": candidate_overturns,
+        "candidate_overturn_rate": ratio(candidate_overturns, len(adjudicated)),
+        "reviewer_consensus_items": consensus_items,
+        "reviewer_consensus_overturn_count": consensus_overturns,
+        "reviewer_consensus_overturn_rate": ratio(
+            consensus_overturns,
+            consensus_items,
+        ),
+        "adjudication_abstention_count": adjudication_abstentions,
+        "adjudication_abstention_rate": ratio(
+            adjudication_abstentions,
+            len(adjudicated),
+        ),
+        "unresolved_count": len(unresolved_ids),
+        "unresolved_ids": sorted(unresolved_ids),
+        "unresolved_rate": ratio(len(unresolved_ids), len(common_ids)),
+    }
+
+
+def _call_metadata(result: dict[str, Any], pricing: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model_id": result.get("model_id"),
+        "input_tokens": result.get("input_tokens"),
+        "output_tokens": result.get("output_tokens"),
+        "latency_s": result.get("latency_s"),
+        "cost_usd": compute_cost(result, pricing) if "error" not in result else None,
+        "stop_reason": result.get("stop_reason"),
+        "requested_max_tokens": result.get("requested_max_tokens"),
+        "effective_max_tokens": result.get("effective_max_tokens"),
+        "error": result.get("error"),
+    }
+
+
+def _run_review_chunk(
+    client,
+    model_id: str,
+    prompt_builder: Callable[[list[str]], str],
+    expected_ids: Sequence[str],
+    normalizer,
+    region: str,
+    max_tokens: int,
+    retries: int,
+) -> dict[str, Any]:
+    """Review one chunk, retaining valid rows and retrying unresolved IDs."""
+    accepted: dict[str, dict[str, Any]] = {}
+    pending = list(expected_ids)
+    attempts: list[dict[str, Any]] = []
+    retry_feedback: list[str] = []
+
+    for _ in range(retries + 1):
+        attempt_ids = list(pending)
+        prompt = prompt_builder(attempt_ids)
+        if retry_feedback:
+            prompt += (
+                "\n\n===== PREVIOUS RESPONSE VALIDATION ERRORS =====\n"
+                + "\n".join(f"- {item}" for item in retry_feedback[:20])
+                + "\nReturn corrected rows only for the requested BP IDs."
+            )
+        try:
+            result = _invoke_model(
+                client,
+                model_id,
+                prompt,
+                region,
+                max_tokens,
+            )
+        except Exception as exc:
+            result = {"model_id": model_id, "error": str(exc)}
+
+        attempt: dict[str, Any] = {
+            "expected_ids": attempt_ids,
+            "result": result,
+        }
+        if "error" not in result:
+            assessment = parse_model_rows(
+                result.get("output", ""),
+                attempt_ids,
+                normalizer,
+            )
+            attempt["assessment"] = assessment
+            duplicate_ids = set(assessment["duplicate_ids"])
+            for bp_id, row in assessment["rows"].items():
+                if bp_id not in duplicate_ids:
+                    accepted[bp_id] = row
+            retry_feedback = [
+                *assessment["invalid_rows"],
+                *(
+                    f"missing row: {bp_id}"
+                    for bp_id in assessment["missing_ids"]
+                ),
+                *(
+                    f"duplicate row: {bp_id}"
+                    for bp_id in assessment["duplicate_ids"]
+                ),
+                *(
+                    f"unexpected row: {bp_id}"
+                    for bp_id in assessment["unexpected_ids"]
+                ),
+            ]
+        else:
+            retry_feedback = [f"model call failed: {result.get('error')}"]
+        attempts.append(attempt)
+        pending = [bp_id for bp_id in expected_ids if bp_id not in accepted]
+        if not pending:
+            break
+
+    return {
+        "expected_ids": list(expected_ids),
+        "attempts": attempts,
+        "assessment": {
+            "complete": bool(expected_ids) and not pending,
+            "rows": {
+                bp_id: accepted[bp_id]
+                for bp_id in expected_ids
+                if bp_id in accepted
+            },
+            "missing_ids": pending,
+            "unexpected_ids": [],
+            "duplicate_ids": [],
+            "invalid_rows": [],
+            "recovered_issue_count": sum(
+                bool(attempt.get("result", {}).get("error"))
+                or not attempt.get("assessment", {}).get("complete", False)
+                for attempt in attempts[:-1]
+            ),
+        },
+    }
+
+
+def merge_chunk_assessments(
+    expected_ids: Sequence[str],
+    assessments: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge disjoint chunk ledgers and enforce full-pillar completeness."""
+    expected = set(expected_ids)
+    rows: dict[str, dict[str, Any]] = {}
+    duplicates: set[str] = set()
+    invalid: list[str] = []
+    unexpected: set[str] = set()
+    recovered_issue_count = 0
+
+    for assessment in assessments:
+        invalid.extend(assessment.get("invalid_rows", []))
+        unexpected.update(assessment.get("unexpected_ids", []))
+        recovered_issue_count += int(assessment.get("recovered_issue_count", 0))
+        for bp_id, row in assessment.get("rows", {}).items():
+            if bp_id in rows:
+                duplicates.add(bp_id)
+            rows[bp_id] = row
+
+    actual = set(rows)
+    missing = sorted(expected - actual)
+    unexpected.update(actual - expected)
+    complete = (
+        bool(expected)
+        and not missing
+        and not unexpected
+        and not duplicates
+        and not invalid
+    )
+    return {
+        "complete": complete,
+        "rows": {bp_id: rows[bp_id] for bp_id in sorted(expected & actual)},
+        "missing_ids": missing,
+        "unexpected_ids": sorted(unexpected),
+        "duplicate_ids": sorted(duplicates),
+        "invalid_rows": invalid,
+        "recovered_issue_count": recovered_issue_count,
+    }
+
+
+def _summarize_calls(calls: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    def total(field: str, *, rounded: bool = False) -> int | float | None:
+        values = [
+            call[field]
+            for call in calls
+            if isinstance(call.get(field), (int, float))
+        ]
+        if not values:
+            return None
+        value = sum(values)
+        return round(value, 6) if rounded else value
+
+    errors = [call["error"] for call in calls if call.get("error")]
+    return {
+        "model_id": calls[0].get("model_id") if calls else None,
+        "attempts": len(calls),
+        "successful_calls": len(calls) - len(errors),
+        "input_tokens": total("input_tokens"),
+        "output_tokens": total("output_tokens"),
+        "latency_s": total("latency_s", rounded=True),
+        "cost_usd": total("cost_usd", rounded=True),
+        "stop_reasons": [
+            call["stop_reason"] for call in calls if call.get("stop_reason")
+        ],
+        "errors": errors,
+    }
+
+
+def _materialize_chunk_result(
+    candidate_id: str,
+    pillar_slug: str,
+    role: str,
+    model_id: str,
+    chunk_index: int,
+    result: dict[str, Any],
+    pricing: dict[str, Any],
+    artifacts_dir: Path | None = None,
+) -> dict[str, Any]:
+    attempts: list[dict[str, Any]] = []
+    calls: list[dict[str, Any]] = []
+    for attempt_index, attempt in enumerate(result["attempts"], start=1):
+        raw_result = attempt["result"]
+        call = _call_metadata(raw_result, pricing)
+        calls.append(call)
+        attempt_record: dict[str, Any] = {
+            "attempt": attempt_index,
+            "expected_ids": attempt["expected_ids"],
+            "call": call,
+        }
+        if "error" not in raw_result:
+            attempt_record["artifact"] = _write_raw_artifact(
+                candidate_id,
+                pillar_slug,
+                f"{role}-chunk-{chunk_index:03d}-attempt-{attempt_index:02d}",
+                model_id,
+                raw_result.get("output", ""),
+                artifacts_dir,
+            )
+            attempt_record["assessment"] = attempt["assessment"]
+        attempts.append(attempt_record)
+    return {
+        "chunk_index": chunk_index,
+        "expected_ids": result.get(
+            "expected_ids",
+            [
+                bp_id for bp_id in result["assessment"]["rows"]
+            ] + result["assessment"]["missing_ids"],
+        ),
+        "calls": calls,
+        "attempts": attempts,
+        "assessment": result["assessment"],
+    }
+
+
+def _finalize_review_record(
+    chunks: Sequence[dict[str, Any]],
+    expected_ids: Sequence[str],
+) -> dict[str, Any]:
+    ordered_chunks = sorted(chunks, key=lambda chunk: chunk["chunk_index"])
+    calls = [
+        call
+        for chunk in ordered_chunks
+        for call in chunk.get("calls", [])
+    ]
+    return {
+        "call": _summarize_calls(calls),
+        "calls": calls,
+        "chunks": ordered_chunks,
+        "assessment": merge_chunk_assessments(
+            expected_ids,
+            (chunk["assessment"] for chunk in ordered_chunks),
+        ),
+    }
+
+
+def _record_calls(record: dict[str, Any]) -> list[dict[str, Any]]:
+    calls = record.get("calls")
+    if isinstance(calls, list):
+        return calls
+    call = record.get("call")
+    return [call] if isinstance(call, dict) else []
+
+
+def summarize_resource_usage(
+    pillars: dict[str, dict[str, Any]],
+    wall_s: float,
+) -> dict[str, Any]:
+    by_role = {
+        "blind": {
+            "calls": 0,
+            "failed_calls": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0.0,
+        },
+        "adversarial": {
+            "calls": 0,
+            "failed_calls": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0.0,
+        },
+    }
+    for pillar in pillars.values():
+        for reviewer in pillar.get("reviewers", {}).values():
+            for call in _record_calls(reviewer):
+                by_role["blind"]["calls"] += 1
+                by_role["blind"]["failed_calls"] += int(bool(call.get("error")))
+                by_role["blind"]["input_tokens"] += int(call.get("input_tokens") or 0)
+                by_role["blind"]["output_tokens"] += int(call.get("output_tokens") or 0)
+                by_role["blind"]["cost_usd"] += float(call.get("cost_usd") or 0)
+        for call in _record_calls(pillar.get("adversary", {})):
+            by_role["adversarial"]["calls"] += 1
+            by_role["adversarial"]["failed_calls"] += int(bool(call.get("error")))
+            by_role["adversarial"]["input_tokens"] += int(call.get("input_tokens") or 0)
+            by_role["adversarial"]["output_tokens"] += int(call.get("output_tokens") or 0)
+            by_role["adversarial"]["cost_usd"] += float(call.get("cost_usd") or 0)
+    for values in by_role.values():
+        values["cost_usd"] = round(values["cost_usd"], 6)
+    return {
+        **by_role,
+        "total": {
+            "calls": sum(values["calls"] for values in by_role.values()),
+            "failed_calls": sum(values["failed_calls"] for values in by_role.values()),
+            "input_tokens": sum(values["input_tokens"] for values in by_role.values()),
+            "output_tokens": sum(values["output_tokens"] for values in by_role.values()),
+            "cost_usd": round(sum(values["cost_usd"] for values in by_role.values()), 6),
+            "wall_s": round(wall_s, 2),
+        },
+    }
+
+
+def aggregate_resource_usage(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    totals = {
+        "calls": 0,
+        "failed_calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cost_usd": 0.0,
+        "wall_s": 0.0,
+    }
+    for candidate in candidates:
+        usage = candidate.get("resource_usage", {}).get("total", {})
+        for field in ("calls", "failed_calls", "input_tokens", "output_tokens"):
+            totals[field] += int(usage.get(field) or 0)
+        for field in ("cost_usd", "wall_s"):
+            totals[field] += float(usage.get(field) or 0)
+    totals["cost_usd"] = round(totals["cost_usd"], 6)
+    totals["wall_s"] = round(totals["wall_s"], 2)
+    return totals
+
+
+def run_quality_review(
+    candidates: list[Candidate],
+    reviewers: tuple[str, str],
+    adversary_model: str,
+    region: str,
+    max_tokens: int,
+    concurrency: int,
+    seed: int,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    retries: int = DEFAULT_RETRIES,
+    resume: dict[str, Any] | None = None,
+    artifacts_dir: Path | None = None,
+) -> dict[str, Any]:
+    artifact_root = (artifacts_dir or ARTIFACTS_DIR).expanduser().resolve()
+    if resume:
+        if resume.get("schema_version") != SCHEMA_VERSION:
+            raise ValueError(
+                "resume schema mismatch: "
+                f"{resume.get('schema_version')} != {SCHEMA_VERSION}"
+            )
+        resume_config = resume.get("config", {})
+        expected_config = {
+            "reviewers": list(reviewers),
+            "adversary": adversary_model,
+            "region": region,
+            "seed": seed,
+            "artifacts_dir": str(artifact_root),
+            "evidence_mode": "verbal_exact_quote",
+        }
+        mismatches = [
+            key
+            for key, value in expected_config.items()
+            if resume_config.get(key) != value
+        ]
+        if mismatches:
+            raise ValueError(
+                "resume configuration mismatch: " + ", ".join(mismatches)
+            )
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=region,
+        config=BotoConfig(read_timeout=600),
+    )
+    pricing = load_benchmark_config().get("pricing", {})
+    previous_candidates = {
+        candidate["candidate_id"]: candidate
+        for candidate in (resume or {}).get("candidates", [])
+        if isinstance(candidate, dict) and candidate.get("candidate_id")
+    }
+    output: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "config": {
+            "reviewers": list(reviewers),
+            "adversary": adversary_model,
+            "region": region,
+            "max_tokens": max_tokens,
+            "chunk_size": chunk_size,
+            "retries": retries,
+            "resumed": bool(resume),
+            "seed": seed,
+            "artifacts_dir": str(artifact_root),
+            "evidence_mode": "verbal_exact_quote",
+        },
+        "candidates": [],
+    }
+
+    for candidate in candidates:
+        candidate_started = time.time()
+        candidate_rows = parse_candidate_ledger(candidate.report)
+        previous_candidate = previous_candidates.get(candidate.candidate_id, {})
+        previous_source = previous_candidate.get("source", {})
+        if previous_source and (
+            int(previous_source.get("case_id", -1)) != candidate.case_id
+            or int(previous_source.get("run_idx", -1)) != candidate.run_idx
+        ):
+            raise ValueError(
+                f"resume candidate mismatch for {candidate.candidate_id}"
+            )
+        previous_pillars = previous_candidate.get("pillars", {})
+        previous_wall_s = float(
+            previous_candidate.get("resource_usage", {})
+            .get("total", {})
+            .get("wall_s", 0)
+            or 0
+        )
+        prefixes = scoped_prefixes(candidate.case_id)
+        candidate_result: dict[str, Any] = {
+            "candidate_id": candidate.candidate_id,
+            "source": {
+                "case_id": candidate.case_id,
+                "run_idx": candidate.run_idx,
+                "model": candidate.source_model,
+                "mode": candidate.source_mode,
+            },
+            "citation_metrics": candidate.citation_metrics,
+            "generation_usage": candidate.generation_usage,
+            "candidate_ledger": {
+                "parsed_bp_count": len(candidate_rows),
+                "status_distribution": {
+                    status: sum(
+                        row["candidate_status"] == status
+                        for row in candidate_rows.values()
+                    )
+                    for status in STATUSES
+                    if status != "Missing"
+                },
+            },
+            "pillars": {},
+        }
+        pillar_expected: dict[str, list[str]] = {}
+        blind_jobs: dict[Any, tuple[str, str, str, str, int, list[str]]] = {}
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            for slug, pillar_name, prefix in PILLARS:
+                if prefix not in prefixes:
+                    continue
+                reference = (REFERENCES_DIR / f"{slug}.md").read_text()
+                expected_ids = canonical_ids(reference, prefix)
+                missing_candidate_ids = set(expected_ids) - set(candidate_rows)
+                if missing_candidate_ids:
+                    raise ValueError(
+                        "candidate ledger is missing expected BP rows: "
+                        + ", ".join(sorted(missing_candidate_ids))
+                    )
+                pillar_expected[prefix] = expected_ids
+                previous_pillar = previous_pillars.get(prefix, {})
+                candidate_result["pillars"][prefix] = {
+                    "slug": slug,
+                    "name": pillar_name,
+                    "expected_bp_count": len(expected_ids),
+                    "reviewers": {},
+                }
+                for label, model_id in zip(("A", "B"), reviewers):
+                    previous_review = copy.deepcopy(
+                        previous_pillar.get("reviewers", {}).get(label, {})
+                    )
+                    previous_model = previous_review.get("call", {}).get("model_id")
+                    if previous_model and previous_model != model_id:
+                        raise ValueError(
+                            f"resume reviewer mismatch for {prefix}/{label}: "
+                            f"{previous_model} != {model_id}"
+                        )
+                    review_record = (
+                        previous_review
+                        if isinstance(previous_review.get("chunks"), list)
+                        else {"chunks": []}
+                    )
+                    candidate_result["pillars"][prefix]["reviewers"][label] = (
+                        review_record
+                    )
+                    existing_rows = set(
+                        review_record.get("assessment", {}).get("rows", {})
+                    )
+                    unresolved_ids = [
+                        bp_id for bp_id in expected_ids if bp_id not in existing_rows
+                    ]
+                    first_chunk_index = 1 + max(
+                        (
+                            int(chunk.get("chunk_index", 0))
+                            for chunk in review_record["chunks"]
+                        ),
+                        default=0,
+                    )
+                    for offset, bp_ids in enumerate(
+                        chunk_values(unresolved_ids, chunk_size),
+                    ):
+                        chunk_index = first_chunk_index + offset
+                        def prompt_builder(
+                            selected: list[str],
+                            *,
+                            workload=candidate.workload,
+                            report=candidate.report,
+                            selected_prefix=prefix,
+                            full_reference=reference,
+                            selected_pillar_name=pillar_name,
+                        ) -> str:
+                            return build_blind_prompt(
+                                workload,
+                                extract_pillar_excerpt(
+                                    report,
+                                    selected_prefix,
+                                    selected,
+                                ),
+                                extract_reference_subset(full_reference, selected),
+                                selected_pillar_name,
+                                len(selected),
+                                selected,
+                            )
+
+                        def reviewer_normalizer(
+                            row: dict[str, Any],
+                            *,
+                            workload=candidate.workload,
+                            parsed_candidate_rows=candidate_rows,
+                        ) -> dict[str, Any]:
+                            return normalize_reviewer_row(
+                                row,
+                                workload=workload,
+                                candidate_rows=parsed_candidate_rows,
+                            )
+
+                        future = pool.submit(
+                            _run_review_chunk,
+                            client,
+                            model_id,
+                            prompt_builder,
+                            bp_ids,
+                            reviewer_normalizer,
+                            region,
+                            max_tokens,
+                            retries,
+                        )
+                        blind_jobs[future] = (
+                            prefix,
+                            slug,
+                            label,
+                            model_id,
+                            chunk_index,
+                            bp_ids,
+                        )
+
+            for future in as_completed(blind_jobs):
+                prefix, slug, label, model_id, chunk_index, bp_ids = blind_jobs[future]
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    result = {
+                        "attempts": [{
+                            "expected_ids": bp_ids,
+                            "result": {"model_id": model_id, "error": str(exc)},
+                        }],
+                        "assessment": {
+                            "complete": False,
+                            "rows": {},
+                            "missing_ids": bp_ids,
+                            "unexpected_ids": [],
+                            "duplicate_ids": [],
+                            "invalid_rows": [],
+                            "recovered_issue_count": 0,
+                        },
+                    }
+                chunk_record = _materialize_chunk_result(
+                    candidate.candidate_id,
+                    slug,
+                    f"reviewer-{label.lower()}",
+                    model_id,
+                    chunk_index,
+                    result,
+                    pricing,
+                    artifact_root,
+                )
+                candidate_result["pillars"][prefix]["reviewers"][label][
+                    "chunks"
+                ].append(chunk_record)
+
+        for prefix, pillar_result in candidate_result["pillars"].items():
+            expected_ids = pillar_expected[prefix]
+            for label in ("A", "B"):
+                chunks = pillar_result["reviewers"][label]["chunks"]
+                pillar_result["reviewers"][label] = _finalize_review_record(
+                    chunks,
+                    expected_ids,
+                )
+
+        adversary_jobs: dict[
+            Any,
+            tuple[str, str, int, list[str]],
+        ] = {}
+        adversary_context: dict[
+            str,
+            tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[str]],
+        ] = {}
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            for slug, pillar_name, prefix in PILLARS:
+                if prefix not in prefixes:
+                    continue
+                pillar_result = candidate_result["pillars"][prefix]
+                review_a = pillar_result["reviewers"].get("A", {}).get("assessment", {})
+                review_b = pillar_result["reviewers"].get("B", {}).get("assessment", {})
+                if not review_a.get("complete") or not review_b.get("complete"):
+                    pillar_result["status"] = "incomplete_blind_review"
+                    continue
+
+                rows_a = review_a["rows"]
+                rows_b = review_b["rows"]
+                selected = select_adversarial_ids(
+                    rows_a,
+                    rows_b,
+                    seed=seed + candidate.case_id + sum(ord(char) for char in prefix),
+                )
+                pillar_result["adversarial_selection"] = selected
+                adversary_context[prefix] = (rows_a, rows_b, selected)
+                if not selected:
+                    pillar_result["status"] = "complete"
+                    pillar_result["metrics"] = compute_quality_metrics(
+                        rows_a,
+                        rows_b,
+                        {},
+                        [],
+                        candidate_rows,
+                    )
+                    continue
+
+                reference = (REFERENCES_DIR / f"{slug}.md").read_text()
+                previous_adversary = copy.deepcopy(
+                    previous_pillars.get(prefix, {}).get("adversary", {})
+                )
+                previous_model = previous_adversary.get("call", {}).get("model_id")
+                if previous_model and previous_model != adversary_model:
+                    raise ValueError(
+                        f"resume adversary mismatch for {prefix}: "
+                        f"{previous_model} != {adversary_model}"
+                    )
+                adversary_record = (
+                    previous_adversary
+                    if isinstance(previous_adversary.get("chunks"), list)
+                    else {"chunks": []}
+                )
+                pillar_result["adversary"] = adversary_record
+                existing_rows = set(
+                    adversary_record.get("assessment", {}).get("rows", {})
+                )
+                unresolved_ids = [
+                    bp_id for bp_id in selected if bp_id not in existing_rows
+                ]
+                first_chunk_index = 1 + max(
+                    (
+                        int(chunk.get("chunk_index", 0))
+                        for chunk in adversary_record["chunks"]
+                    ),
+                    default=0,
+                )
+                for offset, bp_ids in enumerate(
+                    chunk_values(unresolved_ids, chunk_size),
+                ):
+                    chunk_index = first_chunk_index + offset
+                    def prompt_builder(
+                        unresolved: list[str],
+                        *,
+                        workload=candidate.workload,
+                        report=candidate.report,
+                        selected_prefix=prefix,
+                        full_reference=reference,
+                        selected_rows_a=rows_a,
+                        selected_rows_b=rows_b,
+                        selected_pillar_name=pillar_name,
+                    ) -> str:
+                        return build_adversary_prompt(
+                            workload,
+                            extract_pillar_excerpt(
+                                report,
+                                selected_prefix,
+                                unresolved,
+                            ),
+                            extract_reference_subset(full_reference, unresolved),
+                            selected_rows_a,
+                            selected_rows_b,
+                            unresolved,
+                            selected_pillar_name,
+                        )
+
+                    def adversary_normalizer(
+                        row: dict[str, Any],
+                        *,
+                        workload=candidate.workload,
+                        selected_rows_a=rows_a,
+                        selected_rows_b=rows_b,
+                    ) -> dict[str, Any]:
+                        return normalize_adversary_row(
+                            row,
+                            workload=workload,
+                            reviewer_a=selected_rows_a,
+                            reviewer_b=selected_rows_b,
+                        )
+
+                    future = pool.submit(
+                        _run_review_chunk,
+                        client,
+                        adversary_model,
+                        prompt_builder,
+                        bp_ids,
+                        adversary_normalizer,
+                        region,
+                        max_tokens,
+                        retries,
+                    )
+                    adversary_jobs[future] = (
+                        prefix,
+                        slug,
+                        chunk_index,
+                        bp_ids,
+                    )
+
+            for future in as_completed(adversary_jobs):
+                prefix, slug, chunk_index, bp_ids = adversary_jobs[future]
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    result = {
+                        "attempts": [{
+                            "expected_ids": bp_ids,
+                            "result": {
+                                "model_id": adversary_model,
+                                "error": str(exc),
+                            },
+                        }],
+                        "assessment": {
+                            "complete": False,
+                            "rows": {},
+                            "missing_ids": bp_ids,
+                            "unexpected_ids": [],
+                            "duplicate_ids": [],
+                            "invalid_rows": [],
+                            "recovered_issue_count": 0,
+                        },
+                    }
+                chunk_record = _materialize_chunk_result(
+                    candidate.candidate_id,
+                    slug,
+                    "adversary",
+                    adversary_model,
+                    chunk_index,
+                    result,
+                    pricing,
+                    artifact_root,
+                )
+                candidate_result["pillars"][prefix]["adversary"]["chunks"].append(
+                    chunk_record
+                )
+
+        for prefix, (rows_a, rows_b, selected) in adversary_context.items():
+            if not selected:
+                continue
+            pillar_result = candidate_result["pillars"][prefix]
+            adversary_record = _finalize_review_record(
+                pillar_result["adversary"]["chunks"],
+                selected,
+            )
+            pillar_result["adversary"] = adversary_record
+            assessment = adversary_record["assessment"]
+            pillar_result["status"] = (
+                "complete"
+                if assessment.get("complete")
+                else "incomplete_adversarial_review"
+            )
+            pillar_result["metrics"] = compute_quality_metrics(
+                rows_a,
+                rows_b,
+                assessment.get("rows", {}),
+                selected,
+                candidate_rows,
+            )
+
+        complete_metrics = [
+            pillar["metrics"]
+            for pillar in candidate_result["pillars"].values()
+            if pillar.get("status") == "complete" and "metrics" in pillar
+        ]
+        candidate_result["status"] = (
+            "complete"
+            if len(complete_metrics) == len(candidate_result["pillars"])
+            else "incomplete"
+        )
+        candidate_result["summary"] = summarize_metrics(complete_metrics)
+        candidate_result["resource_usage"] = summarize_resource_usage(
+            candidate_result["pillars"],
+            previous_wall_s + time.time() - candidate_started,
+        )
+        output["candidates"].append(candidate_result)
+
+    output["summary"] = summarize_metrics([
+        candidate["summary"]
+        for candidate in output["candidates"]
+        if candidate["status"] == "complete"
+    ])
+    output["resource_usage"] = aggregate_resource_usage(output["candidates"])
+    return output
+
+
+def summarize_metrics(metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    if not metrics:
+        return {"completed_units": 0}
+    macro_rate_fields = (
+        "status_exact_agreement",
+        "status_kappa",
+        "severity_exact_agreement",
+        "severity_within_one_agreement",
+        "severity_weighted_kappa",
+    )
+    summary: dict[str, Any] = {"completed_units": len(metrics)}
+    for field in macro_rate_fields:
+        values = [
+            metric[field]
+            for metric in metrics
+            if isinstance(metric.get(field), (int, float))
+        ]
+        summary[field] = round(statistics.mean(values), 4) if values else None
+    count_fields = (
+        "bps_reviewed",
+        "severity_pairs",
+        "determinate_evidence_count",
+        "evidence_assessed_count",
+        "legitimate_unknown_count",
+        "defensible_high_risk_count",
+        "high_risk_count",
+        "candidate_status_correct_count",
+        "candidate_status_assessed_count",
+        "adversarial_items",
+        "uncertainty_aligned_count",
+        "uncertainty_items",
+        "candidate_uncertainty_count",
+        "overconservative_count",
+        "determinate_assertion_count",
+        "aligned_determinate_assertion_count",
+        "unsupported_determinate_assertion_count",
+        "negative_assertion_count",
+        "aligned_negative_assertion_count",
+        "unsupported_negative_assertion_count",
+        "recommendation_score_count",
+        "adjudicated_count",
+        "candidate_overturn_count",
+        "reviewer_consensus_items",
+        "reviewer_consensus_overturn_count",
+        "adjudication_abstention_count",
+        "unresolved_count",
+    )
+    for field in count_fields:
+        summary[field] = sum(int(metric.get(field, 0)) for metric in metrics)
+    summary["recommendation_score_total"] = round(
+        sum(float(metric.get("recommendation_score_total", 0)) for metric in metrics),
+        4,
+    )
+    ratio_fields = (
+        (
+            "evidence_availability_rate",
+            "determinate_evidence_count",
+            "evidence_assessed_count",
+        ),
+        (
+            "critical_high_precision",
+            "defensible_high_risk_count",
+            "high_risk_count",
+        ),
+        (
+            "candidate_status_accuracy",
+            "candidate_status_correct_count",
+            "candidate_status_assessed_count",
+        ),
+        (
+            "uncertainty_handling_rate",
+            "uncertainty_aligned_count",
+            "uncertainty_items",
+        ),
+        (
+            "uncertainty_recall",
+            "uncertainty_aligned_count",
+            "uncertainty_items",
+        ),
+        (
+            "overconservative_rate",
+            "overconservative_count",
+            "candidate_uncertainty_count",
+        ),
+        (
+            "determinate_status_precision",
+            "aligned_determinate_assertion_count",
+            "determinate_assertion_count",
+        ),
+        (
+            "unsupported_determinate_assertion_rate",
+            "unsupported_determinate_assertion_count",
+            "determinate_assertion_count",
+        ),
+        (
+            "negative_assertion_precision",
+            "aligned_negative_assertion_count",
+            "negative_assertion_count",
+        ),
+        (
+            "unsupported_negative_assertion_rate",
+            "unsupported_negative_assertion_count",
+            "negative_assertion_count",
+        ),
+        (
+            "candidate_overturn_rate",
+            "candidate_overturn_count",
+            "adjudicated_count",
+        ),
+        (
+            "reviewer_consensus_overturn_rate",
+            "reviewer_consensus_overturn_count",
+            "reviewer_consensus_items",
+        ),
+        (
+            "adjudication_abstention_rate",
+            "adjudication_abstention_count",
+            "adjudicated_count",
+        ),
+        (
+            "unresolved_rate",
+            "unresolved_count",
+            "bps_reviewed",
+        ),
+    )
+    for rate_field, numerator_field, denominator_field in ratio_fields:
+        denominator = summary[denominator_field]
+        summary[rate_field] = (
+            round(summary[numerator_field] / denominator, 4)
+            if denominator
+            else None
+        )
+    recommendation_count = summary["recommendation_score_count"]
+    summary["recommendation_quality_mean"] = (
+        round(summary["recommendation_score_total"] / recommendation_count, 4)
+        if recommendation_count
+        else None
+    )
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run blind and adversarial quality review over captured wa-review reports.",
+    )
+    parser.add_argument("--results", type=Path, default=DEFAULT_RESULTS)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        default=ARTIFACTS_DIR,
+        help="Directory for raw blind-review and adversary responses.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Reuse valid rows and call metadata from the existing output file.",
+    )
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument("--pilot", action="store_true", help="Evaluate cases 2 and 3.")
+    selection.add_argument("--cases", type=int, nargs="+", help="Evaluate selected case IDs.")
+    parser.add_argument("--runs", type=int, default=1, help="Candidate runs per case.")
+    parser.add_argument("--reviewers", nargs=2, default=list(DEFAULT_REVIEWERS))
+    parser.add_argument("--adversary", default=DEFAULT_ADVERSARY)
+    parser.add_argument("--region", default=DEFAULT_REGION)
+    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=DEFAULT_CHUNK_SIZE,
+        help="Maximum BPs per model call.",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=DEFAULT_RETRIES,
+        help="Retries for unresolved rows in each chunk.",
+    )
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.runs < 1:
+        parser.error("--runs must be at least 1")
+    if args.concurrency < 1:
+        parser.error("--concurrency must be at least 1")
+    if args.max_tokens < 1:
+        parser.error("--max-tokens must be at least 1")
+    if args.chunk_size < 1:
+        parser.error("--chunk-size must be at least 1")
+    if args.retries < 0:
+        parser.error("--retries must be at least 0")
+    selected_cases = {2, 3} if args.pilot else set(args.cases) if args.cases else None
+    try:
+        candidates = load_candidates(
+            args.results,
+            selected_cases,
+            args.runs,
+            args.seed,
+        )
+        validate_panel(
+            (candidate.source_model for candidate in candidates),
+            args.reviewers,
+            args.adversary,
+        )
+        resume = (
+            json.loads(args.output.read_text())
+            if args.resume
+            else None
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+    if args.resume and resume is None:
+        parser.error(f"resume output does not exist: {args.output}")
+    print(
+        f"Quality review: {len(candidates)} candidate(s), "
+        f"reviewers={', '.join(args.reviewers)}, adversary={args.adversary}"
+    )
+    result = run_quality_review(
+        candidates,
+        tuple(args.reviewers),
+        args.adversary,
+        args.region,
+        args.max_tokens,
+        args.concurrency,
+        args.seed,
+        args.chunk_size,
+        args.retries,
+        resume,
+        args.artifacts_dir,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2))
+    print(f"Saved: {args.output}")
+    print(json.dumps(result["summary"], indent=2))
+    return 0 if all(candidate["status"] == "complete" for candidate in result["candidates"]) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/tests/test_measure_wa_review.py
+++ b/evals/tests/test_measure_wa_review.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Offline tests for the Claude Code wa-review effectiveness harness."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+CLI_DIR = Path(__file__).parent.parent / "cli_effectiveness"
+sys.path.insert(0, str(CLI_DIR))
+
+import measure_wa_review as measure
+
+
+def test_autonomous_preamble_requires_uncertainty_calibration():
+    assert "Cannot\nDetermine" in measure.AUTONOMOUS_PREAMBLE
+    assert "leave severity blank" in measure.AUTONOMOUS_PREAMBLE
+    assert "specific artifact, metric" in measure.AUTONOMOUS_PREAMBLE
+    assert "explicitly says a control is absent" in measure.AUTONOMOUS_PREAMBLE
+    assert "Based on description" not in measure.AUTONOMOUS_PREAMBLE
+
+
+def test_parser_supports_single_case_run_and_isolated_output(tmp_path):
+    output = tmp_path / "candidate_results.json"
+
+    args = measure.build_parser().parse_args([
+        "--cases", "2",
+        "--runs", "1",
+        "--model", "opus",
+        "--output", str(output),
+    ])
+
+    assert args.cases == [2]
+    assert args.runs == 1
+    assert args.model == "opus"
+    assert args.output == output
+
+
+def test_main_rejects_unknown_case_without_calling_claude(tmp_path):
+    with pytest.raises(SystemExit):
+        measure.main([
+            "--cases", "999",
+            "--runs", "1",
+            "--output", str(tmp_path / "unused.json"),
+        ])

--- a/evals/tests/test_review_quality.py
+++ b/evals/tests/test_review_quality.py
@@ -1,0 +1,1002 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Offline tests for blind and adversarial wa-review evaluation."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+EVALS_DIR = Path(__file__).parent.parent
+CLI_DIR = EVALS_DIR / "cli_effectiveness"
+sys.path.insert(0, str(EVALS_DIR))
+sys.path.insert(0, str(CLI_DIR))
+
+import review_quality as rq
+from benchmark import _extract_text
+from generate_ground_truth import MODELS, build_canonical_bps, compute_ground_truth
+from review_quality import (
+    Candidate,
+    build_blind_prompt,
+    build_evidence_catalog,
+    cohen_kappa,
+    compute_quality_metrics,
+    extract_pillar_excerpt,
+    load_candidates,
+    normalize_bp_id,
+    normalize_reviewer_row,
+    parse_candidate_ledger,
+    parse_model_rows,
+    run_quality_review,
+    select_adversarial_ids,
+    severity_within_one,
+    validate_panel,
+)
+
+WORKLOAD = (
+    "The workload uses one EC2 instance and has no backups configured. "
+    "Monitoring is limited to basic metrics."
+)
+
+
+def evidence_for_status(status):
+    return {
+        "Implemented": ("explicit_presence", "uses one EC2 instance"),
+        "Partially Implemented": (
+            "explicit_partial",
+            "Monitoring is limited to basic metrics",
+        ),
+        "Not Implemented": ("explicit_absence", "no backups configured"),
+        "Not Applicable": ("not_applicable", None),
+        "Cannot Determine": ("omitted", None),
+    }[status]
+
+
+def reviewer_row(
+    bp_id,
+    *,
+    candidate_status="Not Implemented",
+    reference_status="Not Implemented",
+    evidence_kind=None,
+    evidence_quote=None,
+    candidate_severity="High",
+    reference_severity="High",
+    recommendation_score=4,
+):
+    default_kind, default_quote = evidence_for_status(reference_status)
+    return {
+        "bp_id": bp_id,
+        # Included for metric fixtures; schema-v3 normalization ignores these
+        # model-supplied values and injects the parsed candidate ledger values.
+        "candidate_status": candidate_status,
+        "reference_status": reference_status,
+        "evidence_kind": evidence_kind or default_kind,
+        "evidence_quote": (
+            default_quote
+            if evidence_kind is None and evidence_quote is None
+            else evidence_quote
+        ),
+        "evidence_rationale": "The workload statement supports this conclusion.",
+        "candidate_severity": candidate_severity,
+        "reference_severity": reference_severity,
+        "recommendation_score": recommendation_score,
+        "challenge": None,
+        "confidence": "high",
+    }
+
+
+def adversary_row(
+    bp_id,
+    *,
+    disposition="uphold_candidate",
+    final_status="Not Implemented",
+    final_severity="High",
+    evidence_kind=None,
+    evidence_quote=None,
+    reviewer_assessment="both_hold",
+):
+    default_kind, default_quote = evidence_for_status(final_status)
+    return {
+        "bp_id": bp_id,
+        "disposition": disposition,
+        "final_status": final_status,
+        "final_severity": final_severity,
+        "evidence_kind": evidence_kind or default_kind,
+        "evidence_quote": (
+            default_quote
+            if evidence_kind is None and evidence_quote is None
+            else evidence_quote
+        ),
+        "reviewer_assessment": reviewer_assessment,
+        "rationale": "The workload directly supports this conclusion.",
+        "confidence": "high",
+    }
+
+
+def candidate_rows(*rows):
+    return {
+        row["bp_id"]: {
+            "bp_id": row["bp_id"],
+            "candidate_status": row["candidate_status"],
+            "candidate_severity": row["candidate_severity"],
+        }
+        for row in rows
+    }
+
+
+def normalize_test_reviewer(row):
+    return normalize_reviewer_row(
+        row,
+        workload=WORKLOAD,
+        candidate_rows=candidate_rows(row),
+    )
+
+
+def normalize_test_adversary(row, reviewer_a, reviewer_b):
+    return rq.normalize_adversary_row(
+        row,
+        workload=WORKLOAD,
+        reviewer_a=reviewer_a,
+        reviewer_b=reviewer_b,
+    )
+
+
+def test_normalize_bp_id_accepts_unicode_hyphen():
+    assert normalize_bp_id("SEC03‑BP02") == "SEC03-BP02"
+
+
+def test_structured_calls_can_exclude_reasoning_blocks():
+    response = {
+        "output": {
+            "message": {
+                "content": [
+                    {"reasoningContent": {"reasoningText": {"text": '{"rows":[]}'}}},
+                    {"text": '{"rows":[{"bp_id":"SEC01-BP01"}]}'},
+                ]
+            }
+        }
+    }
+
+    assert _extract_text(response, include_reasoning=False) == (
+        '{"rows":[{"bp_id":"SEC01-BP01"}]}'
+    )
+
+
+def test_parse_model_rows_requires_exact_complete_ledger():
+    expected = {"SEC01-BP01", "SEC01-BP02"}
+    response = json.dumps({
+        "rows": [
+            reviewer_row("SEC01-BP01"),
+            reviewer_row("SEC01-BP02", candidate_severity=None, reference_severity=None),
+        ]
+    })
+
+    parsed = parse_model_rows(response, expected, normalize_test_reviewer)
+
+    assert parsed["complete"] is True
+    assert set(parsed["rows"]) == expected
+
+
+def test_reviewer_missing_confidence_defaults_to_low():
+    row = reviewer_row("SEC01-BP01")
+    row.pop("confidence")
+
+    normalized = normalize_test_reviewer(row)
+
+    assert normalized["confidence"] == "low"
+
+
+def test_reviewer_requires_status_to_match_evidence_provenance():
+    invalid = reviewer_row(
+        "SEC01-BP01",
+        reference_status="Not Implemented",
+        evidence_kind="omitted",
+        evidence_quote=None,
+        reference_severity=None,
+    )
+
+    with pytest.raises(ValueError, match="incompatible"):
+        normalize_test_reviewer(invalid)
+
+    valid = normalize_test_reviewer(reviewer_row(
+        "SEC01-BP01",
+        reference_status="Cannot Determine",
+        evidence_kind="omitted",
+        evidence_quote=None,
+        reference_severity=None,
+    ))
+
+    assert valid["reference_status"] == "Cannot Determine"
+    assert valid["reference_severity"] is None
+    assert valid["evidence_kind"] == "omitted"
+
+
+def test_reviewer_rejects_fabricated_evidence_quote():
+    row = reviewer_row(
+        "SEC01-BP01",
+        evidence_quote="no incident response process",
+    )
+
+    with pytest.raises(ValueError, match="not an exact workload quote"):
+        normalize_test_reviewer(row)
+
+
+def test_evidence_catalog_preserves_exact_atomic_workload_spans():
+    catalog = build_evidence_catalog(
+        "Single EC2 instance, no backups configured. Basic metrics only."
+    )
+
+    assert catalog == {
+        "W001": "Single EC2 instance",
+        "W002": "no backups configured.",
+        "W003": "Basic metrics only.",
+    }
+
+
+def test_reviewer_resolves_catalog_id_to_exact_workload_quote():
+    row = reviewer_row("SEC01-BP01")
+    row.pop("evidence_quote")
+    row["evidence_quote_id"] = "w001"
+
+    normalized = normalize_test_reviewer(row)
+
+    assert normalized["evidence_quote_id"] == "W001"
+    assert normalized["evidence_quote"] == (
+        "The workload uses one EC2 instance and has no backups configured."
+    )
+
+
+def test_reviewer_rejects_unknown_catalog_id():
+    row = reviewer_row("SEC01-BP01")
+    row.pop("evidence_quote")
+    row["evidence_quote_id"] = "W999"
+
+    with pytest.raises(ValueError, match="invalid evidence_quote_id"):
+        normalize_test_reviewer(row)
+
+
+def test_reviewer_uses_parsed_candidate_status_not_model_supplied_values():
+    raw = reviewer_row(
+        "SEC01-BP01",
+        candidate_status="Not Implemented",
+        candidate_severity="Critical",
+        reference_status="Cannot Determine",
+        reference_severity=None,
+    )
+    parsed_candidate = {
+        "SEC01-BP01": {
+            "bp_id": "SEC01-BP01",
+            "candidate_status": "Cannot Determine",
+            "candidate_severity": None,
+        }
+    }
+
+    normalized = normalize_reviewer_row(
+        raw,
+        workload=WORKLOAD,
+        candidate_rows=parsed_candidate,
+    )
+
+    assert normalized["candidate_status"] == "Cannot Determine"
+    assert normalized["candidate_severity"] is None
+
+
+def test_adversary_requires_status_to_match_reviewer_evidence():
+    blind_a = normalize_test_reviewer(reviewer_row(
+        "SEC01-BP01",
+        candidate_status="Cannot Determine",
+        candidate_severity=None,
+        reference_status="Cannot Determine",
+        reference_severity=None,
+    ))
+    blind_b = dict(blind_a)
+    invalid = adversary_row(
+        "SEC01-BP01",
+        final_status="Not Implemented",
+        final_severity=None,
+        evidence_kind="explicit_absence",
+        evidence_quote="no backups configured",
+        disposition="accept_challenge",
+    )
+
+    with pytest.raises(ValueError, match="supplied by a blind reviewer"):
+        normalize_test_adversary(
+            invalid,
+            {"SEC01-BP01": blind_a},
+            {"SEC01-BP01": blind_b},
+        )
+
+    valid = normalize_test_adversary(adversary_row(
+        "SEC01-BP01",
+        final_status="Cannot Determine",
+        final_severity=None,
+        evidence_kind="omitted",
+        evidence_quote=None,
+        disposition="insufficient_evidence",
+    ), {"SEC01-BP01": blind_a}, {"SEC01-BP01": blind_b})
+
+    assert valid["final_status"] == "Cannot Determine"
+    assert valid["final_severity"] is None
+
+
+@pytest.mark.parametrize(
+    ("rows", "field"),
+    [
+        ([reviewer_row("SEC01-BP01")], "missing_ids"),
+        (
+            [reviewer_row("SEC01-BP01"), reviewer_row("SEC01-BP01")],
+            "duplicate_ids",
+        ),
+        (
+            [reviewer_row("SEC01-BP01"), reviewer_row("REL01-BP01")],
+            "unexpected_ids",
+        ),
+    ],
+)
+def test_parse_model_rows_rejects_incomplete_duplicate_or_unexpected(rows, field):
+    parsed = parse_model_rows(
+        json.dumps({"rows": rows}),
+        {"SEC01-BP01", "SEC01-BP02"},
+        normalize_test_reviewer,
+    )
+
+    assert parsed["complete"] is False
+    assert parsed[field]
+
+
+def test_extract_pillar_excerpt_keeps_only_requested_pillar():
+    report = "\n".join([
+        "| SEC01-BP01 | Not Implemented | High |",
+        "| REL01-BP01 | Implemented | |",
+        "| SEC01‑BP02 | Cannot Determine | |",
+    ])
+
+    excerpt = extract_pillar_excerpt(report, "SEC")
+
+    assert "SEC01-BP01" in excerpt
+    assert "SEC01‑BP02" in excerpt
+    assert "REL01-BP01" not in excerpt
+
+
+def test_reference_and_candidate_excerpts_can_be_scoped_to_chunk():
+    reference = "\n".join([
+        "# Security",
+        "# SEC01-BP01 First",
+        "First guidance.",
+        "# SEC01-BP02 Second",
+        "Second guidance.",
+        "# SEC01-BP03 Third",
+        "Third guidance.",
+    ])
+    report = "\n".join([
+        "| SEC01-BP01 | Implemented |",
+        "| SEC01-BP02 | Not Implemented |",
+        "| SEC01-BP03 | Cannot Determine |",
+    ])
+
+    reference_subset = rq.extract_reference_subset(
+        reference,
+        ["SEC01-BP02"],
+    )
+    candidate_subset = extract_pillar_excerpt(
+        report,
+        "SEC",
+        ["SEC01-BP02"],
+    )
+
+    assert "SEC01-BP02" in reference_subset
+    assert "SEC01-BP01" not in reference_subset
+    assert "SEC01-BP03" not in reference_subset
+    assert "SEC01-BP02" in candidate_subset
+    assert "SEC01-BP01" not in candidate_subset
+    assert "SEC01-BP03" not in candidate_subset
+
+
+def test_candidate_ledger_is_parsed_deterministically():
+    report = "\n".join([
+        "| BP ID | Status | Severity | Evidence |",
+        "| SEC01-BP01 | Cannot Determine | | Need account configuration |",
+        "| SEC01-BP02 | Not Implemented | High | no backups configured |",
+        "| SEC01-BP03 | OPS | Not a ledger row |",
+    ])
+
+    rows = parse_candidate_ledger(report)
+
+    assert rows == {
+        "SEC01-BP01": {
+            "bp_id": "SEC01-BP01",
+            "candidate_status": "Cannot Determine",
+            "candidate_severity": None,
+        },
+        "SEC01-BP02": {
+            "bp_id": "SEC01-BP02",
+            "candidate_status": "Not Implemented",
+            "candidate_severity": "High",
+        },
+    }
+
+
+def test_candidate_ledger_rejects_severity_for_cannot_determine():
+    with pytest.raises(ValueError, match="must be null"):
+        parse_candidate_ledger(
+            "| SEC01-BP01 | Cannot Determine | High | Need account config |"
+        )
+
+
+def test_blind_prompt_does_not_receive_candidate_identity_metadata():
+    prompt = build_blind_prompt(
+        "A workload on AWS.",
+        "| SEC01-BP01 | Implemented |",
+        "# SEC01-BP01 Example",
+        "Security",
+        1,
+    )
+
+    assert "candidate-001" not in prompt
+    assert "wa_review_effectiveness" not in prompt
+    assert "claude-sonnet" not in prompt
+    assert "baseline" not in prompt.lower()
+    assert "existing score" not in prompt.lower()
+    assert "not explicit_absence" in prompt
+    assert "exact contiguous quote from WORKLOAD" in prompt
+    assert "evidence_quote_id" in prompt
+    assert "W001:" in prompt
+    assert "do not return either" in prompt
+
+
+def test_skill_contract_includes_cannot_determine_as_fifth_status():
+    for filename in ("SKILL.md", "SKILL-devops-agent.md"):
+        text = (EVALS_DIR.parent / "skills" / "wa-review" / filename).read_text()
+
+        assert "one of four statuses" not in text
+        assert "all four statuses" not in text
+        assert "one of five statuses" in text
+        assert "Absence of evidence is not evidence of absence." in text
+        assert "`Cannot Determine` counts as evaluated coverage" in text
+
+
+
+def test_validate_panel_rejects_candidate_family_self_grading():
+    with pytest.raises(ValueError, match="self-grading"):
+        validate_panel(
+            ["sonnet"],
+            ["us.anthropic.claude-sonnet-5", "openai.gpt-oss-120b"],
+            "us.deepseek.r1-v1:0",
+        )
+
+
+def test_validate_panel_accepts_three_independent_families():
+    validate_panel(
+        ["sonnet"],
+        ["openai.gpt-oss-120b", "us.amazon.nova-pro-v1:0"],
+        "us.deepseek.r1-v1:0",
+    )
+
+
+def test_invoke_model_applies_provider_output_limit(monkeypatch):
+    captured = {}
+
+    def fake_call_model(client, model_id, messages, **kwargs):
+        captured.update(kwargs)
+        return {
+            "model_id": model_id,
+            "output": "{}",
+            "input_tokens": 1,
+            "output_tokens": 1,
+        }
+
+    monkeypatch.setattr(rq, "call_model", fake_call_model)
+
+    result = rq._invoke_model(
+        object(),
+        "us.amazon.nova-pro-v1:0",
+        "test",
+        "us-east-1",
+        16_384,
+    )
+
+    assert captured["max_tokens"] == 9_999
+    assert result["requested_max_tokens"] == 16_384
+    assert result["effective_max_tokens"] == 9_999
+
+
+def test_chunk_review_retries_only_unresolved_rows(monkeypatch):
+    requested = []
+
+    def prompt_builder(bp_ids):
+        requested.append(list(bp_ids))
+        return ",".join(bp_ids)
+
+    def fake_invoke(client, model_id, prompt, region, max_tokens):
+        bp_ids = prompt.split("\n", 1)[0].split(",")
+        returned = bp_ids[:1]
+        return {
+            "model_id": model_id,
+            "output": json.dumps({
+                "rows": [reviewer_row(bp_id) for bp_id in returned],
+            }),
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "latency_s": 0.1,
+        }
+
+    monkeypatch.setattr(rq, "_invoke_model", fake_invoke)
+
+    result = rq._run_review_chunk(
+        object(),
+        "reviewer-model",
+        prompt_builder,
+        ["SEC01-BP01", "SEC01-BP02"],
+        normalize_test_reviewer,
+        "us-east-1",
+        1024,
+        retries=1,
+    )
+
+    assert requested == [
+        ["SEC01-BP01", "SEC01-BP02"],
+        ["SEC01-BP02"],
+    ]
+    assert result["assessment"]["complete"] is True
+    assert set(result["assessment"]["rows"]) == {
+        "SEC01-BP01",
+        "SEC01-BP02",
+    }
+    assert result["assessment"]["recovered_issue_count"] == 1
+
+
+def test_chunk_merge_rejects_missing_rows():
+    first = {
+        "complete": True,
+        "rows": {"SEC01-BP01": reviewer_row("SEC01-BP01")},
+        "missing_ids": [],
+        "unexpected_ids": [],
+        "duplicate_ids": [],
+        "invalid_rows": [],
+    }
+
+    merged = rq.merge_chunk_assessments(
+        ["SEC01-BP01", "SEC01-BP02"],
+        [first],
+    )
+
+    assert merged["complete"] is False
+    assert merged["missing_ids"] == ["SEC01-BP02"]
+
+
+def test_adversarial_selection_includes_risk_disagreement_and_seeded_sample():
+    reviewer_a = {
+        "SEC01-BP01": reviewer_row("SEC01-BP01"),
+        "SEC01-BP02": reviewer_row(
+            "SEC01-BP02",
+            candidate_severity="Low",
+            reference_severity="Low",
+        ),
+        "SEC01-BP03": reviewer_row(
+            "SEC01-BP03",
+            candidate_severity="Low",
+            reference_severity="Low",
+        ),
+    }
+    reviewer_b = {
+        "SEC01-BP01": reviewer_row("SEC01-BP01"),
+        "SEC01-BP02": reviewer_row(
+            "SEC01-BP02",
+            candidate_severity="Low",
+            reference_severity="Medium",
+        ),
+        "SEC01-BP03": reviewer_row(
+            "SEC01-BP03",
+            candidate_severity="Low",
+            reference_severity="Low",
+        ),
+    }
+
+    first = select_adversarial_ids(reviewer_a, reviewer_b, seed=7)
+    second = select_adversarial_ids(reviewer_a, reviewer_b, seed=7)
+
+    assert first == second
+    assert "SEC01-BP01" in first  # Candidate High finding.
+    assert "SEC01-BP02" in first  # Reviewer severity disagreement.
+    assert "SEC01-BP03" in first  # Deterministic 10% agreement sample.
+
+
+def test_agreement_metrics_handle_exact_and_adjacent_severity():
+    assert cohen_kappa(["a", "b"], ["a", "b"]) == 1.0
+    assert severity_within_one(["High", "Medium"], ["Medium", "Low"]) == 1.0
+
+
+def test_quality_metrics_include_overturns_and_unresolved_items():
+    reviewer_a = {
+        "SEC01-BP01": reviewer_row("SEC01-BP01"),
+        "SEC01-BP02": reviewer_row(
+            "SEC01-BP02",
+            candidate_severity="Low",
+            reference_severity="Low",
+        ),
+    }
+    reviewer_b = {
+        "SEC01-BP01": reviewer_row("SEC01-BP01"),
+        "SEC01-BP02": reviewer_row(
+            "SEC01-BP02",
+            candidate_severity="Low",
+            reference_severity="Medium",
+        ),
+    }
+    adversary = {
+        "SEC01-BP01": adversary_row(
+            "SEC01-BP01",
+            disposition="accept_challenge",
+            final_status="Cannot Determine",
+            final_severity=None,
+            evidence_kind="omitted",
+            evidence_quote=None,
+            reviewer_assessment="both_weak",
+        ),
+        "SEC01-BP02": adversary_row(
+            "SEC01-BP02",
+            disposition="insufficient_evidence",
+            final_status="Cannot Determine",
+            final_severity=None,
+            evidence_kind="omitted",
+            evidence_quote=None,
+        ),
+    }
+    candidates = candidate_rows(*reviewer_a.values())
+
+    metrics = compute_quality_metrics(
+        reviewer_a,
+        reviewer_b,
+        adversary,
+        {"SEC01-BP01", "SEC01-BP02"},
+        candidates,
+    )
+
+    assert metrics["bps_reviewed"] == 2
+    assert metrics["candidate_overturn_rate"] == 0.5
+    assert metrics["reviewer_consensus_overturn_rate"] == 1.0
+    assert metrics["unresolved_count"] == 0
+    assert metrics["adjudication_abstention_count"] == 1
+    assert metrics["critical_high_precision"] == 0.0
+    assert metrics["uncertainty_handling_rate"] == 0.0
+    assert metrics["uncertainty_aligned_count"] == 0
+    assert metrics["uncertainty_items"] == 2
+    assert metrics["uncertainty_ids"] == ["SEC01-BP01", "SEC01-BP02"]
+    assert metrics["unsupported_determinate_assertion_count"] == 2
+    assert metrics["unsupported_determinate_assertion_ids"] == [
+        "SEC01-BP01",
+        "SEC01-BP02",
+    ]
+    assert metrics["unsupported_determinate_assertion_rate"] == 1.0
+    assert metrics["unsupported_negative_assertion_count"] == 2
+    assert metrics["unsupported_negative_assertion_ids"] == [
+        "SEC01-BP01",
+        "SEC01-BP02",
+    ]
+    assert metrics["unsupported_negative_assertion_rate"] == 1.0
+
+
+def test_sparse_evidence_rewards_explicit_abstention():
+    reviewer_a = {
+        "SEC01-BP01": reviewer_row(
+            "SEC01-BP01",
+            candidate_status="Cannot Determine",
+            reference_status="Cannot Determine",
+            evidence_kind="omitted",
+            evidence_quote=None,
+            candidate_severity=None,
+            reference_severity=None,
+            recommendation_score=None,
+        ),
+    }
+    reviewer_b = dict(reviewer_a)
+    adversary = {
+        "SEC01-BP01": adversary_row(
+            "SEC01-BP01",
+            final_status="Cannot Determine",
+            final_severity=None,
+            evidence_kind="omitted",
+            evidence_quote=None,
+        ),
+    }
+    candidates = candidate_rows(*reviewer_a.values())
+
+    metrics = compute_quality_metrics(
+        reviewer_a,
+        reviewer_b,
+        adversary,
+        {"SEC01-BP01"},
+        candidates,
+    )
+
+    assert metrics["uncertainty_aligned_count"] == 1
+    assert metrics["uncertainty_items"] == 1
+    assert metrics["uncertainty_aligned_ids"] == ["SEC01-BP01"]
+    assert metrics["uncertainty_handling_rate"] == 1.0
+    assert metrics["legitimate_unknown_count"] == 1
+    assert metrics["evidence_availability_rate"] == 0.0
+    assert metrics["unsupported_determinate_assertion_count"] == 0
+    assert metrics["unsupported_determinate_assertion_rate"] is None
+
+
+def test_provenance_backed_determinate_status_measures_overconservatism():
+    candidate = reviewer_row(
+        "SEC01-BP01",
+        candidate_status="Cannot Determine",
+        candidate_severity=None,
+    )
+    reviewer_a = {"SEC01-BP01": candidate}
+    reviewer_b = {"SEC01-BP01": dict(candidate)}
+    adversary = {
+        "SEC01-BP01": adversary_row(
+            "SEC01-BP01",
+            disposition="accept_challenge",
+        ),
+    }
+
+    metrics = compute_quality_metrics(
+        reviewer_a,
+        reviewer_b,
+        adversary,
+        {"SEC01-BP01"},
+        candidate_rows(candidate),
+    )
+
+    assert metrics["uncertainty_items"] == 0
+    assert metrics["candidate_uncertainty_count"] == 1
+    assert metrics["overconservative_count"] == 1
+    assert metrics["overconservative_rate"] == 1.0
+
+
+def test_summary_reports_weighted_uncertainty_counts():
+    summary = rq.summarize_metrics([
+        {
+            "uncertainty_aligned_count": 0,
+            "uncertainty_items": 2,
+            "determinate_assertion_count": 10,
+            "unsupported_determinate_assertion_count": 2,
+            "negative_assertion_count": 5,
+            "unsupported_negative_assertion_count": 1,
+        },
+        {
+            "uncertainty_aligned_count": 1,
+            "uncertainty_items": 1,
+            "determinate_assertion_count": 5,
+            "unsupported_determinate_assertion_count": 0,
+            "negative_assertion_count": 2,
+            "unsupported_negative_assertion_count": 0,
+        },
+    ])
+
+    assert summary["uncertainty_aligned_count"] == 1
+    assert summary["uncertainty_items"] == 3
+    assert summary["uncertainty_handling_rate"] == 0.3333
+    assert summary["unsupported_determinate_assertion_rate"] == 0.1333
+    assert summary["unsupported_negative_assertion_rate"] == 0.1429
+
+
+def test_summary_uses_global_counts_for_overturn_rate():
+    summary = rq.summarize_metrics([
+        {
+            "adjudicated_count": 100,
+            "candidate_overturn_count": 10,
+        },
+        {
+            "adjudicated_count": 1,
+            "candidate_overturn_count": 1,
+        },
+    ])
+
+    assert summary["candidate_overturn_rate"] == 0.1089
+
+
+def test_load_candidates_uses_full_eval_prompt_and_requires_captured_report(tmp_path):
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps({
+        "model": "sonnet",
+        "cases": [{
+            "case_id": 2,
+            "runs": [{"run_idx": 1, "assembled_text": "Full candidate report"}],
+        }],
+    }))
+
+    candidates = load_candidates(path, {2}, runs_per_case=1, seed=42)
+
+    assert len(candidates) == 1
+    assert candidates[0].candidate_id == "candidate-001"
+    assert candidates[0].report == "Full candidate report"
+    assert "monolithic Java app" in candidates[0].workload
+
+
+def test_load_candidates_rejects_legacy_results_without_report(tmp_path):
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps({
+        "model": "sonnet",
+        "cases": [{"case_id": 2, "runs": [{"run_idx": 1, "assembled_head": "short"}]}],
+    }))
+
+    with pytest.raises(ValueError, match="no captured candidate reports"):
+        load_candidates(path, {2}, runs_per_case=1, seed=42)
+
+
+def test_raw_artifacts_use_explicit_isolated_directory(tmp_path):
+    artifact = rq._write_raw_artifact(
+        "candidate-001",
+        "security",
+        "reviewer-a",
+        "reviewer/model",
+        '{"rows":[]}',
+        tmp_path / "fresh-responses",
+    )
+
+    expected = (
+        tmp_path
+        / "fresh-responses"
+        / "candidate-001"
+        / "security-reviewer-a-reviewer-model.txt"
+    )
+    assert expected.read_text() == '{"rows":[]}'
+    assert artifact == str(expected)
+
+
+def test_structured_ground_truth_consensus_preserves_status_and_severity():
+    canonical = {"SEC01-BP01"}
+    runs = []
+    for model in MODELS:
+        for run_idx in range(1, 4):
+            runs.append({
+                "model": model,
+                "run_idx": run_idx,
+                "valid_bps": ["SEC01-BP01"],
+                "assessments": {
+                    "SEC01-BP01": {
+                        "bp_id": "SEC01-BP01",
+                        "applicability": "applicable",
+                        "expected_status": "Not Implemented",
+                        "expected_severity": "High",
+                        "evidence_basis": "The workload explicitly lacks this control.",
+                        "confidence": "high",
+                    }
+                },
+            })
+
+    ground_truth = compute_ground_truth(runs, canonical)
+
+    reference = ground_truth["reference_ledger"]["SEC01-BP01"]
+    assert ground_truth["consensus_bps"] == ["SEC01-BP01"]
+    assert reference["applicability"] == "applicable"
+    assert reference["expected_status"] == "Not Implemented"
+    assert reference["acceptable_severities"] == ["High"]
+    assert reference["confidence"] == "high"
+
+
+def test_ground_truth_uses_current_307_bp_pillar_corpus():
+    assert len(build_canonical_bps()) == 307
+
+
+def test_quality_orchestration_requires_complete_blind_and_adversarial_passes(
+    tmp_path,
+    monkeypatch,
+):
+    references = tmp_path / "references"
+    references.mkdir()
+    (references / "security.md").write_text("# SEC01-BP01 Example\nReference content.")
+    monkeypatch.setattr(rq, "REFERENCES_DIR", references)
+    monkeypatch.setattr(rq, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(rq, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(rq, "PILLARS", (("security", "Security", "SEC"),))
+    monkeypatch.setattr(rq.boto3, "client", lambda *args, **kwargs: object())
+
+    calls = []
+
+    def fake_invoke(client, model_id, prompt, region, max_tokens):
+        calls.append((model_id, prompt))
+        if "adversarial adjudicator" in prompt:
+            output = json.dumps({"rows": [adversary_row("SEC01-BP01")]})
+        else:
+            output = json.dumps({"rows": [reviewer_row("SEC01-BP01")]})
+        return {
+            "model_id": model_id,
+            "output": output,
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "latency_s": 0.1,
+        }
+
+    monkeypatch.setattr(rq, "_invoke_model", fake_invoke)
+    candidate = Candidate(
+        candidate_id="candidate-001",
+        case_id=1,
+        run_idx=1,
+        workload=WORKLOAD,
+        report="| SEC01-BP01 | Not Implemented | High | Evidence | Recommendation |",
+        source_model="sonnet",
+        source_mode="skill",
+    )
+
+    result = run_quality_review(
+        [candidate],
+        ("openai.gpt-oss-120b", "us.amazon.nova-pro-v1:0"),
+        "us.deepseek.r1-v1:0",
+        "us-east-1",
+        1024,
+        2,
+        42,
+    )
+
+    reviewed = result["candidates"][0]
+    assert reviewed["status"] == "complete"
+    assert reviewed["pillars"]["SEC"]["status"] == "complete"
+    assert reviewed["summary"]["bps_reviewed"] == 1
+    assert reviewed["resource_usage"]["total"]["calls"] == 3
+    assert result["resource_usage"]["calls"] == 3
+    assert len(calls) == 3
+
+    calls.clear()
+    resumed = run_quality_review(
+        [candidate],
+        ("openai.gpt-oss-120b", "us.amazon.nova-pro-v1:0"),
+        "us.deepseek.r1-v1:0",
+        "us-east-1",
+        1024,
+        2,
+        42,
+        chunk_size=1,
+        retries=1,
+        resume=result,
+    )
+
+    assert resumed["candidates"][0]["status"] == "complete"
+    assert resumed["resource_usage"]["calls"] == 3
+    assert calls == []
+
+
+def test_quality_orchestration_never_scores_incomplete_reviewer_output(
+    tmp_path,
+    monkeypatch,
+):
+    references = tmp_path / "references"
+    references.mkdir()
+    (references / "security.md").write_text("# SEC01-BP01 Example\nReference content.")
+    monkeypatch.setattr(rq, "REFERENCES_DIR", references)
+    monkeypatch.setattr(rq, "ARTIFACTS_DIR", tmp_path / "artifacts")
+    monkeypatch.setattr(rq, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(rq, "PILLARS", (("security", "Security", "SEC"),))
+    monkeypatch.setattr(rq.boto3, "client", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        rq,
+        "_invoke_model",
+        lambda client, model_id, prompt, region, max_tokens: {
+            "model_id": model_id,
+            "output": '{"rows":[]}',
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "latency_s": 0.1,
+        },
+    )
+    candidate = Candidate(
+        candidate_id="candidate-001",
+        case_id=1,
+        run_idx=1,
+        workload=WORKLOAD,
+        report="| SEC01-BP01 | Cannot Determine | | Need evidence | Verify |",
+        source_model="sonnet",
+        source_mode="skill",
+    )
+
+    result = run_quality_review(
+        [candidate],
+        ("openai.gpt-oss-120b", "us.amazon.nova-pro-v1:0"),
+        "us.deepseek.r1-v1:0",
+        "us-east-1",
+        1024,
+        2,
+        42,
+    )
+
+    reviewed = result["candidates"][0]
+    assert reviewed["status"] == "incomplete"
+    assert reviewed["pillars"]["SEC"]["status"] == "incomplete_blind_review"
+    assert reviewed["summary"] == {"completed_units": 0}
+    assert result["summary"] == {"completed_units": 0}

--- a/skills/wa-review/SKILL-devops-agent.md
+++ b/skills/wa-review/SKILL-devops-agent.md
@@ -17,7 +17,7 @@ description: |
   remediation. Evidence comes from incident history, observable metrics, application
   logs, and source code — not from user prompts.
 not_for: routine incident triage (use standard investigation flow), learning WA (use wa-builder), migration readiness (use migration-readiness), generating guardrails (use wa-guardrails)
-version: 2.2.0-devops-agent
+version: 2.2.1-devops-agent
 ---
 
 # Well-Architected Review — DevOps Agent Variant
@@ -97,9 +97,11 @@ Derive infrastructure evidence from:
 - **Source code**: connection pool settings, retry configuration, timeout values,
   exception handling patterns are the IaC equivalent for application-layer WA
 
-Mark infrastructure findings as "Based on observable evidence — verify in
-configuration" rather than "Cannot Determine". The absence of IaC is itself
-a finding under OPS 5 (infrastructure as code).
+Use "Based on observable evidence — verify in configuration" only when the
+available metrics, logs, or source code support a determinate status. If the
+relevant evidence is unavailable or inconclusive, use `Cannot Determine` and
+state what signal is needed. The absence of IaC is itself evidence for an OPS 5
+finding, but it is not evidence that unrelated controls are absent.
 
 For each infrastructure component, document:
 - Resource type, logical name, and configuration
@@ -126,13 +128,23 @@ Analyze application code for architectural patterns:
 
 ## Step 4: Evaluate EVERY WA Framework question with code evidence
 
-**CRITICAL — DO NOT PRODUCE A SHORT REVIEW.** The single most common failure mode is citing 20-30 BPs and stopping. The reference corpus contains **307 BPs across 57 questions**; a real full review MUST evaluate ALL 307. Every BP receives a status: Implemented, Partially Implemented, Not Implemented, or Not Applicable (with rationale). If you find yourself with fewer than 200 BP citations, you have not finished the review. Iterate until every BP is addressed.
+**CRITICAL — DO NOT PRODUCE A SHORT REVIEW.** The single most common failure mode is citing 20-30 BPs and stopping. The reference corpus contains **307 BPs across 57 questions**; a real full review MUST evaluate ALL 307. Every BP receives one of five statuses: Implemented, Partially Implemented, Not Implemented, Not Applicable, or Cannot Determine (with rationale). If you find yourself with fewer than 200 BP citations, you have not finished the review. Iterate until every BP is addressed.
 
 Assess the workload against ALL 57 questions in the Well-Architected Framework. For each question, provide:
-- **Status**: "Implemented", "Partially Implemented", "Not Implemented", "Cannot Determine"
+- **Status**: "Implemented", "Partially Implemented", "Not Implemented", "Not Applicable", "Cannot Determine"
 - **Evidence**: specific file paths and line numbers (or metric/log source for non-IaC workloads)
 - **Gaps**: what's missing or could be improved
 - **Risk**: what could go wrong due to the gap
+
+### Evidence sufficiency gate
+
+- **Implemented** — explicit evidence demonstrates the complete BP.
+- **Partially Implemented** — explicit evidence demonstrates part of the BP and a concrete gap.
+- **Not Implemented** — explicit evidence states the control is absent, or an authoritative and sufficiently complete source was examined where the control would have to appear and it is absent.
+- **Not Applicable** — the BP is outside the workload scope; provide a workload-specific rationale.
+- **Cannot Determine** — available incident, runtime, code, or configuration evidence is missing or inconclusive. State the exact signal needed.
+
+Absence of evidence is not evidence of absence. Leave severity blank for `Implemented`, `Not Applicable`, and `Cannot Determine`. A `Cannot Determine` row contains a verification action, not a remediation finding.
 
 The 6 pillars and their questions:
 - **Operational Excellence** (OPS 1–11): Organization, observability, deployment risk, operational readiness, event management, evolution
@@ -189,10 +201,14 @@ Dispatch all 6 Task calls in a single turn (parallel execution). **Each subagent
 
 **Row requirements:**
 - One row per BP evaluated (target 30-55 rows per pillar; MUST cover every BP in the pillar file)
-- Status: exactly one of `Implemented` / `Partially Implemented` / `Not Implemented` / `Not Applicable`
-- Severity: `Critical` / `High` / `Medium` / `Low` (or blank for Implemented/Not Applicable)
-- Evidence: specific file:line references when code was analyzed, or metric/log source for non-IaC workloads
+- Status: exactly one of `Implemented` / `Partially Implemented` / `Not Implemented` / `Not Applicable` / `Cannot Determine`
+- Severity: `Critical` / `High` / `Medium` / `Low` (or blank for Implemented/Not Applicable/Cannot Determine)
+- Evidence: specific file:line references, metric/log sources, explicit incident facts, or `Cannot Determine — need {specific evidence}`
 - BP ID in canonical `PILLAR##-BP##` format only
+
+Append this exact calibration rule to every pillar subagent prompt:
+
+> Apply the evidence sufficiency gate: omitted or inconclusive information is Cannot Determine, not Not Implemented. Use Not Implemented only for an explicitly absent control or absence from an authoritative source where the control must appear. Leave severity blank for Cannot Determine and state the specific evidence needed.
 
 **Dispatch template:**
 
@@ -234,13 +250,13 @@ Once all 6 subagents return, merge their findings into a single structured repor
 3. **Verify count before writing.** Count BP IDs in your assembled draft BEFORE returning. If the count is lower than the sum of subagent citations, you dropped some — go back and add them.
 4. **Cross-pillar patterns and prioritization** are additive analyses that reference the ledger; they do NOT replace it.
 
-**Coverage expectations** — a full review MUST evaluate all **307 BPs**. Every BP receives one of four statuses.
+**Coverage expectations** — a full review MUST evaluate all **307 BPs**. Every BP receives one of five statuses; `Cannot Determine` counts as evaluated coverage.
 
 ### Step 4d — MANDATORY coverage audit (do NOT skip)
 
 Before producing the final report, perform a self-audit:
 
-1. Count unique BP IDs evaluated (all four statuses)
+1. Count unique BP IDs evaluated (all five statuses)
 2. Compare against the target: 307 BPs
 3. If below 307: compare against `references/manifest.md`, add missing entries, repeat
 4. Continue until every BP has an entry
@@ -251,7 +267,7 @@ Before producing the final report, perform a self-audit:
 ## Coverage audit
 - BPs evaluated: {count} / 307
 - Iterations performed: {N}
-- Status distribution: {implemented} Implemented, {partial} Partial, {not_impl} Not Implemented, {na} N/A
+- Status distribution: {implemented} Implemented, {partial} Partial, {not_impl} Not Implemented, {na} N/A, {cannot_determine} Cannot Determine
 ```
 
 ### When a WA Lens applies
@@ -400,9 +416,9 @@ subagent rows. If not, you dropped citations — go back and add them.}
 - A workload with multi-AZ, encryption, CI/CD with rollback, monitoring, and auto-scaling is MATURE — most findings should be improvements, not Critical
 - Do NOT manufacture Critical findings for a well-built workload — accuracy over alarm
 - When business criticality is "critical", apply stricter standards (multi-region DR, chaos testing, sub-minute RTO expected)
-- Every finding MUST have evidence — no generic recommendations without backing
-- If something cannot be determined from available evidence, say "Cannot Determine" and state what data would be needed
-- For on-premises workloads, "Cannot Determine" is rarely appropriate — observable signals (metrics, logs, source code) are always available; use them
+- Every determinate finding MUST have evidence — no generic recommendations without backing
+- If something cannot be determined from available evidence, say "Cannot Determine", leave severity blank, and state what data would be needed
+- For on-premises workloads, exhaust available metrics, logs, configuration, and source code before using `Cannot Determine`; do not treat unavailable evidence as an absent control
 
 <!--
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/skills/wa-review/SKILL.md
+++ b/skills/wa-review/SKILL.md
@@ -2,7 +2,7 @@
 name: wa-review
 description: Perform a full AWS Well-Architected Framework review evaluating all 57 questions across 6 pillars by analyzing code, IaC, and configurations to produce evidence-backed findings with Eisenhower-prioritized remediation.
 not_for: single-pillar deep-dives (use the specific pillar skill), learning WA (use wa-builder), ADRs (use architecture-decision-record), migration (use migration-readiness)
-version: 2.2.0
+version: 2.2.1
 ---
 
 # Well-Architected Review
@@ -19,7 +19,7 @@ Ask the user to describe the workload:
 
 If the user has already provided architecture details or you are in a codebase with IaC, skip the prompt and proceed with discovery.
 
-**IMPORTANT**: When no code or IaC is available to analyze (e.g., the user describes their architecture verbally), proceed with the review based on the information provided. Produce the full report using the architecture description as evidence. Mark findings where you cannot verify implementation details as "Based on description — verify in code." Do NOT ask for code if the user has already given you enough context to perform a meaningful review.
+**IMPORTANT**: When no code or IaC is available to analyze (e.g., the user describes their architecture verbally), proceed with the review based on the information provided. Produce the full report using explicit statements in the architecture description as evidence. Treat omitted details as unknown, not as evidence that a control is absent. Mark unverifiable implementation details `Cannot Determine`, state what evidence would resolve them, and do NOT ask for code if the user has already given you enough context to perform a meaningful review.
 
 Determine if a specialized WA Lens applies:
 - SaaS, Serverless, Data Analytics, Machine Learning, IoT, Containers, Games, Financial Services, Healthcare
@@ -76,13 +76,27 @@ Do NOT proceed past this point until the user explicitly confirms.
 
 ## Step 4: Evaluate EVERY WA Framework question with code evidence
 
-**CRITICAL — DO NOT PRODUCE A SHORT REVIEW.** The single most common failure mode is citing 20-30 BPs and stopping. The reference corpus contains **307 BPs across 57 questions**; a real full review MUST evaluate ALL 307. Every BP receives a status: Implemented, Partially Implemented, Not Implemented, or Not Applicable (with rationale). If you find yourself with fewer than 200 BP citations, you have not finished the review. Iterate until every BP is addressed.
+**CRITICAL — DO NOT PRODUCE A SHORT REVIEW.** The single most common failure mode is citing 20-30 BPs and stopping. The reference corpus contains **307 BPs across 57 questions**; a real full review MUST evaluate ALL 307. Every BP receives one of five statuses: Implemented, Partially Implemented, Not Implemented, Not Applicable, or Cannot Determine (with rationale). If you find yourself with fewer than 200 BP citations, you have not finished the review. Iterate until every BP is addressed.
 
 Assess the workload against ALL 57 questions in the Well-Architected Framework. For each question, provide:
-- **Status**: "Implemented", "Partially Implemented", "Not Implemented", "Cannot Determine"
+- **Status**: "Implemented", "Partially Implemented", "Not Implemented", "Not Applicable", "Cannot Determine"
 - **Evidence**: specific file paths and line numbers
 - **Gaps**: what's missing or could be improved
 - **Risk**: what could go wrong due to the gap
+
+### Evidence sufficiency gate
+
+Assign a status only after applying this gate:
+
+- **Implemented** — explicit evidence demonstrates the complete BP.
+- **Partially Implemented** — explicit evidence demonstrates part of the BP and identifies a concrete gap.
+- **Not Implemented** — explicit evidence states the control is absent, or an authoritative and sufficiently complete source was examined where the control would have to appear and it is absent.
+- **Not Applicable** — the BP is outside the workload scope; provide a workload-specific rationale.
+- **Cannot Determine** — available evidence is missing, inconclusive, runtime-only, or outside the inspected scope. State the exact artifact, metric, configuration, or interview answer needed to decide.
+
+Absence of evidence is not evidence of absence. A verbal description omitting a control, or code/IaC that is not authoritative for that control, MUST result in `Cannot Determine`, not `Not Implemented`. For example, "no backups configured" supports `Not Implemented`; no mention of control objectives or TCO analysis supports only `Cannot Determine`.
+
+Leave severity blank for `Implemented`, `Not Applicable`, and `Cannot Determine`. For `Cannot Determine`, provide a verification action rather than a remediation finding. Do not convert uncertainty into a High or Critical finding.
 
 The 6 pillars and their questions:
 - **Operational Excellence** (OPS 1–11): Organization, observability, deployment risk, operational readiness, event management, evolution
@@ -202,10 +216,14 @@ Dispatch all 6 Task calls in a single turn (parallel execution). **Each subagent
 
 **Row requirements:**
 - One row per BP evaluated (target 30-55 rows per pillar; MUST cover every BP in the pillar file)
-- Status: exactly one of `Implemented` / `Partially Implemented` / `Not Implemented` / `Not Applicable`
-- Severity: `Critical` / `High` / `Medium` / `Low` (or blank for Implemented/Not Applicable)
-- Evidence: specific file:line references when code was analyzed, or "Based on description" when reviewing verbally
+- Status: exactly one of `Implemented` / `Partially Implemented` / `Not Implemented` / `Not Applicable` / `Cannot Determine`
+- Severity: `Critical` / `High` / `Medium` / `Low` (or blank for Implemented/Not Applicable/Cannot Determine)
+- Evidence: specific file:line references when code was analyzed, an explicit quoted fact when reviewing verbally, or `Cannot Determine — need {specific evidence}`
 - BP ID in canonical `PILLAR##-BP##` format only
+
+Append this exact calibration rule to every pillar subagent prompt:
+
+> Apply the evidence sufficiency gate: omitted or inconclusive information is Cannot Determine, not Not Implemented. Use Not Implemented only for an explicitly absent control or absence from an authoritative source where the control must appear. Leave severity blank for Cannot Determine and state the specific evidence needed.
 
 **Dispatch template:**
 
@@ -256,20 +274,21 @@ Once all 6 subagents return, merge their findings into a single structured repor
 For each BP citation, the ledger row shows:
 - **Implemented** — the workload demonstrates this BP (cite the BP + evidence)
 - **Partially Implemented** — some coverage, gaps exist (cite the BP + gap)
-- **Not Implemented** — the workload lacks this BP (cite the BP as missing)
+- **Not Implemented** — explicit or authoritative evidence demonstrates that the workload lacks this BP
 - **Not Applicable** — this BP doesn't apply to the workload's context (explain why briefly)
+- **Cannot Determine** — evidence is insufficient to decide (state the specific evidence needed)
 
-**Coverage expectations** — a full review MUST evaluate all **307 BPs**. Every BP receives one of four statuses. "Not Implemented" for absent controls is a valid, valuable finding — do not skip a BP just because the workload lacks the underlying capability.
+**Coverage expectations** — a full review MUST evaluate all **307 BPs**. Every BP receives one of five statuses. `Cannot Determine` counts as evaluated coverage; exhaustive coverage does not require inventing a determinate status. `Not Implemented` for an evidenced absence is a valid, valuable finding.
 
 ### Step 4d — MANDATORY coverage audit (do NOT skip)
 
 **Before producing the final report**, you MUST perform a self-audit and iterate if coverage is incomplete:
 
-1. **Count**: How many unique BP IDs have you evaluated so far (in canonical `PILLAR##-BP##` format)? Count all four statuses — Implemented, Partially Implemented, Not Implemented, AND Not Applicable.
+1. **Count**: How many unique BP IDs have you evaluated so far (in canonical `PILLAR##-BP##` format)? Count all five statuses — Implemented, Partially Implemented, Not Implemented, Not Applicable, AND Cannot Determine.
 2. **Compare against the target**: A full review evaluates ALL **307 BPs** in the manifest. Anything less is incomplete.
 3. **If your evaluated count is below 307**, you MUST NOT proceed to the final report. Instead, iterate:
    - Compare your evaluated set against the full 307-BP list in `references/manifest.md`
-   - For each un-evaluated BP, load the corresponding pillar file if not already loaded, then add an entry (Implemented / Partially Implemented / Not Implemented / N/A)
+   - For each un-evaluated BP, load the corresponding pillar file if not already loaded, then add an entry (Implemented / Partially Implemented / Not Implemented / N/A / Cannot Determine)
    - Repeat the count check.
 4. **Continue iterating** until every one of the 307 BPs has an entry. If a BP is genuinely N/A (e.g., serverless-specific BP for a container workload), mark it N/A with a one-line rationale — do not silently skip.
 
@@ -281,7 +300,7 @@ For each BP citation, the ledger row shows:
 ## Coverage audit
 - BPs evaluated: {count} / 307
 - Iterations performed: {N}
-- Status distribution: {implemented} Implemented, {partial} Partial, {not_impl} Not Implemented, {na} N/A
+- Status distribution: {implemented} Implemented, {partial} Partial, {not_impl} Not Implemented, {na} N/A, {cannot_determine} Cannot Determine
 ```
 
 If `BPs evaluated` is less than 307, you have not finished the review — go back to Step 4d.
@@ -527,8 +546,8 @@ After delivering the report, offer:
 - Do NOT manufacture Critical findings for a well-built workload — accuracy over alarm
 - When business criticality is "low"/"standard", accept simpler architectures (single-region is fine for internal tools)
 - When business criticality is "critical", apply stricter standards (multi-region DR, chaos testing, sub-minute RTO expected)
-- Every finding MUST have code evidence — no generic recommendations without backing
-- If something cannot be determined from code, say "Cannot Determine" and explain what runtime/interview data is needed
+- Every determinate finding MUST have concrete code, configuration, runtime, or explicit user-provided evidence — no generic recommendations without backing
+- If something cannot be determined from the available evidence, say "Cannot Determine", leave severity blank, and explain what runtime/interview data is needed
 - Acknowledge strengths prominently — a mature workload should feel validated, not just criticized
 
 <!--

--- a/skills/wa-review/evals/evals.json
+++ b/skills/wa-review/evals/evals.json
@@ -11,7 +11,8 @@
         "The output includes a pillar scorecard with numerical scores (1-5) per pillar",
         "Risk assessment uses Impact x Likelihood matrix producing Critical/High/Medium/Low classifications",
         "The output includes an Eisenhower-matrix prioritized remediation plan with four quadrants (Do First, Plan, Delegate, Defer)",
-        "Findings include serverless-specific issues referencing Lambda cold starts, DynamoDB capacity modes, API Gateway throttling, or CloudFront caching"
+        "Findings include serverless-specific issues referencing Lambda cold starts, DynamoDB capacity modes, API Gateway throttling, or CloudFront caching",
+        "Controls omitted from the short architecture description are marked Cannot Determine with no severity and a specific verification action, rather than assumed Not Implemented"
       ],
       "process_assertions": [
         "Response covers all 57 questions (not just 5-10 high-level themes)",
@@ -35,9 +36,9 @@
     {
       "id": 2,
       "prompt": "Review my architecture: we have a monolithic Java app on a single EC2 instance, MySQL on RDS single-AZ, no backups configured, SSH access with shared keys, no monitoring besides CloudWatch basic metrics. It's a customer-facing SaaS product.",
-      "expected_output": "A review with 57-question table showing majority 'Not Implemented', BP-level citations for critical gaps, risk matrix showing multiple Critical/High findings, low pillar scores (1-2), and Eisenhower prioritization recognizing business criticality mismatch.",
+      "expected_output": "A review with a complete 57-question and 307-BP ledger that marks explicitly stated gaps Not Implemented, marks omitted controls Cannot Determine, cites critical gaps, and prioritizes remediation for the customer-facing SaaS workload.",
       "assertions": [
-        "Per-question assessment table covers all 57 questions with majority marked Not Implemented or Partially Implemented",
+        "Per-question assessment covers all 57 questions and distinguishes explicitly absent controls from omitted details; unspecified controls such as control objectives, TCO analysis, and incident-response processes are Cannot Determine with no severity and a specific verification action",
         "BP IDs cited for critical gaps: REL02 (network topology), REL11 (backups), SEC03 (permissions/shared keys), SEC08 (compute protection), OPS06 (observability)",
         "Risk assessment: single EC2 = Critical (Severe x High), no backups = High (Severe x Medium), shared SSH keys = Critical (Severe x High), single-AZ RDS = High (Severe x Medium)",
         "Pillar scorecard shows low scores (1-2) across most pillars",
@@ -56,7 +57,8 @@
         "Does NOT classify majority of findings as Critical — architecture is solid with multi-AZ, WAF, GuardDuty, canary deployments",
         "Prominently acknowledges existing strengths: canary deployments, multi-AZ Aurora, WAF, GuardDuty, X-Ray, automated scaling, Savings Plans",
         "Suggests advanced improvements: chaos engineering, multi-region DR, game days, sustainability, SLA-based alerting",
-        "Includes Eisenhower-matrix or equivalent prioritized remediation plan"
+        "Includes Eisenhower-matrix or equivalent prioritized remediation plan",
+        "Practices not evidenced by the architecture summary are marked Cannot Determine rather than inferred as implemented or absent"
       ]
     },
     {

--- a/skills/wa-review/metadata-devops-agent.json
+++ b/skills/wa-review/metadata-devops-agent.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0-devops-agent",
+  "version": "2.2.1-devops-agent",
   "organization": "AWS",
   "date": "July 2026",
   "abstract": "Well-Architected Framework review optimized for the AWS DevOps Agent context: autonomous execution, post-incident triggering, and evidence derived from incident history, metrics, logs, and source code already accessed during the investigation.",


### PR DESCRIPTION
## Problem

The DevOps-Agent WA review (and the interactive `SKILL.md`) only had four BP statuses — `Implemented`, `Partially Implemented`, `Not Implemented`, `Not Applicable`. When incident/runtime evidence was missing or inconclusive, the reviewer was pushed to record `Not Implemented`, conflating *absence of evidence* with *evidence of absence* and manufacturing false gaps.

## Why it matters

False `Not Implemented` findings inflate risk, waste remediation effort, and erode trust in the review. For on-prem/observable-only workloads (the DevOps-Agent's common case), evidence is frequently partial — the model needs a principled way to say "insufficient evidence" instead of guessing.

## Fix (symptom → root cause → change)

- **Symptom:** inconclusive evidence recorded as `Not Implemented`.
- **Root cause:** no status expressed "evidence insufficient"; the 4-status vocabulary forced a determinate call.
- **Change:** introduce a fifth status **`Cannot Determine`** plus an **evidence-sufficiency gate** in both `skills/wa-review/SKILL.md` and `skills/wa-review/SKILL-devops-agent.md`: `Not Implemented` requires an explicitly absent control (or absence from an authoritative source); missing/inconclusive evidence → `Cannot Determine` with the specific signal needed and blank severity. Coverage audit, status distribution, and dispatch-prompt calibration updated to five statuses. Bumped `metadata-devops-agent.json` / SKILL version to `2.2.1`.
- **Eval harness:** extend `evals/cli_effectiveness/` — richer `generate_ground_truth.py`, `measure_wa_review.py`, per-runtime `measure_*.py` tagging, new `review_quality.py`, and `benchmark.py` updates; add `.gitignore` entries for generated `devops-agent-skills/` output and review artifacts.

This branch was rebased on the latest `main`, so it also carries the merged pillar-playbook loading (#115) in the devops-agent dispatch prompts — the two changes coexist (playbook refs on the prompt lines + the evidence gate around them).

## Tests

`cd evals && uv run pytest tests/ -m "not eval"` → **72 passed**, including new `tests/test_measure_wa_review.py` and `tests/test_review_quality.py`, and the `test_triggering.py` contract suite. The Bedrock-backed `-m eval` scenarios were not run in this pass (network/cost).

## Manual verification

- Confirmed `SKILL-devops-agent.md` retains all 6 pillar-playbook dispatch refs (files resolve) AND the full evidence-sufficiency gate (version 2.2.1, 13 `Cannot Determine` references) after rebase.
- N/A for UI — no user-visible surface changed.
