### PR TITLE
feat(wa-review): structured output + continuous WA CI gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ skills/                             Step-by-step playbooks (tool-agnostic)
 scripts/                            Maintenance tooling
   crawl-wa-framework.py               Crawl AWS docs to regenerate reference files
 
+schemas/                            Structured output contracts
+  wa-review-v1.schema.json            Versioned JSON Schema for wa-review.json
+  README.md                           Contract, versioning policy, guarantees
+
+tools/                              Standalone tooling (stdlib Python, no AWS)
+  wa-ci/                              Gate a PR on the Well-Architected delta
+    wa_ci.py                            Diff a review vs a baseline, classify, gate
+    examples/                           Baseline + review + GitHub Actions workflow
+
 adapters/                           Tool-specific configuration
   claude-code/                        CLAUDE.md + slash commands
   cursor/                             .cursor/rules/*.md
@@ -535,6 +544,34 @@ graph LR
 | Amp | `AGENTS.md` | `.agents/skills/*/SKILL.md` |
 | OpenClaw | `AGENTS.md` | `.agents/skills/*/SKILL.md` |
 | AWS DevOps Agent | N/A (skills are self-contained) | `SKILL.md` zip upload to Agent Space — use `SKILL-devops-agent.md` for `wa-review` (see [AWS DevOps Agent](#aws-devops-agent)) |
+
+---
+
+## 🔁 Continuous Well-Architected (structured output + CI gate)
+
+A review is a snapshot. To keep a workload aligned as it changes, `wa-review` also emits a
+machine-readable `wa-review.json` alongside its markdown report (Step 6b), conforming to the
+versioned contract in [`schemas/wa-review-v1.schema.json`](schemas/wa-review-v1.schema.json).
+The markdown is for people; the JSON is for tools.
+
+[`tools/wa-ci`](tools/wa-ci/) turns that artifact into a merge gate. Commit an accepted review as
+`.well-architected/baseline.json`, then diff each PR's fresh review against it:
+
+```bash
+python3 tools/wa-ci/wa_ci.py \
+  --baseline .well-architected/baseline.json \
+  --current wa-review.json \
+  --fail-on high
+```
+
+Each best practice is paired on its `bp_id` and classified as **Resolved**, **Still-open**,
+**New**, or **Regressed**. Only New and Regressed gaps at or above `--fail-on` fail the build,
+because those are what the change introduced; pre-existing gaps do not block an unrelated PR. The
+gate never reads a missing finding as proof a control exists (coverage is high-recall, not
+exhaustive), and it never mutates code. See [`tools/wa-ci/README.md`](tools/wa-ci/README.md) for
+the classification rules and an example GitHub Actions workflow.
+
+The same contract is the input a portfolio view would aggregate across many workloads.
 
 ---
 

--- a/adapters/claude-code/commands/wa-review.md
+++ b/adapters/claude-code/commands/wa-review.md
@@ -190,6 +190,57 @@ Output a structured report:
 {Top 5 concrete actions the team should take this week}
 ```
 
+## Step 6b: Emit structured output (`wa-review.json`)
+
+After the markdown report, ALSO emit a machine-readable `wa-review.json` so the review can be
+diffed over time (a CI gate), aggregated across workloads, or imported into the WA Tool. Conform
+to the versioned contract in `schemas/wa-review-v1.schema.json` (repo root). Serialize the same
+findings you just reported — do not re-run the analysis.
+
+**Rules:**
+- One `findings` entry per BP you evaluated, including `implemented` and `not_applicable` ones, so
+  a consumer can tell an evaluated-and-passed BP from one never assessed.
+- For a core-framework or ID-bearing lens BP, `bp_id` MUST be canonical `PILLAR##-BP##` (e.g.
+  `SEC03-BP02`, `IOTCOST01-BP01`) — it is the identity key a baseline diff pairs on.
+- Some lenses are topic-organized and expose no BP ID (serverless-applications, saas, government,
+  healthcare-industry, container-build, sap, streaming-media, plus a few mixed cases). For those,
+  OMIT `bp_id` and give a `title` (plus `lens`). They are advisory: reported, never gated. Do not
+  invent an ID to satisfy the diff.
+- Set `review_mode` to the depth you ran (`full`, `quick`, `pillar-scoped`, `score`) and set
+  `skill_version` plus a unique `run_id`.
+- Every gap (`not_implemented` / `partially_implemented`) MUST carry a `severity`; the gate ranks
+  by it, so an unrated gap fails the build closed. Omit severity only for non-gap statuses.
+- `recall_note` MUST state coverage is high-recall but not exhaustive, so a gate never reads a
+  missing finding as proof a control exists.
+- `recommendation` stays prose guidance, never a code diff.
+
+```json
+{
+  "schema_version": "1.0.0",
+  "workload": "{name}",
+  "date": "{YYYY-MM-DD}",
+  "review_mode": "full",
+  "skill_version": "{skill version}",
+  "run_id": "{date}T{time}-{workload-slug}",
+  "pillar_scores": { "security": 2, "reliability": 2 },
+  "findings": [
+    {
+      "bp_id": "SEC08-BP01",
+      "pillar": "security",
+      "status": "not_implemented",
+      "severity": "high",
+      "evidence": { "file": "infra/s3.tf", "line": 14 },
+      "effort": "low",
+      "recommendation": "Enable SSE and BlockPublicAccess on the uploads bucket."
+    }
+  ],
+  "recall_note": "Full review, F1 approx 0.96. High recall but not exhaustive; absence of a finding is not proof of implementation."
+}
+```
+
+Commit this file as `.well-architected/baseline.json` and run `tools/wa-ci` in a pipeline to gate
+future PRs on the Well-Architected delta.
+
 ## Step 7: Offer follow-up
 
 After delivering the report, offer:
@@ -200,6 +251,7 @@ After delivering the report, offer:
 > - Create a migration plan for a specific architectural change?
 > - Compare your workload against a specific WA Lens in detail?
 > - Generate automated checks (Config rules, custom metrics) for ongoing compliance?
+> - Set up a continuous WA gate: commit `wa-review.json` as a baseline and run `tools/wa-ci` in CI?
 > - Produce a WA Tool import for tracking in the AWS console?
 
 ## Calibration Guidance

--- a/powers/wa-review/steering/wa-review.md
+++ b/powers/wa-review/steering/wa-review.md
@@ -2,7 +2,7 @@
 name: wa-review
 description: Perform a full AWS Well-Architected Framework review evaluating all 57 questions across 6 pillars by analyzing code, IaC, and configurations to produce evidence-backed findings with Eisenhower-prioritized remediation.
 not_for: single-pillar deep-dives (use the specific pillar skill), learning WA (use wa-builder), ADRs (use architecture-decision-record), migration (use migration-readiness)
-version: 2.1.0
+version: 2.2.0
 ---
 
 # Well-Architected Review
@@ -508,6 +508,84 @@ For each solution in "Do First" and "Plan":
 {Top 5 concrete actions from the "Do First" quadrant — the team should start this week}
 ```
 
+## Step 6b: Emit structured output (`wa-review.json`)
+
+After the markdown report, ALSO emit a machine-readable `wa-review.json` so the review can be
+diffed over time (CI gate), aggregated across workloads, or imported into the WA Tool. The
+markdown is for humans; this artifact is for tools. Conform to the versioned contract in
+`schemas/wa-review-v1.schema.json` (repo root). Serialize the same findings from the Full BP
+Ledger you just produced — do NOT re-run the analysis.
+
+**Rules:**
+- One `findings` entry per BP you evaluated, including `implemented` and `not_applicable` ones. A
+  consumer must be able to tell an evaluated-and-passed BP from one that was never assessed, so do
+  not drop the passing rows.
+- For a core-framework BP, `bp_id` MUST be canonical `PILLAR##-BP##` — it is the identity key a
+  baseline diff pairs on. Most lens BPs also publish a canonical ID (e.g. `IOTCOST01-BP01`); use it.
+- Some lenses are organized by topic and expose NO BP ID (serverless-applications, saas,
+  government, healthcare-industry, container-build, sap, streaming-media, and a few mixed cases).
+  For a finding from one of those, OMIT `bp_id` and give a `title` (plus `lens`). A title is not a
+  stable key, so these findings are reported as advisory and are never gated. Do not invent a BP
+  ID to satisfy the diff; that produces keys that drift between reviews.
+- Set `review_mode` to the depth you actually ran (`full`, `quick`, `pillar-scoped`, `score`). A
+  non-full run does not cover all 307 BPs; say so in `recall_note`.
+- Set `skill_version` to this steering doc's version, and generate a unique `run_id`
+  (e.g. `{date}T{time}-{workload-slug}`) so two same-day reviews stay distinguishable.
+- Every gap (`not_implemented` / `partially_implemented`) MUST carry a `severity`
+  (`critical`/`high`/`medium`/`low`). The CI gate ranks by severity, so an unrated gap fails the
+  build closed. Leave `severity` off only for `implemented` / `not_applicable` / `cannot_determine`.
+- `recall_note` MUST state that coverage is high-recall but not exhaustive (wa-review measures
+  F1 ~0.96), so downstream gates never read a missing finding as proof a control exists.
+- `recommendation` stays prose guidance — never a code diff (repo design principle).
+
+**Shape** (see the schema for the authoritative, complete definition):
+
+```json
+{
+  "schema_version": "1.0.0",
+  "workload": "{workload name}",
+  "date": "{YYYY-MM-DD}",
+  "review_mode": "full",
+  "skill_version": "2.2.0",
+  "run_id": "{date}T{time}-{workload-slug}",
+  "lens": ["{lens-name}"],
+  "business_criticality": "{critical|high|standard|low}",
+  "pillar_scores": {
+    "operational_excellence": 3, "security": 2, "reliability": 2,
+    "performance_efficiency": 3, "cost_optimization": 4, "sustainability": 3
+  },
+  "findings": [
+    {
+      "bp_id": "SEC08-BP01",
+      "pillar": "security",
+      "status": "not_implemented",
+      "severity": "high",
+      "evidence": { "file": "infra/s3.tf", "line": 14 },
+      "effort": "low",
+      "recommendation": "Enable SSE and BlockPublicAccess on the uploads bucket."
+    },
+    {
+      "title": "Use asynchronous invocation for non-critical Lambda work",
+      "lens": "serverless-applications",
+      "pillar": "performance_efficiency",
+      "status": "not_implemented",
+      "severity": "medium",
+      "recommendation": "Move the notification path to async invocation so the request path is not blocked."
+    }
+  ],
+  "recall_note": "Full review, F1 approx 0.96. High recall but not exhaustive; absence of a finding is not proof of implementation."
+}
+```
+
+The second finding above shows a topic-organized lens finding: no `bp_id`, a `title` instead. It
+is advisory (reported, not gated).
+
+Once written, mention the file and point the user at CI use:
+
+> I have also written `wa-review.json` (machine-readable, conforms to `schemas/wa-review-v1.schema.json`).
+> Commit it as `.well-architected/baseline.json` and wire `tools/wa-ci` into your pipeline to gate
+> future PRs on the Well-Architected delta.
+
 ## Step 7: Offer follow-up
 
 After delivering the report, offer:
@@ -518,6 +596,7 @@ After delivering the report, offer:
 > - Create a migration plan for a specific architectural change?
 > - Compare your workload against a specific WA Lens in detail?
 > - Generate automated checks (Config rules, custom metrics) for ongoing compliance?
+> - Set up a continuous WA gate: commit `wa-review.json` as a baseline and run `tools/wa-ci` in CI?
 > - Produce a WA Tool import for tracking in the AWS console?
 
 ## Calibration Guidance

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,88 @@
+# wa-review structured output schema
+
+`wa-review-v1.schema.json` is the versioned contract for `wa-review.json`, the machine-readable
+artifact the [`wa-review`](../skills/wa-review/SKILL.md) skill emits alongside its markdown report.
+It exists so downstream tools consume a stable shape instead of parsing prose:
+
+- [`tools/wa-ci`](../tools/wa-ci/) diffs a review against a committed baseline and gates a PR.
+- `wa-portfolio` (proposed, [#89](https://github.com/aws-samples/sample-well-architected-skills-and-steering/issues/89)) aggregates many reviews into a fleet view.
+- A future WA Tool import can map findings into the AWS console.
+
+Build the artifact once; several features follow.
+
+## Versioning
+
+The filename carries the major version (`-v1`) and the document repeats it in `schema_version`.
+This is a published contract: external tools depend on it, so treat changes with care.
+
+- **Backward-compatible change** (new optional field, a widened enum): bump the minor/patch in
+  `schema_version`, keep the same file. Consumers keyed on the major version keep working.
+- **Breaking change** (a required field, a removed/narrowed field): add
+  `wa-review-v2.schema.json` and leave v1 in place until consumers migrate.
+
+A consumer should read `schema_version` and reject a document whose major version it does not
+support, rather than assume the shape.
+
+## What the contract guarantees, and what it does not
+
+- **Identity key.** A finding with a canonical `bp_id` (`PILLAR##-BP##`) is identified by it, and
+  a baseline diff pairs on `bp_id`. Producers MUST use canonical IDs for these, never shorthand.
+  This covers every core-framework BP and every lens that publishes BP IDs (most of them, e.g.
+  `IOTCOST01-BP01`).
+- **Advisory findings (no ID).** A handful of lenses are organized by topic and expose no BP IDs
+  (serverless-applications, saas, government, healthcare-industry, container-build, sap,
+  streaming-media; a couple of others mix ID'd and ID-less findings). Their findings carry a
+  `title` instead of a `bp_id`. A `title` is NOT a stable identity key, so a diff does not pair on
+  it: these findings are reported and counted but are **advisory only and never gate a build**.
+  This is deliberate. Gating on an identity that can drift between reviews would make the gate
+  noisy and untrustworthy. Every finding therefore has a `bp_id` OR a `title` (enforced by the
+  schema's `anyOf`).
+- **Coverage is not exhaustiveness.** `wa-review` measures F1 = 0.96, not 1.0. The absence of a
+  finding is NOT proof a control exists. Every document carries a `recall_note` stating this, and
+  `review_mode` tells a consumer how much was evaluated (a `score` or `pillar-scoped` run does not
+  cover all 307 BPs). Gates MUST NOT read "no finding" as "implemented".
+- **Every gap is rated.** A finding with a gap status (`not_implemented` /
+  `partially_implemented`) MUST carry a non-null `severity`; the schema enforces this. A gate
+  ranks by severity, so an unrated gap would fail open. Non-gap statuses (`implemented`,
+  `not_applicable`, `cannot_determine`) may omit it. `tools/wa-ci` also fails closed on an unrated
+  new or regressed gap as defense in depth.
+- **Guidance, not code.** `recommendation` is prose guidance. Consistent with the repo's
+  [design principles](../CONTRIBUTING.md), the artifact never contains a code diff.
+
+## Validating a document
+
+```bash
+# With check-jsonschema (pip install check-jsonschema), or any Draft 2020-12 validator:
+check-jsonschema --schemafile schemas/wa-review-v1.schema.json path/to/wa-review.json
+```
+
+A minimal valid document:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "workload": "payments-api",
+  "date": "2026-08-06",
+  "review_mode": "full",
+  "skill_version": "2.2.0",
+  "run_id": "2026-08-06T14-02-payments-api",
+  "pillar_scores": { "security": 3, "reliability": 2 },
+  "findings": [
+    {
+      "bp_id": "SEC08-BP01",
+      "pillar": "security",
+      "status": "not_implemented",
+      "severity": "high",
+      "evidence": { "file": "infra/s3.tf", "line": 14 },
+      "effort": "low",
+      "recommendation": "Enable SSE and BlockPublicAccess on the uploads bucket."
+    }
+  ],
+  "recall_note": "Full review, F1 approx 0.96. High recall but not exhaustive; absence of a finding is not proof of implementation."
+}
+```
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/schemas/wa-review-v1.schema.json
+++ b/schemas/wa-review-v1.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/aws-samples/sample-well-architected-skills-and-steering/schemas/wa-review-v1.schema.json",
+  "title": "wa-review structured output",
+  "description": "Machine-readable output of the wa-review skill. Emitted as wa-review.json alongside the markdown report so downstream tools (wa-ci baseline diff, wa-portfolio aggregation, WA Tool import) can consume a stable contract instead of parsing prose. Version this file; external tools depend on it.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "workload",
+    "date",
+    "review_mode",
+    "skill_version",
+    "run_id",
+    "pillar_scores",
+    "findings",
+    "recall_note"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Version of this schema the document conforms to. Consumers should reject a document whose major version they do not support."
+    },
+    "workload": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable workload name, stable across reviews so a baseline diff can pair a review with its predecessor."
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "Review date in ISO 8601 (YYYY-MM-DD)."
+    },
+    "review_mode": {
+      "type": "string",
+      "enum": ["full", "quick", "pillar-scoped", "score"],
+      "description": "Which wa-review depth produced this document. Consumers use it to interpret coverage: a pillar-scoped or score run does not evaluate all 307 BPs, so its absence of a finding is not evidence of implementation."
+    },
+    "skill_version": {
+      "type": "string",
+      "description": "SKILL.md frontmatter version that generated this document (e.g. 2.2.0). Lets a consumer detect when the producing skill changed between baseline and current."
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Opaque identifier unique to this review run. Used to distinguish two reviews of the same workload on the same date when diffing against a baseline."
+    },
+    "lens": {
+      "type": "array",
+      "description": "WA lenses applied on top of the core framework (e.g. serverless-applications, financial-services). Empty or omitted for a core-only review.",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "business_criticality": {
+      "type": "string",
+      "enum": ["critical", "high", "standard", "low"],
+      "description": "Declared business criticality of the workload. A gate may weight findings by this (e.g. fail only on new High findings in critical workloads)."
+    },
+    "pillar_scores": {
+      "type": "object",
+      "description": "Maturity score 1-5 per pillar. A pillar-scoped or single-pillar review MAY include only the pillars it evaluated.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "operational_excellence": { "$ref": "#/$defs/pillarScore" },
+        "security": { "$ref": "#/$defs/pillarScore" },
+        "reliability": { "$ref": "#/$defs/pillarScore" },
+        "performance_efficiency": { "$ref": "#/$defs/pillarScore" },
+        "cost_optimization": { "$ref": "#/$defs/pillarScore" },
+        "sustainability": { "$ref": "#/$defs/pillarScore" }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "description": "One entry per best practice evaluated. A full review targets the full 307-BP corpus; other modes carry fewer. Every finding, including Implemented and Not Applicable ones, MAY appear so a consumer can tell an evaluated-and-passed BP from one that was never assessed.",
+      "items": { "$ref": "#/$defs/finding" }
+    },
+    "recall_note": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Honest statement of coverage limits. wa-review measures F1=0.96 (not 1.0), so this output is high-recall but not guaranteed exhaustive. Consumers and gates MUST NOT treat the absence of a finding as proof a control exists. State the measured recall and the review mode's coverage here."
+    }
+  },
+  "$defs": {
+    "pillarScore": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 5,
+      "description": "Maturity 1 (major gaps) to 5 (well-architected)."
+    },
+    "finding": {
+      "type": "object",
+      "required": ["pillar", "status"],
+      "additionalProperties": false,
+      "description": "One evaluated best practice. MUST carry a bp_id OR a title (see anyOf). Core framework BPs and most lens BPs have a canonical bp_id and are the only findings a baseline diff can pair over time. Some lenses (e.g. serverless-applications, saas, government, healthcare-industry, container-build, sap, streaming-media) are organized by topic and expose no BP IDs; their findings carry a title instead and are reported as advisory, never gated.",
+      "anyOf": [
+        { "required": ["bp_id"] },
+        { "required": ["title"] }
+      ],
+      "allOf": [
+        {
+          "$comment": "A gap finding (not_implemented / partially_implemented) MUST carry a non-null severity. A gate ranks by severity, so an unrated gap would silently fail open. Implemented / not_applicable / cannot_determine findings may omit it.",
+          "if": {
+            "properties": {
+              "status": { "enum": ["not_implemented", "partially_implemented"] }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "required": ["severity"],
+            "properties": {
+              "severity": { "enum": ["critical", "high", "medium", "low"] }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "bp_id": {
+          "type": "string",
+          "pattern": "^[A-Z]{2,}[0-9]{1,3}-BP[0-9]{1,3}$",
+          "description": "Canonical best-practice ID in PILLAR##-BP## form (e.g. SEC03-BP02, or a lens-prefixed IOTCOST01-BP01). This is the identity key a baseline diff pairs on. Present for every core-framework BP and every lens BP that publishes an ID. Omit ONLY for findings from a topic-organized lens that exposes no BP ID; those findings MUST carry a title and are advisory (never gated)."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short human-readable name of the best practice or topic. Required when bp_id is absent (a topic-organized lens finding). Optional context otherwise. Not a stable identity key: a diff does NOT pair on title, so a finding with only a title is reported and counted but never gated."
+        },
+        "lens": {
+          "type": "string",
+          "description": "Name of the WA lens this finding comes from (e.g. serverless-applications), matching an entry in the document-level lens array. Omit for a core-framework finding."
+        },
+        "pillar": {
+          "type": "string",
+          "enum": [
+            "operational_excellence",
+            "security",
+            "reliability",
+            "performance_efficiency",
+            "cost_optimization",
+            "sustainability"
+          ],
+          "description": "Owning pillar. For a lens BP, use the pillar the lens BP maps to."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "implemented",
+            "partially_implemented",
+            "not_implemented",
+            "not_applicable",
+            "cannot_determine"
+          ],
+          "description": "Assessment outcome for this BP. cannot_determine means the review could not verify from the available evidence, distinct from a confirmed gap."
+        },
+        "severity": {
+          "type": ["string", "null"],
+          "enum": ["critical", "high", "medium", "low", null],
+          "description": "Risk severity for a gap (Impact x Likelihood). Null or omitted for implemented / not_applicable BPs."
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence",
+          "description": "Where in the workload this was observed. Omit when the review was verbal and no code was analyzed."
+        },
+        "effort": {
+          "type": ["string", "null"],
+          "enum": ["low", "medium", "high", null],
+          "description": "Estimated remediation effort, feeding Eisenhower prioritization downstream."
+        },
+        "recommendation": {
+          "type": "string",
+          "description": "Concise remediation guidance. Never a code diff, consistent with the repo's review-and-guidance-not-code-mutation principle."
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Repo-relative path where the evidence was found."
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed line number in file."
+        },
+        "note": {
+          "type": "string",
+          "description": "Free-text evidence when no precise file:line applies (e.g. 'Based on description, verify in code')."
+        }
+      }
+    }
+  }
+}

--- a/schemas/wa-review-v1.schema.json
+++ b/schemas/wa-review-v1.schema.json
@@ -19,8 +19,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "const": "1.0.0",
-      "description": "Version of this schema the document conforms to. Consumers should reject a document whose major version they do not support."
+      "pattern": "^1\\.[0-9]+\\.[0-9]+$",
+      "description": "Version of this schema the document conforms to. This is the v1 contract, so it accepts any 1.x.y: a backward-compatible minor/patch bump (new optional field, widened enum) still validates. Consumers reject on the MAJOR only; wa-ci compares major versions. A breaking change ships as wa-review-v2.schema.json."
     },
     "workload": {
       "type": "string",

--- a/skills/wa-review/SKILL.md
+++ b/skills/wa-review/SKILL.md
@@ -2,7 +2,7 @@
 name: wa-review
 description: Perform a full AWS Well-Architected Framework review evaluating all 57 questions across 6 pillars by analyzing code, IaC, and configurations to produce evidence-backed findings with Eisenhower-prioritized remediation.
 not_for: single-pillar deep-dives (use the specific pillar skill), learning WA (use wa-builder), ADRs (use architecture-decision-record), migration (use migration-readiness)
-version: 2.2.0
+version: 2.3.0
 ---
 
 # Well-Architected Review
@@ -509,6 +509,87 @@ For each solution in "Do First" and "Plan":
 {Top 5 concrete actions from the "Do First" quadrant — the team should start this week}
 ```
 
+## Step 6b: Emit structured output (`wa-review.json`)
+
+After the markdown report, ALSO emit a machine-readable `wa-review.json` so the review can be
+diffed over time (CI gate), aggregated across workloads, or imported into the WA Tool. The
+markdown is for humans; this artifact is for tools. Conform to the versioned contract in
+[`schemas/wa-review-v1.schema.json`](../../schemas/wa-review-v1.schema.json).
+
+Write it to `wa-review.json` in the workload root (or a path the user names). Populate it from the
+same findings you just reported — do NOT re-run the analysis, just serialize what the Full BP
+Ledger already contains.
+
+**Rules:**
+- One `findings` entry per BP you evaluated, including `implemented` and `not_applicable` ones. A
+  consumer must be able to tell an evaluated-and-passed BP from one that was never assessed, so do
+  not drop the passing rows.
+- For a core-framework BP, `bp_id` MUST be canonical `PILLAR##-BP##` — it is the identity key a
+  baseline diff pairs on. Most lens BPs also publish a canonical ID (e.g. `IOTCOST01-BP01`); use it.
+- Some lenses are organized by topic and expose NO BP ID (serverless-applications, saas,
+  government, healthcare-industry, container-build, sap, streaming-media, and a few mixed cases).
+  For a finding from one of those, OMIT `bp_id` and give a `title` (plus `lens`). A title is not a
+  stable key, so these findings are reported as advisory and are never gated. Do not invent a BP
+  ID to satisfy the diff; that produces keys that drift between reviews.
+- Set `review_mode` to the depth you actually ran (`full`, `quick`, `pillar-scoped`, `score`). A
+  non-full run does not cover all 307 BPs; say so in `recall_note`.
+- Set `skill_version` to this skill's frontmatter `version`, and generate a unique `run_id`
+  (e.g. `{date}T{time}-{workload-slug}`) so two same-day reviews stay distinguishable.
+- Every gap (`not_implemented` / `partially_implemented`) MUST carry a `severity`
+  (`critical`/`high`/`medium`/`low`). The CI gate ranks by severity, so an unrated gap fails the
+  build closed. Leave `severity` off only for `implemented` / `not_applicable` / `cannot_determine`.
+- `recall_note` MUST state that coverage is high-recall but not exhaustive (wa-review measures
+  F1 ~0.96), so downstream gates never read a missing finding as proof a control exists.
+- `recommendation` stays prose guidance — never a code diff (repo design principle).
+
+**Shape** (see the schema for the authoritative, complete definition):
+
+```json
+{
+  "schema_version": "1.0.0",
+  "workload": "{workload name}",
+  "date": "{YYYY-MM-DD}",
+  "review_mode": "full",
+  "skill_version": "2.3.0",
+  "run_id": "{date}T{time}-{workload-slug}",
+  "lens": ["{lens-name}"],
+  "business_criticality": "{critical|high|standard|low}",
+  "pillar_scores": {
+    "operational_excellence": 3, "security": 2, "reliability": 2,
+    "performance_efficiency": 3, "cost_optimization": 4, "sustainability": 3
+  },
+  "findings": [
+    {
+      "bp_id": "SEC08-BP01",
+      "pillar": "security",
+      "status": "not_implemented",
+      "severity": "high",
+      "evidence": { "file": "infra/s3.tf", "line": 14 },
+      "effort": "low",
+      "recommendation": "Enable SSE and BlockPublicAccess on the uploads bucket."
+    },
+    {
+      "title": "Use asynchronous invocation for non-critical Lambda work",
+      "lens": "serverless-applications",
+      "pillar": "performance_efficiency",
+      "status": "not_implemented",
+      "severity": "medium",
+      "recommendation": "Move the notification path to async invocation so the request path is not blocked."
+    }
+  ],
+  "recall_note": "Full review, F1 approx 0.96. High recall but not exhaustive; absence of a finding is not proof of implementation."
+}
+```
+
+The second finding above shows a topic-organized lens finding: no `bp_id`, a `title` instead. It
+is advisory (reported, not gated).
+
+Once written, mention the file and point the user at CI use:
+
+> I have also written `wa-review.json` (machine-readable, conforms to `schemas/wa-review-v1.schema.json`).
+> Commit it as `.well-architected/baseline.json` and wire `tools/wa-ci` into your pipeline to gate
+> future PRs on the Well-Architected delta.
+
 ## Step 7: Offer follow-up
 
 After delivering the report, offer:
@@ -519,6 +600,7 @@ After delivering the report, offer:
 > - Create a migration plan for a specific architectural change?
 > - Compare your workload against a specific WA Lens in detail?
 > - Generate automated checks (Config rules, custom metrics) for ongoing compliance?
+> - Set up a continuous WA gate: commit `wa-review.json` as a baseline and run `tools/wa-ci` in CI?
 > - Produce a WA Tool import for tracking in the AWS console?
 
 ## Calibration Guidance

--- a/tools/wa-ci/README.md
+++ b/tools/wa-ci/README.md
@@ -67,9 +67,12 @@ python3 tools/wa-ci/wa_ci.py --current wa-review.json --update-baseline .well-ar
 
 The report flags conditions that make a delta less trustworthy rather than failing silently:
 
-- the schema major version changed between baseline and current, or
+- the schema major version changed between baseline and current,
 - the current review is narrower than the baseline (e.g. `quick` vs `full`), so some baseline
-  gaps were not re-evaluated. Those are held as Still-open, never silently Resolved.
+  gaps were not re-evaluated. Those are held as Still-open, never silently Resolved, or
+- a baseline gap is now `cannot_determine`. It drops from the delta (neither Still-open nor
+  Resolved, since `cannot_determine` is not a pass), so `Still open` can undercount. This never
+  fails open; the warning names the affected BPs so the drop is visible.
 
 ## Wiring it into CI
 

--- a/tools/wa-ci/README.md
+++ b/tools/wa-ci/README.md
@@ -1,0 +1,120 @@
+# wa-ci: continuous Well-Architected gating
+
+`wa_ci.py` diffs a fresh `wa-review.json` against a committed baseline and gates a pull request
+on the Well-Architected delta. A review is a point-in-time snapshot; this turns it into a
+tripwire, so a change that erodes the workload's posture fails the build instead of landing
+silently.
+
+It consumes the structured output the [`wa-review`](../../skills/wa-review/SKILL.md) skill emits
+(Step 6b), validated by [`schemas/wa-review-v1.schema.json`](../../schemas/wa-review-v1.schema.json).
+
+- **Stdlib only.** No third-party packages, no AWS credentials, no network. Runs on any Python 3.8+.
+- **Reports and gates. Never mutates code**, consistent with the repo's
+  [design principles](../../CONTRIBUTING.md).
+
+## How the delta is classified
+
+Findings pair on `bp_id` (the contract's identity key). Each changed BP is one of:
+
+| Class | Meaning | Gates the build? |
+|-------|---------|------------------|
+| **Resolved** | A baseline gap the current review explicitly marks `implemented` or `not_applicable`. | No |
+| **Still-open** | A gap in the baseline that is still a gap now. | No (pre-existing) |
+| **New** | A gap now that the baseline did not record as a gap (absent, or `cannot_determine`). | Yes, at/above `--fail-on` |
+| **Regressed** | A BP the baseline marked passing that is now a gap. | Yes, at/above `--fail-on` |
+
+Three rules keep the gate honest, all drawn from the schema's coverage guarantees:
+
+- **Absence is never a pass.** A baseline gap that simply drops out of the current review (for
+  example, a narrower `review_mode` did not evaluate it) is NOT counted as Resolved. Resolution
+  requires the BP to be present and explicitly passing.
+- **`cannot_determine` is neither.** It is not a confirmed gap and not proof of a control, so a
+  BP going from `cannot_determine` to a gap is New, not Regressed.
+- **Advisory findings never gate.** A few lenses are topic-organized and expose no BP ID
+  (serverless-applications, saas, government, healthcare-industry, container-build, sap,
+  streaming-media, plus some mixed cases). Their findings carry a `title` instead of a `bp_id`.
+  A title is not a stable identity key, so the diff cannot pair it across reviews. These gaps are
+  counted and printed under an "Advisory" heading so coverage stays visible, but they never fail
+  the build. Gating on a key that can drift between reviews would make the gate noisy.
+
+Only New and Regressed findings can fail the build: they are what *this change* introduced.
+Still-open gaps are pre-existing and must not block an unrelated PR; fix them deliberately, then
+refresh the baseline.
+
+## Usage
+
+```bash
+# Gate a PR: fail on any new or regressed finding at High or above (the default).
+python3 tools/wa-ci/wa_ci.py \
+  --baseline .well-architected/baseline.json \
+  --current wa-review.json \
+  --fail-on high
+
+# Report the full delta without ever failing (useful on a warn-only branch).
+python3 tools/wa-ci/wa_ci.py --baseline baseline.json --current wa-review.json --fail-on none
+
+# Emit the classified delta as JSON (for a bot comment, a dashboard, wa-portfolio).
+python3 tools/wa-ci/wa_ci.py --baseline baseline.json --current wa-review.json --json
+
+# Accept a new review as the baseline (run after a review is reviewed and merged).
+python3 tools/wa-ci/wa_ci.py --current wa-review.json --update-baseline .well-architected/baseline.json
+```
+
+`--fail-on` accepts `low`, `medium`, `high` (default), `critical`, or `none`. The process exits
+`1` when the gate fails and `0` otherwise.
+
+### Coverage warnings
+
+The report flags conditions that make a delta less trustworthy rather than failing silently:
+
+- the schema major version changed between baseline and current, or
+- the current review is narrower than the baseline (e.g. `quick` vs `full`), so some baseline
+  gaps were not re-evaluated. Those are held as Still-open, never silently Resolved.
+
+## Wiring it into CI
+
+See [`examples/github-actions-wa-gate.yml`](examples/github-actions-wa-gate.yml) for a GitHub
+Actions workflow. `wa-review` runs inside an AI coding agent, not a headless runner, so teams
+typically generate `wa-review.json` as part of the change (and commit it or attach it as an
+artifact) rather than invoking the skill in CI. The gate job only diffs two JSON documents.
+
+Recommended flow:
+
+1. Run a full `wa-review`, accept it, and commit the emitted `wa-review.json` as
+   `.well-architected/baseline.json`.
+2. For each PR, produce a fresh `wa-review.json` for the change and run `wa_ci.py` against the
+   baseline.
+3. When you deliberately close gaps, refresh the baseline with `--update-baseline` so Still-open
+   counts shrink over time.
+
+## Running the tests
+
+```bash
+python3 -m unittest tools/wa-ci/test_wa_ci.py
+# or, from this directory:
+cd tools/wa-ci && python3 -m pytest test_wa_ci.py -q
+```
+
+The tests are stdlib `unittest` with no external dependencies, kept separate from the Bedrock
+eval harness in [`evals/`](../../evals/) (which needs Python 3.13 + boto3). They cover every
+delta class, the two absence rules, the severity threshold behavior, coverage warnings, and the
+process exit codes.
+
+## Try it against the examples
+
+[`examples/`](examples/) holds a `baseline.json` and a later `wa-review.json` for the same
+workload. Running the gate against them produces one Resolved, one New (critical), one Regressed
+(high), two Still-open findings, and one Advisory (a serverless-lens finding with no BP ID, shown
+but not gated), and exits `1`:
+
+```bash
+python3 tools/wa-ci/wa_ci.py \
+  --baseline tools/wa-ci/examples/baseline.json \
+  --current tools/wa-ci/examples/wa-review.json \
+  --fail-on high
+```
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/tools/wa-ci/examples/baseline.json
+++ b/tools/wa-ci/examples/baseline.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0.0",
+  "workload": "payments-api",
+  "date": "2026-07-01",
+  "review_mode": "full",
+  "skill_version": "2.2.0",
+  "run_id": "2026-07-01T09-15-payments-api",
+  "business_criticality": "critical",
+  "pillar_scores": {
+    "operational_excellence": 3,
+    "security": 2,
+    "reliability": 3,
+    "performance_efficiency": 3,
+    "cost_optimization": 4,
+    "sustainability": 3
+  },
+  "findings": [
+    {
+      "bp_id": "SEC08-BP01",
+      "pillar": "security",
+      "status": "not_implemented",
+      "severity": "high",
+      "evidence": { "file": "infra/s3.tf", "line": 14 },
+      "effort": "low",
+      "recommendation": "Enable SSE and BlockPublicAccess on the uploads bucket."
+    },
+    {
+      "bp_id": "SEC03-BP02",
+      "pillar": "security",
+      "status": "partially_implemented",
+      "severity": "medium",
+      "evidence": { "file": "infra/iam.tf", "line": 40 },
+      "effort": "medium",
+      "recommendation": "Add permission boundaries to the deploy role."
+    },
+    {
+      "bp_id": "REL09-BP01",
+      "pillar": "reliability",
+      "status": "implemented",
+      "evidence": { "file": "infra/rds.tf", "line": 22 }
+    },
+    {
+      "bp_id": "COST04-BP01",
+      "pillar": "cost_optimization",
+      "status": "not_implemented",
+      "severity": "low",
+      "evidence": { "note": "No log retention policy set; log groups never expire." },
+      "effort": "low",
+      "recommendation": "Set a retention policy on CloudWatch log groups."
+    }
+  ],
+  "recall_note": "Full review, F1 approx 0.96. High recall but not exhaustive; absence of a finding is not proof of implementation."
+}

--- a/tools/wa-ci/examples/github-actions-wa-gate.yml
+++ b/tools/wa-ci/examples/github-actions-wa-gate.yml
@@ -1,0 +1,54 @@
+# Example GitHub Actions workflow: gate a pull request on the Well-Architected delta.
+#
+# Copy this into your workload repo at .github/workflows/wa-gate.yml and adjust
+# the paths. It assumes:
+#   - .well-architected/baseline.json is committed (an accepted wa-review.json).
+#   - A fresh wa-review.json is produced for the PR head and made available to
+#     this job (see the "Produce a fresh review" note below).
+#
+# This job runs no AWS calls and needs no credentials. It only diffs two JSON
+# documents and sets the build status.
+
+name: Well-Architected gate
+
+on:
+  pull_request:
+    # Only gate when architecture-relevant files change. Tune to your repo.
+    paths:
+      - "infra/**"
+      - "**/*.tf"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - ".well-architected/**"
+
+jobs:
+  wa-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Produce a fresh review for the PR head.
+      #
+      # wa-review runs inside an AI coding agent, not a headless CI runner, so
+      # teams typically generate wa-review.json as part of the change and commit
+      # it (or attach it as an artifact) rather than running the skill in CI.
+      # This step assumes the fresh review is already at ./wa-review.json.
+      #
+      # If you do not have one yet, fail early with a clear message:
+      - name: Check for a fresh review
+        run: |
+          if [ ! -f wa-review.json ]; then
+            echo "No wa-review.json found. Run the wa-review skill on this change and commit the result."
+            exit 1
+          fi
+
+      - name: Well-Architected gate
+        run: |
+          python3 tools/wa-ci/wa_ci.py \
+            --baseline .well-architected/baseline.json \
+            --current wa-review.json \
+            --fail-on high

--- a/tools/wa-ci/examples/wa-review.json
+++ b/tools/wa-ci/examples/wa-review.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "1.0.0",
+  "workload": "payments-api",
+  "date": "2026-08-06",
+  "review_mode": "full",
+  "skill_version": "2.2.0",
+  "run_id": "2026-08-06T14-02-payments-api",
+  "business_criticality": "critical",
+  "pillar_scores": {
+    "operational_excellence": 3,
+    "security": 3,
+    "reliability": 2,
+    "performance_efficiency": 3,
+    "cost_optimization": 4,
+    "sustainability": 3
+  },
+  "findings": [
+    {
+      "bp_id": "SEC08-BP01",
+      "pillar": "security",
+      "status": "implemented",
+      "evidence": { "file": "infra/s3.tf", "line": 14 },
+      "recommendation": "SSE-KMS and BlockPublicAccess now enabled on the uploads bucket."
+    },
+    {
+      "bp_id": "SEC03-BP02",
+      "pillar": "security",
+      "status": "partially_implemented",
+      "severity": "medium",
+      "evidence": { "file": "infra/iam.tf", "line": 40 },
+      "effort": "medium",
+      "recommendation": "Permission boundary added to the deploy role; still missing on the CI role."
+    },
+    {
+      "bp_id": "REL09-BP01",
+      "pillar": "reliability",
+      "status": "not_implemented",
+      "severity": "high",
+      "evidence": { "file": "infra/rds.tf", "line": 22 },
+      "effort": "low",
+      "recommendation": "Automated backups were disabled in the last change; re-enable PITR on the primary database."
+    },
+    {
+      "bp_id": "COST04-BP01",
+      "pillar": "cost_optimization",
+      "status": "not_implemented",
+      "severity": "low",
+      "evidence": { "note": "No log retention policy set; log groups never expire." },
+      "effort": "low",
+      "recommendation": "Set a retention policy on CloudWatch log groups."
+    },
+    {
+      "bp_id": "SEC05-BP01",
+      "pillar": "security",
+      "status": "not_implemented",
+      "severity": "critical",
+      "evidence": { "file": "infra/sg.tf", "line": 8 },
+      "effort": "low",
+      "recommendation": "A security group now allows 0.0.0.0/0 on port 22; restrict SSH to the bastion CIDR."
+    },
+    {
+      "title": "Use asynchronous invocation for non-critical Lambda work",
+      "lens": "serverless-applications",
+      "pillar": "performance_efficiency",
+      "status": "not_implemented",
+      "severity": "medium",
+      "recommendation": "Move the order-confirmation email off the request path to an async invocation."
+    }
+  ],
+  "lens": ["serverless-applications"],
+  "recall_note": "Full review, F1 approx 0.96. High recall but not exhaustive; absence of a finding is not proof of implementation."
+}

--- a/tools/wa-ci/test_wa_ci.py
+++ b/tools/wa-ci/test_wa_ci.py
@@ -253,6 +253,17 @@ class TestCoverageWarnings(unittest.TestCase):
         cur = review([], review_mode="full")
         self.assertEqual(wa_ci.coverage_warnings(base, cur), [])
 
+    def test_baseline_gap_now_cannot_determine_warns(self):
+        base = review([finding("SEC08-BP01", "not_implemented", "high")])
+        cur = review([finding("SEC08-BP01", "cannot_determine")])
+        warnings = wa_ci.coverage_warnings(base, cur)
+        self.assertTrue(any("cannot_determine" in w and "SEC08-BP01" in w for w in warnings))
+
+    def test_baseline_gap_still_open_does_not_warn_cannot_determine(self):
+        base = review([finding("SEC08-BP01", "not_implemented", "high")])
+        cur = review([finding("SEC08-BP01", "not_implemented", "high")])
+        self.assertFalse(any("cannot_determine" in w for w in wa_ci.coverage_warnings(base, cur)))
+
 
 class TestMainExitCodes(unittest.TestCase):
     def _write(self, doc):

--- a/tools/wa-ci/test_wa_ci.py
+++ b/tools/wa-ci/test_wa_ci.py
@@ -1,0 +1,301 @@
+"""Tests for wa-ci delta classification and gating.
+
+Stdlib unittest, no network, no AWS, no third-party deps. Run with either:
+    python3 -m unittest tools/wa-ci/test_wa_ci.py
+    cd tools/wa-ci && python3 -m pytest test_wa_ci.py -q
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import wa_ci  # noqa: E402
+
+
+def finding(bp_id, status, severity=None, pillar="security"):
+    row = {"bp_id": bp_id, "pillar": pillar, "status": status}
+    if severity is not None:
+        row["severity"] = severity
+    return row
+
+
+def review(findings, **overrides):
+    doc = {
+        "schema_version": "1.0.0",
+        "workload": "test",
+        "date": "2026-08-06",
+        "review_mode": "full",
+        "skill_version": "2.2.0",
+        "run_id": "test-run",
+        "pillar_scores": {"security": 3},
+        "findings": findings,
+        "recall_note": "test",
+    }
+    doc.update(overrides)
+    return doc
+
+
+def deltas_by_id(changes):
+    return {c["bp_id"]: c["delta"] for c in changes}
+
+
+class TestClassify(unittest.TestCase):
+    def test_resolved_when_gap_becomes_implemented(self):
+        base = review([finding("SEC08-BP01", "not_implemented", "high")])
+        cur = review([finding("SEC08-BP01", "implemented")])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {"SEC08-BP01": wa_ci.RESOLVED})
+
+    def test_resolved_when_gap_becomes_not_applicable(self):
+        base = review([finding("SEC08-BP01", "partially_implemented", "medium")])
+        cur = review([finding("SEC08-BP01", "not_applicable")])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {"SEC08-BP01": wa_ci.RESOLVED})
+
+    def test_still_open_when_gap_persists(self):
+        base = review([finding("SEC08-BP01", "not_implemented", "high")])
+        cur = review([finding("SEC08-BP01", "not_implemented", "high")])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {"SEC08-BP01": wa_ci.STILL_OPEN})
+
+    def test_partial_to_not_implemented_is_still_open(self):
+        # Both are gap statuses, so this stays Still-open (not New/Regressed).
+        base = review([finding("SEC08-BP01", "partially_implemented", "medium")])
+        cur = review([finding("SEC08-BP01", "not_implemented", "high")])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {"SEC08-BP01": wa_ci.STILL_OPEN})
+
+    def test_new_when_bp_absent_from_baseline(self):
+        base = review([])
+        cur = review([finding("SEC05-BP01", "not_implemented", "critical")])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {"SEC05-BP01": wa_ci.NEW})
+
+    def test_regressed_when_passing_becomes_gap(self):
+        base = review([finding("REL09-BP01", "implemented")])
+        cur = review([finding("REL09-BP01", "not_implemented", "high")])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {"REL09-BP01": wa_ci.REGRESSED})
+
+    def test_cannot_determine_baseline_gap_now_is_new_not_regressed(self):
+        # cannot_determine is neither pass nor gap; a gap now is New, not Regressed.
+        base = review([finding("SEC08-BP01", "cannot_determine")])
+        cur = review([finding("SEC08-BP01", "not_implemented", "high")])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {"SEC08-BP01": wa_ci.NEW})
+
+    def test_absent_baseline_gap_not_reported_as_resolved(self):
+        # A baseline gap that simply drops out of the current review is NOT resolved.
+        base = review([finding("SEC08-BP01", "not_implemented", "high")])
+        cur = review([])
+        self.assertEqual(wa_ci.classify(base, cur), [])
+
+    def test_unchanged_passing_bp_produces_no_delta(self):
+        base = review([finding("REL09-BP01", "implemented")])
+        cur = review([finding("REL09-BP01", "implemented")])
+        self.assertEqual(wa_ci.classify(base, cur), [])
+
+    def test_full_example_mix(self):
+        base = review([
+            finding("SEC08-BP01", "not_implemented", "high"),
+            finding("SEC03-BP02", "partially_implemented", "medium"),
+            finding("REL09-BP01", "implemented", pillar="reliability"),
+        ])
+        cur = review([
+            finding("SEC08-BP01", "implemented"),                       # resolved
+            finding("SEC03-BP02", "partially_implemented", "medium"),   # still open
+            finding("REL09-BP01", "not_implemented", "high", "reliability"),  # regressed
+            finding("SEC05-BP01", "not_implemented", "critical"),       # new
+        ])
+        self.assertEqual(deltas_by_id(wa_ci.classify(base, cur)), {
+            "SEC08-BP01": wa_ci.RESOLVED,
+            "SEC03-BP02": wa_ci.STILL_OPEN,
+            "REL09-BP01": wa_ci.REGRESSED,
+            "SEC05-BP01": wa_ci.NEW,
+        })
+
+
+class TestGating(unittest.TestCase):
+    def _changes(self):
+        base = review([finding("REL09-BP01", "implemented", pillar="reliability")])
+        cur = review([
+            finding("REL09-BP01", "not_implemented", "high", "reliability"),  # regressed high
+            finding("SEC05-BP01", "not_implemented", "critical"),             # new critical
+            finding("COST04-BP01", "not_implemented", "low", "cost_optimization"),  # new low
+        ])
+        return wa_ci.classify(base, cur)
+
+    def test_fail_on_high_catches_high_and_critical(self):
+        failures = wa_ci.gating_failures(self._changes(), "high")
+        self.assertEqual(
+            sorted(f["bp_id"] for f in failures),
+            ["REL09-BP01", "SEC05-BP01"],
+        )
+
+    def test_fail_on_low_catches_everything_new_or_regressed(self):
+        failures = wa_ci.gating_failures(self._changes(), "low")
+        self.assertEqual(len(failures), 3)
+
+    def test_fail_on_critical_catches_only_critical(self):
+        failures = wa_ci.gating_failures(self._changes(), "critical")
+        self.assertEqual([f["bp_id"] for f in failures], ["SEC05-BP01"])
+
+    def test_still_open_never_gates(self):
+        # A pre-existing gap that persists must not fail the build.
+        base = review([finding("SEC08-BP01", "not_implemented", "critical")])
+        cur = review([finding("SEC08-BP01", "not_implemented", "critical")])
+        self.assertEqual(wa_ci.gating_failures(wa_ci.classify(base, cur), "low"), [])
+
+    def test_resolved_never_gates(self):
+        base = review([finding("SEC08-BP01", "not_implemented", "critical")])
+        cur = review([finding("SEC08-BP01", "implemented")])
+        self.assertEqual(wa_ci.gating_failures(wa_ci.classify(base, cur), "low"), [])
+
+    def test_new_gap_without_severity_fails_closed(self):
+        # A New gap with no severity must gate at every threshold, not slip through.
+        base = review([])
+        cur = review([finding("SEC05-BP01", "not_implemented", severity=None)])
+        changes = wa_ci.classify(base, cur)
+        for level in ("low", "medium", "high", "critical"):
+            self.assertEqual(
+                [f["bp_id"] for f in wa_ci.gating_failures(changes, level)],
+                ["SEC05-BP01"],
+                f"unrated new gap should gate at --fail-on {level}",
+            )
+
+    def test_regressed_gap_without_severity_fails_closed(self):
+        base = review([finding("REL09-BP01", "implemented", pillar="reliability")])
+        cur = review([finding("REL09-BP01", "not_implemented", severity=None, pillar="reliability")])
+        changes = wa_ci.classify(base, cur)
+        self.assertEqual(
+            [f["bp_id"] for f in wa_ci.gating_failures(changes, "critical")],
+            ["REL09-BP01"],
+        )
+
+    def test_unrated_gap_does_not_affect_still_open(self):
+        # Still-open never gates, even without a severity.
+        base = review([finding("SEC08-BP01", "not_implemented", severity=None)])
+        cur = review([finding("SEC08-BP01", "not_implemented", severity=None)])
+        self.assertEqual(wa_ci.gating_failures(wa_ci.classify(base, cur), "low"), [])
+
+
+def advisory(title, status, severity=None, pillar="performance_efficiency", lens="serverless-applications"):
+    row = {"title": title, "pillar": pillar, "status": status, "lens": lens}
+    if severity is not None:
+        row["severity"] = severity
+    return row
+
+
+class TestAdvisoryFindings(unittest.TestCase):
+    def test_findings_without_bp_id_are_excluded_from_diff(self):
+        # An ID-less gap must never appear as New/Regressed/etc.
+        base = review([])
+        cur = review([advisory("Async Lambda", "not_implemented", "high")])
+        self.assertEqual(wa_ci.classify(base, cur), [])
+
+    def test_findings_without_bp_id_never_gate(self):
+        base = review([])
+        cur = review([advisory("Async Lambda", "not_implemented", "critical")])
+        changes = wa_ci.classify(base, cur)
+        self.assertEqual(wa_ci.gating_failures(changes, "low"), [])
+
+    def test_advisory_gaps_are_collected(self):
+        cur = review([
+            finding("SEC05-BP01", "not_implemented", "critical"),
+            advisory("Async Lambda", "not_implemented", "medium"),
+            advisory("Tenant isolation", "partially_implemented", "high", lens="saas"),
+        ])
+        advisories = wa_ci.advisory_findings(cur)
+        self.assertEqual(len(advisories), 2)
+        self.assertEqual({a["title"] for a in advisories}, {"Async Lambda", "Tenant isolation"})
+
+    def test_passing_advisory_is_not_collected(self):
+        # Only gap-status advisories are worth surfacing.
+        cur = review([advisory("Async Lambda", "implemented")])
+        self.assertEqual(wa_ci.advisory_findings(cur), [])
+
+    def test_advisory_alone_does_not_fail_the_build(self):
+        base = _named(review([]))
+        cur = _named(review([advisory("Async Lambda", "not_implemented", "critical")]))
+        rc = wa_ci.main(["--baseline", base, "--current", cur, "--fail-on", "low"])
+        self.assertEqual(rc, 0)
+
+
+_TMP_PATHS = []
+
+
+def _named(doc):
+    handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8")
+    json.dump(doc, handle)
+    handle.close()
+    _TMP_PATHS.append(handle.name)
+    return handle.name
+
+
+def tearDownModule():
+    for path in _TMP_PATHS:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+class TestCoverageWarnings(unittest.TestCase):
+    def test_schema_major_mismatch_warns(self):
+        base = review([], schema_version="1.0.0")
+        cur = review([], schema_version="2.0.0")
+        self.assertTrue(any("schema major" in w for w in wa_ci.coverage_warnings(base, cur)))
+
+    def test_narrower_current_mode_warns(self):
+        base = review([], review_mode="full")
+        cur = review([], review_mode="quick")
+        self.assertTrue(any("review_mode" in w for w in wa_ci.coverage_warnings(base, cur)))
+
+    def test_matching_full_reviews_no_warning(self):
+        base = review([], review_mode="full")
+        cur = review([], review_mode="full")
+        self.assertEqual(wa_ci.coverage_warnings(base, cur), [])
+
+
+class TestMainExitCodes(unittest.TestCase):
+    def _write(self, doc):
+        handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8")
+        json.dump(doc, handle)
+        handle.close()
+        self.addCleanup(os.unlink, handle.name)
+        return handle.name
+
+    def test_exit_zero_when_no_new_or_regressed(self):
+        base = self._write(review([finding("SEC08-BP01", "not_implemented", "high")]))
+        cur = self._write(review([finding("SEC08-BP01", "implemented")]))
+        rc = wa_ci.main(["--baseline", base, "--current", cur, "--fail-on", "high"])
+        self.assertEqual(rc, 0)
+
+    def test_exit_one_on_new_high_finding(self):
+        base = self._write(review([]))
+        cur = self._write(review([finding("SEC05-BP01", "not_implemented", "high")]))
+        rc = wa_ci.main(["--baseline", base, "--current", cur, "--fail-on", "high"])
+        self.assertEqual(rc, 1)
+
+    def test_fail_on_none_never_gates(self):
+        base = self._write(review([]))
+        cur = self._write(review([finding("SEC05-BP01", "not_implemented", "critical")]))
+        rc = wa_ci.main(["--baseline", base, "--current", cur, "--fail-on", "none"])
+        self.assertEqual(rc, 0)
+
+    def test_update_baseline_writes_file(self):
+        cur = self._write(review([finding("SEC08-BP01", "not_implemented", "high")]))
+        out = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+        out.close()
+        self.addCleanup(os.unlink, out.name)
+        rc = wa_ci.main(["--current", cur, "--update-baseline", out.name])
+        self.assertEqual(rc, 0)
+        with open(out.name, encoding="utf-8") as handle:
+            written = json.load(handle)
+        self.assertEqual(written["findings"][0]["bp_id"], "SEC08-BP01")
+
+    def test_baseline_required_without_update(self):
+        cur = self._write(review([]))
+        with self.assertRaises(SystemExit):
+            wa_ci.main(["--current", cur])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/wa-ci/wa_ci.py
+++ b/tools/wa-ci/wa_ci.py
@@ -265,6 +265,24 @@ def coverage_warnings(baseline_doc, current_doc):
             f"current review_mode is '{current_doc.get('review_mode')}' but baseline was 'full'; "
             "absent baseline gaps are NOT treated as resolved."
         )
+    # A baseline gap that the current review marks cannot_determine drops out of
+    # the delta entirely: it is neither Still-open (current is not a gap) nor
+    # Resolved (cannot_determine is not a pass). This never fails open, but it can
+    # make "Still open" undercount, so name the BPs rather than let them vanish.
+    baseline = index_findings(baseline_doc)
+    current = index_findings(current_doc)
+    undetermined = [
+        bp_id
+        for bp_id, base in baseline.items()
+        if base.get("status") in GAP_STATUSES
+        and current.get(bp_id, {}).get("status") == "cannot_determine"
+    ]
+    if undetermined:
+        warnings.append(
+            f"{len(undetermined)} baseline gap(s) are now 'cannot_determine' "
+            f"({', '.join(sorted(undetermined))}); they drop from the delta "
+            "(not still-open, not resolved), so 'Still open' may undercount."
+        )
     return warnings
 
 

--- a/tools/wa-ci/wa_ci.py
+++ b/tools/wa-ci/wa_ci.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""wa-ci: gate a pull request on the Well-Architected delta.
+
+Diffs a fresh wa-review.json against a committed baseline and classifies each
+best practice as Resolved, Still-open, New, or Regressed. Exits non-zero when
+the delta introduces a gap at or above a severity threshold, so a pipeline can
+block a change that erodes the workload's Well-Architected posture.
+
+Stdlib only. No AWS credentials, no network. Reads the structured output
+contract in schemas/wa-review-v1.schema.json (identity key: bp_id).
+
+Design boundary: this reports and gates. It never mutates a workload's code.
+
+Usage:
+    python3 wa_ci.py --baseline .well-architected/baseline.json \\
+                     --current wa-review.json \\
+                     --fail-on high
+
+    # Refresh the baseline after a review is accepted (no gating):
+    python3 wa_ci.py --current wa-review.json --update-baseline .well-architected/baseline.json
+"""
+
+import argparse
+import json
+import sys
+
+# Severity order, lowest to highest. A finding with no severity (implemented /
+# not_applicable rows carry none) sorts below "low" so it never trips a gate.
+SEVERITY_ORDER = ["low", "medium", "high", "critical"]
+
+# A BP in one of these statuses is an open gap in the workload.
+GAP_STATUSES = {"not_implemented", "partially_implemented"}
+# A BP in one of these statuses is explicitly passing. Note "cannot_determine"
+# is deliberately NEITHER: it is not a confirmed gap and not proof of a control.
+PASS_STATUSES = {"implemented", "not_applicable"}
+
+# Delta classifications.
+RESOLVED = "resolved"        # was a gap in baseline, now explicitly passing
+STILL_OPEN = "still_open"    # gap in baseline and still a gap now
+NEW = "new"                  # a gap now that was not a gap in baseline
+REGRESSED = "regressed"      # was passing in baseline, now a gap
+
+
+def severity_rank(severity):
+    """Rank a severity string. Unknown / null sorts below the lowest real level."""
+    if severity in SEVERITY_ORDER:
+        return SEVERITY_ORDER.index(severity)
+    return -1
+
+
+def load_review(path):
+    """Load and minimally validate a wa-review document."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            doc = json.load(handle)
+    except FileNotFoundError:
+        raise SystemExit(f"wa-ci: file not found: {path}")
+    except json.JSONDecodeError as err:
+        raise SystemExit(f"wa-ci: {path} is not valid JSON: {err}")
+    if not isinstance(doc, dict) or "findings" not in doc:
+        raise SystemExit(f"wa-ci: {path} does not look like a wa-review document (no 'findings').")
+    return doc
+
+
+def index_findings(doc):
+    """Map bp_id -> finding, for findings that carry a canonical bp_id.
+
+    Only bp_id-bearing findings can be paired across reviews, so only these
+    participate in the diff and the gate. Findings without a bp_id (topic-organized
+    lens findings, which carry a title instead) are handled separately by
+    advisory_findings so they are counted and shown, never silently dropped.
+    Last write wins if a document repeats a BP id.
+    """
+    index = {}
+    for finding in doc.get("findings", []):
+        bp_id = finding.get("bp_id")
+        if bp_id:
+            index[bp_id] = finding
+    return index
+
+
+def advisory_findings(doc):
+    """Findings with no bp_id: gaps a title identifies but a diff cannot pair.
+
+    These come from topic-organized lenses (e.g. serverless-applications, saas).
+    They are reported and counted so coverage is visible, but they never gate a
+    build because a title is not a stable identity key across reviews.
+    """
+    advisories = []
+    for finding in doc.get("findings", []):
+        if finding.get("bp_id"):
+            continue
+        if finding.get("status") not in GAP_STATUSES:
+            continue
+        advisories.append({
+            "title": finding.get("title", "(untitled)"),
+            "pillar": finding.get("pillar"),
+            "lens": finding.get("lens"),
+            "status": finding.get("status"),
+            "severity": finding.get("severity"),
+            "recommendation": finding.get("recommendation", ""),
+        })
+    return advisories
+
+
+def schema_major(doc):
+    """Major version of the document's schema_version (e.g. '1' from '1.2.0')."""
+    version = str(doc.get("schema_version", ""))
+    return version.split(".")[0] if version else ""
+
+
+def classify(baseline_doc, current_doc):
+    """Return the list of changed findings, each tagged with a delta class.
+
+    Pairs findings on bp_id. Only findings whose status changed in a way that
+    matters to the gate are returned; unchanged rows are omitted to keep the
+    report focused on the delta.
+
+    Absence is never read as a pass. A BP that drops out of the current review
+    (e.g. a narrower review_mode did not evaluate it) is NOT counted as
+    Resolved, because the contract guarantees coverage is not exhaustiveness.
+    """
+    baseline = index_findings(baseline_doc)
+    current = index_findings(current_doc)
+
+    changes = []
+    for bp_id, cur in current.items():
+        base = baseline.get(bp_id)
+        cur_status = cur.get("status")
+        base_status = base.get("status") if base else None
+
+        cur_is_gap = cur_status in GAP_STATUSES
+        base_was_gap = base_status in GAP_STATUSES
+        base_was_pass = base_status in PASS_STATUSES
+
+        if cur_is_gap and not base_was_gap:
+            # New gap. Regressed if the baseline explicitly passed it; otherwise
+            # New (baseline was absent, or cannot_determine).
+            changes.append(_change(REGRESSED if base_was_pass else NEW, cur, base))
+        elif cur_is_gap and base_was_gap:
+            changes.append(_change(STILL_OPEN, cur, base))
+
+    # Resolved: a baseline gap that the current review explicitly marks passing.
+    # Requires the BP to be present-and-passing in current, not merely absent.
+    for bp_id, base in baseline.items():
+        if base.get("status") not in GAP_STATUSES:
+            continue
+        cur = current.get(bp_id)
+        if cur and cur.get("status") in PASS_STATUSES:
+            changes.append(_change(RESOLVED, cur, base))
+
+    return changes
+
+
+def _change(delta, current_finding, baseline_finding):
+    return {
+        "delta": delta,
+        "bp_id": current_finding.get("bp_id"),
+        "pillar": current_finding.get("pillar"),
+        "status": current_finding.get("status"),
+        "baseline_status": baseline_finding.get("status") if baseline_finding else None,
+        "severity": current_finding.get("severity"),
+        "recommendation": current_finding.get("recommendation", ""),
+    }
+
+
+def gating_failures(changes, fail_on):
+    """Findings that should fail the build: New or Regressed gaps at/above fail_on.
+
+    A New or Regressed gap whose severity is missing or unrecognized ALSO fails,
+    regardless of threshold. The schema requires a severity on every gap finding,
+    so an unrated gap means a malformed review; failing closed keeps the gate from
+    silently passing a regression a producer forgot to rate.
+    """
+    threshold = severity_rank(fail_on)
+    failures = []
+    for c in changes:
+        if c["delta"] not in (NEW, REGRESSED):
+            continue
+        rank = severity_rank(c["severity"])
+        if rank < 0 or rank >= threshold:
+            failures.append(c)
+    return failures
+
+
+def render_report(changes, failures, fail_on, baseline_doc, current_doc, coverage_warnings, advisories):
+    """Human-readable summary for the CI log."""
+    lines = []
+    workload = current_doc.get("workload", "unknown")
+    lines.append(f"Well-Architected delta for: {workload}")
+    lines.append(
+        f"  baseline: {baseline_doc.get('date', '?')} "
+        f"(mode={baseline_doc.get('review_mode', '?')}, run={baseline_doc.get('run_id', '?')})"
+    )
+    lines.append(
+        f"  current:  {current_doc.get('date', '?')} "
+        f"(mode={current_doc.get('review_mode', '?')}, run={current_doc.get('run_id', '?')})"
+    )
+
+    counts = {RESOLVED: 0, STILL_OPEN: 0, NEW: 0, REGRESSED: 0}
+    for change in changes:
+        counts[change["delta"]] += 1
+    lines.append("")
+    lines.append(
+        f"  Resolved: {counts[RESOLVED]}   New: {counts[NEW]}   "
+        f"Regressed: {counts[REGRESSED]}   Still open: {counts[STILL_OPEN]}"
+        f"   Advisory: {len(advisories)}"
+    )
+
+    for warning in coverage_warnings:
+        lines.append(f"  ! {warning}")
+
+    def block(title, delta):
+        rows = [c for c in changes if c["delta"] == delta]
+        if not rows:
+            return
+        lines.append("")
+        lines.append(f"{title} ({len(rows)}):")
+        for change in _sorted_by_severity(rows):
+            sev = change["severity"] or "-"
+            lines.append(f"  [{sev:>8}] {change['bp_id']} ({change['pillar']}): {change['status']}")
+
+    block("Regressed", REGRESSED)
+    block("New gaps", NEW)
+    block("Resolved", RESOLVED)
+    block("Still open", STILL_OPEN)
+
+    if advisories:
+        lines.append("")
+        lines.append(f"Advisory (lens findings without a BP ID, not gated) ({len(advisories)}):")
+        for adv in _sorted_by_severity(advisories):
+            sev = adv["severity"] or "-"
+            lens = f" [{adv['lens']}]" if adv.get("lens") else ""
+            lines.append(f"  [{sev:>8}]{lens} {adv['title']} ({adv['pillar']}): {adv['status']}")
+
+    lines.append("")
+    if failures:
+        lines.append(
+            f"FAIL: {len(failures)} new or regressed finding(s) at or above '{fail_on}'."
+        )
+    else:
+        lines.append(f"PASS: no new or regressed findings at or above '{fail_on}'.")
+    return "\n".join(lines)
+
+
+def _sorted_by_severity(rows):
+    return sorted(rows, key=lambda c: severity_rank(c["severity"]), reverse=True)
+
+
+def coverage_warnings(baseline_doc, current_doc):
+    """Warn about conditions that make the delta less trustworthy."""
+    warnings = []
+    base_major = schema_major(baseline_doc)
+    cur_major = schema_major(current_doc)
+    if base_major and cur_major and base_major != cur_major:
+        warnings.append(
+            f"schema major version changed ({base_major} -> {cur_major}); "
+            "the delta may not be comparable."
+        )
+    # A narrower current review evaluates fewer BPs, so a baseline gap can vanish
+    # from the current findings without being resolved. classify() already refuses
+    # to call that Resolved, but the reader should know coverage shrank.
+    if current_doc.get("review_mode") != "full" and baseline_doc.get("review_mode") == "full":
+        warnings.append(
+            f"current review_mode is '{current_doc.get('review_mode')}' but baseline was 'full'; "
+            "absent baseline gaps are NOT treated as resolved."
+        )
+    return warnings
+
+
+def update_baseline(current_path, baseline_path):
+    """Copy the current review to the baseline path verbatim."""
+    doc = load_review(current_path)
+    with open(baseline_path, "w", encoding="utf-8") as handle:
+        json.dump(doc, handle, indent=2)
+        handle.write("\n")
+    print(f"wa-ci: wrote baseline {baseline_path} from {current_path}")
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="wa-ci",
+        description="Gate a pull request on the Well-Architected delta between a baseline and a fresh review.",
+    )
+    parser.add_argument("--current", required=True, help="Path to the fresh wa-review.json.")
+    parser.add_argument("--baseline", help="Path to the committed baseline wa-review.json.")
+    parser.add_argument(
+        "--fail-on",
+        default="high",
+        choices=SEVERITY_ORDER + ["none"],
+        help="Fail the build on a new or regressed finding at or above this severity "
+             "(default: high). 'none' reports without ever failing.",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        metavar="PATH",
+        help="Write --current to PATH as the new baseline and exit. Does not gate.",
+    )
+    parser.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help="Emit the classified delta as JSON on stdout instead of a text report.",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    if args.update_baseline:
+        update_baseline(args.current, args.update_baseline)
+        return 0
+
+    if not args.baseline:
+        raise SystemExit("wa-ci: --baseline is required unless --update-baseline is given.")
+
+    baseline_doc = load_review(args.baseline)
+    current_doc = load_review(args.current)
+
+    changes = classify(baseline_doc, current_doc)
+    warnings = coverage_warnings(baseline_doc, current_doc)
+    # Gaps from the current review that carry no bp_id: reported, never gated.
+    advisories = advisory_findings(current_doc)
+
+    # A New/Regressed gap without a valid severity is a malformed review (the
+    # schema requires one). Warn so the fail-closed behavior is not mysterious.
+    unrated = [
+        c for c in changes
+        if c["delta"] in (NEW, REGRESSED) and severity_rank(c["severity"]) < 0
+    ]
+    if unrated:
+        ids = ", ".join(c["bp_id"] for c in unrated)
+        warnings.append(
+            f"{len(unrated)} new/regressed finding(s) have no valid severity ({ids}); "
+            "treating as gating. Add a severity in the review."
+        )
+
+    # --fail-on none: report every delta but never gate.
+    failures = [] if args.fail_on == "none" else gating_failures(changes, args.fail_on)
+
+    if args.emit_json:
+        print(json.dumps({
+            "workload": current_doc.get("workload"),
+            "fail_on": args.fail_on,
+            "changes": changes,
+            "advisories": advisories,
+            "failures": [f["bp_id"] for f in failures],
+            "warnings": warnings,
+            "gate": "fail" if failures else "pass",
+        }, indent=2))
+    else:
+        print(render_report(changes, failures, args.fail_on, baseline_doc, current_doc, warnings, advisories))
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What and why

Closes the loop on #90. A wa-review today produces a markdown report a human reads once. This gives the review a machine-readable companion and a way to gate PRs on the Well-Architected delta over time, so a workload that regresses does not merge silently.

Two pieces:

1. **A structured artifact.** wa-review now emits `wa-review.json` alongside its markdown report, governed by a versioned JSON Schema. Downstream tooling consumes a stable shape instead of parsing prose. The same contract is what #89 (wa-portfolio) needs and what a future WA Tool import could map from.
2. **A CI gate.** `tools/wa-ci` diffs a fresh review against a committed baseline, classifies each best practice as Resolved / Still-open / New / Regressed, and fails the build when a new or regressed gap crosses a severity threshold.

Consistent with the repo's design principle (review and guidance, not code mutation): the artifact carries findings and prose recommendations, never a diff, and the tool only reports and gates.

## What is in the change

- **`schemas/wa-review-v1.schema.json`** (Draft 2020-12), versioned by filename and `schema_version`. Findings pair on a canonical `bp_id` (`PILLAR##-BP##`). A handful of lenses are topic-organized and expose no BP ID; those findings carry a `title`, are reported and counted, but are advisory and never gate, because a title is not a stable identity key to diff on. A gap status (`not_implemented` / `partially_implemented`) MUST carry a non-null `severity`, enforced by the schema, so the gate cannot fail open on an unrated gap.
- **`tools/wa-ci`** (stdlib-only, no dependencies). `--fail-on` sets the threshold; `--json` for programmatic use; `--update-baseline` to accept a new review. Three honesty rules are enforced and tested: absence of a finding is never read as a pass, `cannot_determine` is neither a pass nor a gap, and an unrated new/regressed gap fails closed with a warning. Ships examples, a GitHub Actions workflow, a README, and 31 unit tests.
- **Step 6b** added to all three wa-review surfaces (skill, Kiro power, claude-code command) instructing the model to emit the artifact from the findings it already reported. wa-review skill bumped to 2.3.0 and the power copy to 2.2.0 to reflect the addition.
- **README**: a Continuous Well-Architected section and `schemas/` + `tools/` tree entries.

## Testing

- 31 wa-ci unit tests pass (classification, gating, advisory handling, coverage warnings, exit codes, and three regression tests for the fail-closed severity behavior).
- 30 existing eval tests still pass; the eval harness reads markdown, not the JSON, so it is unaffected.
- Schema self-checks against its meta-schema; both example artifacts and every embedded doc template validate.
- Verified the safety property end to end: a high-severity baseline gap that a narrower pillar-scoped review never re-evaluates is not falsely reported as Resolved, and an unrated new gap gates at every threshold.

## Scope notes

- The pre-existing skill/power version drift and the absence of a sync mechanism between the skill and its byte-copy power are tracked separately (#118) and are not addressed here.
- Optional producer-side schema validation of the committed baseline is a reasonable follow-up, kept out of this change to keep the tool dependency-free.

Closes #90