### PR TITLE
chore(security): ignore historical gitleaks false-positive from insecure demo

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,6 @@
 3c3bf78bb52b68415af012f831b93451b403cbac:evals/results/eval_20260531_230845.json:aws-access-token:2168
+# Intentional sample secrets in a deliberately-insecure demo CDK stack, used to
+# exercise the WA security review (note the `// WA-ISSUE:` marker). The example
+# dir was later removed from the tree; this acknowledges the historical finding.
+# Not a live credential — no rotation required.
+a1643dbf81bf033cf60c75a36a6394cd27bae239:examples/insecure-serverless-app-cdk/lib/stack.ts:generic-api-key:110


### PR DESCRIPTION
## Problem

A full-history `gitleaks detect` reports one finding — `generic-api-key` at `examples/insecure-serverless-app-cdk/lib/stack.ts:110` (commit `a1643db`).

## Why it matters

It's noise, but noise that can mask a real leak: anyone running a full-history scan (audit, pre-release check) sees a spurious "leak found" and has to re-triage it every time.

## Fix (symptom → root cause → change)

- **Symptom:** full-history gitleaks reports 1 leak; the current-tree (`--no-git`) scan the CI gate uses is already clean.
- **Root cause:** the finding is an **intentional sample secret** in a deliberately-insecure demo CDK stack (the line sits under a literal `// WA-ISSUE: [Security] Secrets in environment variables` marker, with fake values like `SuperSecret123!`). That `examples/` dir was later removed, so it survives only in history. **Not a live credential** — no rotation needed.
- **Change:** add the finding's fingerprint to `.gitleaksignore` with an explanatory comment, so full-history scans stay clean.

## Tests / verification

`gitleaks detect --redact` over full history reports **no leaks found** after this change (was 1 before). No impact on the CI `secret-scan` job, which scans the working tree (`--no-git`) and was already clean.

Follow-up to #120 (the merge landed before this line was pushed).
