### PR TITLE
docs: fix gemini-cli GEMINI.md links for offline lychee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,7 @@ jobs:
         run: diff -rq skills/wa-review/references powers/wa-review/steering/references
 
   link-check:
-    # Advisory (non-blocking) for now: surfaces broken relative links in the log
-    # but does not gate. Blocked on adapters/gemini-cli/GEMINI.md, which uses
-    # repo-root-absolute links (/skills/.../SKILL.md) that render on GitHub but
-    # aren't resolvable by lychee --offline. Flip fail:true once those are fixed.
+    # Hard gate: gemini-cli GEMINI.md links are relative and resolvable offline.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +49,7 @@ jobs:
             --exclude-path skills/example-skill/references
             --exclude-path powers/wa-review/steering/references
             "./**/*.md"
-          fail: false
+          fail: true
 
   secret-scan:
     # Enforces the intent behind the existing .gitleaksignore. CLI (not the action) avoids the org-license requirement.

--- a/adapters/gemini-cli/GEMINI.md
+++ b/adapters/gemini-cli/GEMINI.md
@@ -51,16 +51,16 @@ When delivering Well-Architected guidance:
 ## Skills
 
 Well-Architected skills are available as reusable playbooks in the `skills/` directory. If the user requests a specific audit or plan (e.g. WA review, security assessment, reliability improvement plan), locate and follow the step-by-step instructions in the corresponding skill directory:
-- [wa-review](file:///skills/wa-review/SKILL.md) (Full Well-Architected review)
-- [security-assessment](file:///skills/security-assessment/SKILL.md) (Security posture assessment)
-- [reliability-improvement-plan](file:///skills/reliability-improvement-plan/SKILL.md) (Reliability remediation plan)
-- [cost-optimization-review](file:///skills/cost-optimization-review/SKILL.md) (Cost optimization audit)
-- [performance-efficiency](file:///skills/performance-efficiency/SKILL.md) (Performance efficiency review)
-- [sustainability-optimization](file:///skills/sustainability-optimization/SKILL.md) (Sustainability optimization review)
-- [migration-readiness](file:///skills/migration-readiness/SKILL.md) (Migration readiness assessment)
-- [architecture-decision-record](file:///skills/architecture-decision-record/SKILL.md) (Architecture decision record template)
-- [wa-builder](file:///skills/wa-builder/SKILL.md) (Understand Well-Architected for your workload and generate visual artifacts: annotated diagrams, decision trees, roadmaps)
-- [wa-guardrails](file:///skills/wa-guardrails/SKILL.md) (Generate preventive guardrails: Config rules, SCPs, CI policy checks, alarms to keep a workload aligned with Well-Architected best practices over time)
+- [wa-review](../../skills/wa-review/SKILL.md) (Full Well-Architected review)
+- [security-assessment](../../skills/security-assessment/SKILL.md) (Security posture assessment)
+- [reliability-improvement-plan](../../skills/reliability-improvement-plan/SKILL.md) (Reliability remediation plan)
+- [cost-optimization-review](../../skills/cost-optimization-review/SKILL.md) (Cost optimization audit)
+- [performance-efficiency](../../skills/performance-efficiency/SKILL.md) (Performance efficiency review)
+- [sustainability-optimization](../../skills/sustainability-optimization/SKILL.md) (Sustainability optimization review)
+- [migration-readiness](../../skills/migration-readiness/SKILL.md) (Migration readiness assessment)
+- [architecture-decision-record](../../skills/architecture-decision-record/SKILL.md) (Architecture decision record template)
+- [wa-builder](../../skills/wa-builder/SKILL.md) (Understand Well-Architected for your workload and generate visual artifacts: annotated diagrams, decision trees, roadmaps)
+- [wa-guardrails](../../skills/wa-guardrails/SKILL.md) (Generate preventive guardrails: Config rules, SCPs, CI policy checks, alarms to keep a workload aligned with Well-Architected best practices over time)
 
 <!--
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
## Summary
`adapters/gemini-cli/GEMINI.md` used `file:///skills/...` links that fail `lychee --offline` (resolved against the filesystem root).

## Changes
- Point skill links at `../../skills/...` relative to the adapter doc

Closes #121