### PR TITLE
feat(kiro-cli): Add vendable well-architected custom agent

### DIFF
--- a/adapters/kiro-cli/README.md
+++ b/adapters/kiro-cli/README.md
@@ -15,7 +15,7 @@ The agent follows the repository design principles (see `AGENTS.md`):
 - Aligned, not compliant. The prompt forbids "compliant" as a customer outcome.
 - Local-only. No MCP servers and no API calls are configured; the agent works entirely from the local steering, skills, and workspace files.
 
-Resources are declared for both project-level (`.kiro/...`) and global (`~/.kiro/...`) install locations; whichever exists is loaded.
+Resources are declared for both project-level (`.kiro/...`) and global (`~/.kiro/...`) install locations. Install to only one scope per machine — installing to both causes each SKILL.md to be loaded twice into the agent's context window.
 
 ## Install
 
@@ -47,3 +47,8 @@ Or switch inside a session with `/agent swap`. Validate after edits with:
 ```bash
 kiro-cli agent validate --path .kiro/agents/well-architected.json
 ```
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/adapters/kiro-cli/README.md
+++ b/adapters/kiro-cli/README.md
@@ -1,0 +1,49 @@
+# Kiro CLI Adapter — Well-Architected Agent
+
+A dedicated Kiro CLI custom agent that scopes a session to Well-Architected work. It complements the Kiro steering and skills (which the installer also copies) by packaging them into a switchable agent with a review-first tool policy.
+
+## What it provides
+
+- `agents/well-architected.json` — a custom agent config installed to `.kiro/agents/` (project) or `~/.kiro/agents/` (global).
+
+## Design
+
+The agent follows the repository design principles (see `AGENTS.md`):
+
+- Review and guidance, not code mutation. Only `fs_read` is pre-approved; every write or command execution requires explicit user approval.
+- Data-driven. The prompt requires each finding to cite the specific resource, file, or configuration that supports it.
+- Aligned, not compliant. The prompt forbids "compliant" as a customer outcome.
+- Local-only. No MCP servers and no API calls are configured; the agent works entirely from the local steering, skills, and workspace files.
+
+Resources are declared for both project-level (`.kiro/...`) and global (`~/.kiro/...`) install locations; whichever exists is loaded.
+
+## Install
+
+Handled by the root installers:
+
+```bash
+./install.sh ~/my-project --tool kiro
+```
+
+```powershell
+.\install.ps1 -TargetDir C:\Projects\my-app -Tool kiro
+```
+
+Or manually:
+
+```bash
+mkdir -p .kiro/agents
+cp adapters/kiro-cli/agents/well-architected.json .kiro/agents/
+```
+
+## Use
+
+```bash
+kiro-cli chat --agent well-architected
+```
+
+Or switch inside a session with `/agent swap`. Validate after edits with:
+
+```bash
+kiro-cli agent validate --path .kiro/agents/well-architected.json
+```

--- a/adapters/kiro-cli/agents/prompt.md
+++ b/adapters/kiro-cli/agents/prompt.md
@@ -1,0 +1,29 @@
+You are an AWS Well-Architected Framework specialist. Follow these principles strictly.
+
+**Review and guidance, not code mutation.** Your output is findings, plans, controls, or visual artifacts — never a diff applied to the user's codebase. Keep the user in control of implementation decisions.
+
+**Data-driven.** Ground every finding in evidence from the user's code, IaC, or configuration. Cite the specific resource, file, or configuration that supports it.
+
+**Aligned, not compliant.** Never describe a workload as "compliant". Use "aligned with best practices" or "adherent to WA guidance".
+
+**Keep it simple.** Prefer the simplest assessment path that satisfies the request.
+
+## Routing
+
+Route each request to the most specific skill:
+
+| User intent | Skill |
+|-------------|-------|
+| Pillar-specific (security, reliability, cost, performance, sustainability, ops) | Pillar-scoped review |
+| Comprehensive / "full review" / "all pillars" | `wa-review` |
+| Diagrams, roadmaps, ADRs, learning WA | `wa-builder` |
+| Preventive controls (Config rules, SCPs, CI checks) | `wa-guardrails` |
+| Customer facilitation / WAFR workshop prep | `wafr-facilitator` |
+| Migration assessment / 7 Rs | `migration-readiness` |
+
+## Output format
+
+- Group findings by pillar.
+- Label every finding with a severity: 🔴 High Risk, 🟡 Medium Risk, 🟢 Improvement.
+- For each finding include **Why it matters** and a **concrete next step**.
+- State trade-offs explicitly (e.g., security controls may add latency; high availability increases cost).

--- a/adapters/kiro-cli/agents/well-architected.json
+++ b/adapters/kiro-cli/agents/well-architected.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
+  "name": "well-architected",
+  "description": "AWS Well-Architected reviewer. Produces evidence-backed findings, plans, guardrails, and visual artifacts across all six pillars using the wa-* skills. Review and guidance only - never applies code changes without approval.",
+  "prompt": "You are an AWS Well-Architected Framework specialist. Follow these principles strictly. Review and guidance, not code mutation: your output is findings, plans, controls, or visual artifacts - never a diff applied to the user's codebase; keep the user in control of implementation decisions. Data-driven: ground every finding in evidence from the user's code, IaC, or configuration, and cite the specific resource, file, or configuration that supports it. Aligned, not compliant: never describe a workload as 'compliant'; use 'aligned with best practices' or 'adherent to WA guidance'. Keep it simple: prefer the simplest assessment path that satisfies the request. Routing: pillar-specific requests get a pillar-scoped review; comprehensive requests use the wa-review skill; artifact requests (diagrams, roadmaps, ADRs) use wa-builder; preventive controls use wa-guardrails; customer facilitation uses wafr-facilitator; migration assessments use migration-readiness. Format: group findings by pillar, label severity as High Risk, Medium Risk, or Improvement, include why it matters and a concrete next step for each finding, and state trade-offs explicitly.",
+  "includeMcpJson": false,
+  "resources": [
+    "file://.kiro/steering/well-architected.md",
+    "file://.kiro/skills/wa-review/SKILL.md",
+    "file://.kiro/skills/wa-builder/SKILL.md",
+    "file://.kiro/skills/wa-guardrails/SKILL.md",
+    "file://.kiro/skills/wafr-facilitator/SKILL.md",
+    "file://.kiro/skills/migration-readiness/SKILL.md",
+    "file://~/.kiro/steering/well-architected.md",
+    "file://~/.kiro/skills/wa-review/SKILL.md",
+    "file://~/.kiro/skills/wa-builder/SKILL.md",
+    "file://~/.kiro/skills/wa-guardrails/SKILL.md",
+    "file://~/.kiro/skills/wafr-facilitator/SKILL.md",
+    "file://~/.kiro/skills/migration-readiness/SKILL.md"
+  ],
+  "tools": [
+    "*"
+  ],
+  "allowedTools": [
+    "fs_read"
+  ]
+}

--- a/adapters/kiro-cli/agents/well-architected.json
+++ b/adapters/kiro-cli/agents/well-architected.json
@@ -2,8 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
   "name": "well-architected",
   "description": "AWS Well-Architected reviewer. Produces evidence-backed findings, plans, guardrails, and visual artifacts across all six pillars using the wa-* skills. Review and guidance only - never applies code changes without approval.",
-  "prompt": "You are an AWS Well-Architected Framework specialist. Follow these principles strictly. Review and guidance, not code mutation: your output is findings, plans, controls, or visual artifacts - never a diff applied to the user's codebase; keep the user in control of implementation decisions. Data-driven: ground every finding in evidence from the user's code, IaC, or configuration, and cite the specific resource, file, or configuration that supports it. Aligned, not compliant: never describe a workload as 'compliant'; use 'aligned with best practices' or 'adherent to WA guidance'. Keep it simple: prefer the simplest assessment path that satisfies the request. Routing: pillar-specific requests get a pillar-scoped review; comprehensive requests use the wa-review skill; artifact requests (diagrams, roadmaps, ADRs) use wa-builder; preventive controls use wa-guardrails; customer facilitation uses wafr-facilitator; migration assessments use migration-readiness. Format: group findings by pillar, label severity as High Risk, Medium Risk, or Improvement, include why it matters and a concrete next step for each finding, and state trade-offs explicitly.",
-  "includeMcpJson": false,
+  "prompt": "file://./prompt.md",
+  "useLegacyMcpJson": false,
   "resources": [
     "file://.kiro/steering/well-architected.md",
     "file://.kiro/skills/wa-review/SKILL.md",

--- a/install.ps1
+++ b/install.ps1
@@ -113,6 +113,7 @@ function Install-Kiro {
         Copy-SkillReferences $skill.FullName "$base\.kiro\skills\$($skill.Name)"
     }
     Copy-OrLink "$ScriptDir\adapters\kiro-cli\agents\well-architected.json" "$base\.kiro\agents\well-architected.json"
+    Copy-OrLink "$ScriptDir\adapters\kiro-cli\agents\prompt.md" "$base\.kiro\agents\prompt.md"
     Write-Host "  Done. Kiro will load steering automatically and skills on demand."
     Write-Host "  Kiro CLI users: run 'kiro-cli chat --agent well-architected' for the dedicated WA agent.`n"
 }

--- a/install.ps1
+++ b/install.ps1
@@ -112,7 +112,9 @@ function Install-Kiro {
         Copy-OrLink "$($skill.FullName)\SKILL.md" "$base\.kiro\skills\$($skill.Name)\SKILL.md"
         Copy-SkillReferences $skill.FullName "$base\.kiro\skills\$($skill.Name)"
     }
-    Write-Host "  Done. Kiro will load steering automatically and skills on demand.`n"
+    Copy-OrLink "$ScriptDir\adapters\kiro-cli\agents\well-architected.json" "$base\.kiro\agents\well-architected.json"
+    Write-Host "  Done. Kiro will load steering automatically and skills on demand."
+    Write-Host "  Kiro CLI users: run 'kiro-cli chat --agent well-architected' for the dedicated WA agent.`n"
 }
 
 function Install-ClaudeCode {

--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,7 @@ install_kiro() {
   done
 
   copy_or_link "$SCRIPT_DIR/adapters/kiro-cli/agents/well-architected.json" "$base/.kiro/agents/well-architected.json"
+  copy_or_link "$SCRIPT_DIR/adapters/kiro-cli/agents/prompt.md" "$base/.kiro/agents/prompt.md"
   echo "  Done. Kiro will load steering automatically and skills on demand."
   echo "  Kiro CLI users: run 'kiro-cli chat --agent well-architected' for the dedicated WA agent."
   echo ""
@@ -521,7 +522,7 @@ uninstall_tool() {
   case "$tool" in
     kiro|kiro-cli)
       rm -f "$base/.kiro/steering/well-architected.md"
-      rm -f "$base/.kiro/agents/well-architected.json"
+      rm -f "$base/.kiro/agents/well-architected.json" "$base/.kiro/agents/prompt.md"
       for skill_dir in "$SCRIPT_DIR/skills"/*/; do
         local skill_name
         skill_name="$(basename "$skill_dir")"

--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,10 @@ install_kiro() {
     copy_or_link "$skill_dir/SKILL.md" "$base/.kiro/skills/$skill_name/SKILL.md"
     copy_skill_references "$skill_dir" "$base/.kiro/skills/$skill_name"
   done
+
+  copy_or_link "$SCRIPT_DIR/adapters/kiro-cli/agents/well-architected.json" "$base/.kiro/agents/well-architected.json"
   echo "  Done. Kiro will load steering automatically and skills on demand."
+  echo "  Kiro CLI users: run 'kiro-cli chat --agent well-architected' for the dedicated WA agent."
   echo ""
 }
 
@@ -518,13 +521,14 @@ uninstall_tool() {
   case "$tool" in
     kiro|kiro-cli)
       rm -f "$base/.kiro/steering/well-architected.md"
+      rm -f "$base/.kiro/agents/well-architected.json"
       for skill_dir in "$SCRIPT_DIR/skills"/*/; do
         local skill_name
         skill_name="$(basename "$skill_dir")"
         [[ "$skill_name" == "_shared" ]] && continue
         rm -rf "$base/.kiro/skills/$skill_name"
       done
-      echo "  Removed: Kiro steering and skills"
+      echo "  Removed: Kiro steering, skills, and agent"
       ;;
     claude-code)
       rm -f "$base/CLAUDE.md"


### PR DESCRIPTION
## Summary

Adds a new `adapters/kiro-cli/` adapter vending a **well-architected custom agent** for Kiro CLI, so users can scope a session to WA work with `kiro-cli chat --agent well-architected` (or `/agent swap`).

### What's included

- `adapters/kiro-cli/agents/well-architected.json` — the agent config. Loads the WA steering and the five wa-* skill playbooks (wa-review, wa-builder, wa-guardrails, wafr-facilitator, migration-readiness) from either project-level (`.kiro/`) or global (`~/.kiro/`) install locations.
- `adapters/kiro-cli/README.md` — adapter documentation (design, install, usage).
- `install.sh` / `install.ps1` — the Kiro install path now copies the agent to `.kiro/agents/`; the bash uninstall path removes it.

### Design (per AGENTS.md principles)

- **Review and guidance, not code mutation** — only `fs_read` is pre-approved; all writes and command executions require explicit user approval.
- **Data-driven** — the prompt requires every finding to cite the specific resource, file, or configuration supporting it.
- **Aligned, not compliant** — the prompt forbids "compliant" as a customer outcome.
- **Local-only** — no MCP servers, no API calls; works entirely from local steering, skills, and workspace files.

### Pillars covered

All six (the agent routes pillar-scoped and comprehensive requests through the existing skills).

### Testing

- `kiro-cli agent validate` passes on the agent config
- Agent discovered and listed by `kiro-cli agent list` after install
- `bash -n install.sh` passes; installer diff limited to the Kiro paths