### PR TITLE
fix(crawler): normalize pillar matching for British spelling and "pillar" suffix (#80)

### DIFF
--- a/scripts/crawl-wa-framework.py
+++ b/scripts/crawl-wa-framework.py
@@ -546,9 +546,27 @@ def discover_leaf_pages(toc_json: dict, pillar_sections: list[str] | None = None
         "Performance efficiency", "Cost optimization", "Sustainability",
     ]
 
+    def _normalize_pillar_text(s: str) -> str:
+        # Make pillar matching locale-agnostic. Some lenses deviate from the
+        # canonical US-English, unsuffixed pillar names the buckets are keyed on:
+        #   - British spelling: Māori lens uses "Cost optimisation" (vs
+        #     "Cost optimization"); without folding "optimis" -> "optimiz" that
+        #     whole pillar's leaves are silently dropped.
+        #   - trailing "pillar" suffix: government lens uses "Operational
+        #     excellence pillar".
+        # Fold case, reconcile the British "-isation" spelling, and drop a
+        # trailing " pillar" so a title matches regardless of these variations.
+        s = s.replace("\xa0", " ").strip().lower()
+        s = s.replace("optimis", "optimiz")
+        if s.endswith(" pillar"):
+            s = s[: -len(" pillar")]
+        return s
+
     def matches_pillar(title):
-        tl = title.lower()
-        return next((p for p in pillar_names if p.lower() in tl), None)
+        tl = _normalize_pillar_text(title)
+        return next(
+            (p for p in pillar_names if _normalize_pillar_text(p) in tl), None
+        )
 
     # A numbered-question branch title, e.g. "1 – Monitor the health..." or
     # "11 – Choose cost-effective compute and storage...". These sit between a

--- a/scripts/test_crawl_wa_framework.py
+++ b/scripts/test_crawl_wa_framework.py
@@ -1,0 +1,109 @@
+"""Regression tests for the topic-page crawler's pillar detection (issue #80).
+
+Stdlib unittest, no network, no AWS, no third-party deps. Uses small inline
+toc-contents.json fixtures that reproduce the structural variations found in
+real lens TOCs. Run with either:
+    python3 -m unittest scripts/test_crawl_wa_framework.py
+    cd scripts && python3 -m pytest test_crawl_wa_framework.py -q
+
+Focus: discover_leaf_pages must bucket leaves under the correct WA pillar even
+when a lens deviates from the canonical US-English, unsuffixed pillar names:
+  - British spelling ("Cost optimisation")  -- Māori lens
+  - trailing "pillar" suffix                -- government lens
+  - a pillar expressed as a single content page (pillar-as-leaf)
+  - generic scaffolding pages (Resources/Definitions/...) stay excluded
+American-spelling lenses must keep behaving exactly as before (no regression).
+"""
+
+import importlib.util
+import os
+import unittest
+
+# The crawler module's filename has hyphens, so import it by path.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "crawl-wa-framework.py")
+_spec = importlib.util.spec_from_file_location("crawl_wa_framework", _SCRIPT)
+cwf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cwf)
+
+
+def leaf(title, href):
+    return {"title": title, "href": href}
+
+
+def branch(title, children, href=""):
+    return {"title": title, "href": href, "contents": children}
+
+
+def sections(pages):
+    """Map section -> sorted list of captured hrefs."""
+    out = {}
+    for p in pages:
+        out.setdefault(p["section"], []).append(p["href"])
+    return {k: sorted(v) for k, v in out.items()}
+
+
+class TestPillarMatching(unittest.TestCase):
+    def test_british_spelling_cost_optimisation_is_captured(self):
+        """Māori lens uses 'Cost optimisation'; its leaf must bucket as
+        'Cost optimization' (issue #80 root cause #2) rather than being dropped."""
+        toc = {"contents": [
+            branch("Cost optimisation", [
+                leaf("MD_CO 1 Understand costs", "md_cos-1.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertIn("Cost optimization", secs)
+        self.assertEqual(secs["Cost optimization"], ["md_cos-1.html"])
+
+    def test_trailing_pillar_suffix_matches(self):
+        """government lens uses 'Operational excellence pillar' (suffix)."""
+        toc = {"contents": [
+            branch("Operational excellence pillar", [
+                leaf("GOVOPS 1 How do you...", "govops-1.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs.get("Operational excellence"), ["govops-1.html"])
+
+    def test_pillar_as_leaf(self):
+        """A pillar expressed as a single content page (no child BPs) is captured
+        under its own name (e.g. Māori 'Performance efficiency')."""
+        toc = {"contents": [
+            leaf("Performance efficiency", "performance-efficiency.html"),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs.get("Performance efficiency"),
+                         ["performance-efficiency.html"])
+
+    def test_generic_and_custom_pages_excluded(self):
+        """Generic scaffolding (Resources/Definitions) and non-pillar custom
+        sections (Te Ao Māori principles) are not captured."""
+        toc = {"contents": [
+            leaf("Definitions", "definitions.html"),
+            leaf("Te Ao Māori principles", "te-ao-maori.html"),
+            branch("Security", [
+                leaf("MD_SEC 1 How is data protected?", "md_sec-1.html"),
+                leaf("Resources", "md_sec-resources.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs, {"Security": ["md_sec-1.html"]})
+        all_hrefs = {h for hs in secs.values() for h in hs}
+        self.assertNotIn("definitions.html", all_hrefs)
+        self.assertNotIn("te-ao-maori.html", all_hrefs)
+        self.assertNotIn("md_sec-resources.html", all_hrefs)
+
+    def test_american_spelling_unchanged(self):
+        """Canonical US-English 'Cost optimization' still matches — the
+        normalization must be additive, never altering existing behavior."""
+        toc = {"contents": [
+            branch("Cost optimization", [
+                leaf("1 – Choose cost-effective resources", "co-1.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs.get("Cost optimization"), ["co-1.html"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #80

## Problem
`discover_leaf_pages` (the topic-page crawl path) buckets each leaf under a Well-Architected pillar by doing a case-insensitive **substring** match against the canonical US-English, unsuffixed pillar names. Lenses whose TOC deviates from those exact names had whole pillars **silently dropped** — the crawl still reported "Done", just with a missing pillar.

The most severe remaining case is the **Māori data lens**: it labels its cost pillar **"Cost optimisation"** (British spelling). `"cost optimisation"` does not contain `"cost optimization"`, so the match failed and the pillar's `MD_CO 1` leaf was never captured.

## Why it matters
Anyone crawling the Māori lens (blocks #76) gets an incomplete reference corpus with **no error** — a silent-failure class of bug. This is the same family as the earlier IoT/government/M&A gaps, and directly blocks the lens-addition backlog.

## Fix (symptom → root cause → change)
- **Symptom:** Māori "Cost optimisation" pillar produces 0 captured leaves.
- **Root cause:** pillar matching compares against fixed US-English names with no spelling/suffix normalization (issue #80 root cause #2).
- **Change:** add a `_normalize_pillar_text` helper inside `discover_leaf_pages` that (1) case-folds, (2) reconciles the British `optimis` → `optimiz` spelling, and (3) strips a trailing `" pillar"` suffix (e.g. government's "Operational excellence pillar") before matching. Both the title and the pillar-name list are normalized, so a British-spelled section still buckets under the canonical `Cost optimization` label.

The change is **purely additive**: for American-spelling titles the normalization is a no-op (no `"optimis"` substring, no `" pillar"` suffix), so existing lenses are unaffected.

The earlier depth-1 / pillar-as-leaf fixes (`92fc44e`, `6fb4873`) already recovered iot, government, and M&A; this closes the last remaining structural gap for #80.

## Tests
Adds `scripts/test_crawl_wa_framework.py` — an **offline** stdlib `unittest` (no network/AWS/deps) with inline TOC fixtures locking in:
- British `"Cost optimisation"` → captured as `Cost optimization` (the fix)
- trailing `" pillar"` suffix matches
- pillar-as-leaf (a pillar that is itself a single content page)
- generic scaffolding (`Resources`/`Definitions`) and non-pillar custom sections stay excluded
- American-spelling `"Cost optimization"` still matches (regression guard)

Run: `python3 -m unittest scripts/test_crawl_wa_framework.py` → 5 passing.

## Manual verification
Ran `discover_leaf_pages` against the **live** lens TOCs before/after:
- **Māori:** 10 → **11** leaves; all 6 pillars now discovered (`Cost optimization` recovered).
- **M&A:** unchanged (27 leaves, already complete).
- **Regression:** government / serverless / analytics / sap / migration discovery is **byte-identical** before vs after — 238 leaves, **0 diff**.

## Scope note
Māori's `Te Ao Māori principles` is a lens-specific preamble section, **not** one of the 6 WA pillars. Bucketing a non-pillar custom section is an output-model decision that belongs with the lens-addition PR (#76), so it is intentionally out of scope here. The maintainer's stated acceptance test — "confirm all pillars are discovered" — is satisfied.

## Screenshots
N/A — crawler/script change, no user-visible UI.
