### PR TITLE
feat(install): add --devops-agent packaging flag for the 100-file limit (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,17 +1065,23 @@ The AWS DevOps Agent operates differently from coding agents — it runs **auton
 
 ```bash
 # Generate a DevOps Agent-compatible zip for wa-review (16 files, <1 MB)
-zip wa-review-devops-agent.zip \
-  skills/wa-review/SKILL-devops-agent.md \
-  skills/wa-review/metadata-devops-agent.json \
-  skills/wa-review/references/manifest.md \
-  skills/wa-review/references/pillars/*.md \
-  skills/wa-review/references/pillar-playbooks/*.md
-# Then upload via the Operator Web App
+./install.sh --devops-agent --skill wa-review
+# -> wa-review-devops-agent.zip in the current directory
+
+# Windows (PowerShell):
+#   .\install.ps1 -DevOpsAgent -Skill wa-review
+
+# Then upload wa-review-devops-agent.zip via the Operator Web App.
 ```
 
+The `--devops-agent` flag packages `SKILL.md`, `metadata.json`, and everything
+under `references/` **except** the lens corpus. When a skill ships DevOps Agent
+variants (`SKILL-devops-agent.md` / `metadata-devops-agent.json`), those are
+packaged under the standard `SKILL.md` / `metadata.json` names. Omit `--skill`
+to package every skill. Run without arguments to package all skills.
+
 > [!NOTE]
-> The zip excludes lens files — the full skill directory exceeds the 100-file upload limit. Full-review subagent dispatch uses only the 6 pillar files; lenses can be added per-deployment if needed.
+> The zip excludes lens files — the full skill directory (970+ files) exceeds the DevOps Agent 100-file-per-zip upload limit. Full-review subagent dispatch uses only the 6 pillar files; lenses can be added per-deployment if needed.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -25,6 +25,15 @@
 .PARAMETER Force
     Overwrite existing files without prompting
 
+.PARAMETER DevOpsAgent
+    Package a skill into a DevOps Agent-compatible zip in the current directory,
+    then exit. Includes SKILL.md, metadata.json, and all references/ EXCEPT the
+    lens corpus, so the result stays under the DevOps Agent 100-file-per-zip
+    upload limit.
+
+.PARAMETER Skill
+    Skill(s) to package with -DevOpsAgent. Defaults to all skills. (e.g. wa-review)
+
 .EXAMPLE
     .\install.ps1 -TargetDir C:\Projects\my-app -Tool claude-code
 
@@ -33,6 +42,9 @@
 
 .EXAMPLE
     .\install.ps1 -Tool all -Force
+
+.EXAMPLE
+    .\install.ps1 -DevOpsAgent -Skill wa-review
 #>
 
 param(
@@ -40,7 +52,9 @@ param(
     [string[]]$Tool = @("all"),
     [switch]$Symlink,
     [switch]$Global,
-    [switch]$Force
+    [switch]$Force,
+    [switch]$DevOpsAgent,
+    [string[]]$Skill = @()
 )
 
 $ErrorActionPreference = "Stop"
@@ -335,7 +349,69 @@ function Get-DetectedTools {
     return $detected
 }
 
+# Package a single skill into a DevOps Agent-compatible zip in the current
+# directory. Includes SKILL.md, metadata.json, and every references/ file EXCEPT
+# the lens corpus (900+ files on its own, which blows past the DevOps Agent
+# 100-file-per-zip upload limit). When the skill ships DevOps Agent variants
+# (SKILL-devops-agent.md / metadata-devops-agent.json) those are packaged, but
+# written under the standard SKILL.md / metadata.json names the Agent expects.
+function Export-DevOpsAgentPackage {
+    param([string]$SkillName)
+
+    $skillDir = "$ScriptDir\skills\$SkillName"
+    if (-not (Test-Path -LiteralPath $skillDir -PathType Container)) {
+        Write-Host "  ERROR: skill not found: $SkillName (looked in $ScriptDir\skills\)"
+        return
+    }
+
+    $stage = Join-Path ([System.IO.Path]::GetTempPath()) ("wa-devops-agent-" + [System.Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path "$stage\references" -Force | Out-Null
+
+    if (Test-Path "$skillDir\SKILL-devops-agent.md") { Copy-Item "$skillDir\SKILL-devops-agent.md" "$stage\SKILL.md" }
+    elseif (Test-Path "$skillDir\SKILL.md") { Copy-Item "$skillDir\SKILL.md" "$stage\SKILL.md" }
+
+    if (Test-Path "$skillDir\metadata-devops-agent.json") { Copy-Item "$skillDir\metadata-devops-agent.json" "$stage\metadata.json" }
+    elseif (Test-Path "$skillDir\metadata.json") { Copy-Item "$skillDir\metadata.json" "$stage\metadata.json" }
+
+    # All references except the lens corpus, preserving directory structure.
+    $refRoot = "$skillDir\references"
+    if (Test-Path $refRoot) {
+        $lensRoot = Join-Path $refRoot "lenses"
+        foreach ($ref in Get-ChildItem $refRoot -Recurse -File) {
+            if ($ref.FullName.StartsWith($lensRoot, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+            $rel = $ref.FullName.Substring($refRoot.Length).TrimStart('\')
+            $dest = "$stage\references\$rel"
+            $destDir = Split-Path -Parent $dest
+            if (-not (Test-Path $destDir)) { New-Item -ItemType Directory -Path $destDir -Force | Out-Null }
+            Copy-Item $ref.FullName $dest
+        }
+    }
+
+    $count = @(Get-ChildItem $stage -Recurse -File).Count
+    $zipPath = Join-Path (Get-Location).Path "$SkillName-devops-agent.zip"
+    if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+    Compress-Archive -Path "$stage\*" -DestinationPath $zipPath -Force
+    Remove-Item $stage -Recurse -Force -ErrorAction SilentlyContinue
+
+    Write-Host "  Packaged: $zipPath ($count files)"
+    if ($count -gt 100) {
+        Write-Host "  WARNING: $count files exceeds the DevOps Agent 100-file upload limit."
+    }
+}
+
 # Main
+if ($DevOpsAgent) {
+    Write-Host "Packaging DevOps Agent-compatible skill zip(s)..."
+    $skillsToPackage = $Skill
+    if (-not $skillsToPackage -or $skillsToPackage.Count -eq 0) {
+        $skillsToPackage = @(Get-Skills | ForEach-Object { $_.Name })
+    }
+    foreach ($s in $skillsToPackage) { Export-DevOpsAgentPackage $s }
+    Write-Host ""
+    Write-Host "Done. Upload the .zip via the DevOps Agent Operator Web App."
+    exit 0
+}
+
 Write-Host "================================================"
 Write-Host " Well-Architected Skills & Steering Installer"
 Write-Host "================================================"

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,12 @@ Options:
                 Valid: kiro, kiro-cli, claude-code, cursor, codex, windsurf, github-copilot, cline, gemini-cli, antigravity, junie, amp, openclaw, cortex-code, devops-agent, auto, all
   --uninstall   Remove previously installed WA files from the target directory
   --check-update  Check if a newer version is available on GitHub
+  --devops-agent  Package a skill into a DevOps Agent-compatible zip in the
+                  current directory, then exit. Includes SKILL.md, metadata.json,
+                  and all references/ EXCEPT the lens corpus, so the result stays
+                  under the DevOps Agent 100-file-per-zip upload limit.
+  --skill SKILL   Skill to package with --devops-agent. Can be repeated.
+                  Defaults to all skills. (e.g. wa-review)
   --symlink     Use symlinks instead of copies (auto-updates when this repo changes)
   --global      Install to global config (~/.kiro, ~/.claude, etc.) instead of project
   --force       Overwrite existing files without prompting
@@ -36,6 +42,7 @@ Examples:
   ./install.sh ~/my-project --tool all --force
   ./install.sh ~/my-project --uninstall --tool claude-code
   ./install.sh --check-update
+  ./install.sh --devops-agent --skill wa-review
 EOF
   exit 0
 }
@@ -46,6 +53,8 @@ GLOBAL=false
 FORCE=false
 UNINSTALL=false
 CHECK_UPDATE=false
+DEVOPS_AGENT_PACKAGE=false
+SKILLS=()
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -72,6 +81,14 @@ while [[ $# -gt 0 ]]; do
     --check-update)
       CHECK_UPDATE=true
       shift
+      ;;
+    --devops-agent)
+      DEVOPS_AGENT_PACKAGE=true
+      shift
+      ;;
+    --skill)
+      SKILLS+=("$2")
+      shift 2
       ;;
     --help|-h)
       usage
@@ -673,6 +690,77 @@ check_update() {
 
 if [[ "$CHECK_UPDATE" == true ]]; then
   check_update
+  exit 0
+fi
+
+# Package a single skill into a DevOps Agent-compatible zip in the current
+# directory. Includes SKILL.md, metadata.json, and every references/ file EXCEPT
+# the lens corpus (900+ files on its own, which blows past the DevOps Agent
+# 100-file-per-zip upload limit). When the skill ships DevOps Agent variants
+# (SKILL-devops-agent.md / metadata-devops-agent.json) those are packaged, but
+# written under the standard SKILL.md / metadata.json names the Agent expects.
+package_devops_agent() {
+  local skill_name="$1"
+  local skill_dir="$SCRIPT_DIR/skills/$skill_name"
+
+  if [[ ! -d "$skill_dir" ]]; then
+    echo "  ERROR: skill not found: $skill_name (looked in $SCRIPT_DIR/skills/)" >&2
+    return 1
+  fi
+
+  local stage
+  stage="$(mktemp -d)"
+  mkdir -p "$stage/references"
+
+  if [[ -f "$skill_dir/SKILL-devops-agent.md" ]]; then
+    cp "$skill_dir/SKILL-devops-agent.md" "$stage/SKILL.md"
+  elif [[ -f "$skill_dir/SKILL.md" ]]; then
+    cp "$skill_dir/SKILL.md" "$stage/SKILL.md"
+  fi
+
+  if [[ -f "$skill_dir/metadata-devops-agent.json" ]]; then
+    cp "$skill_dir/metadata-devops-agent.json" "$stage/metadata.json"
+  elif [[ -f "$skill_dir/metadata.json" ]]; then
+    cp "$skill_dir/metadata.json" "$stage/metadata.json"
+  fi
+
+  # All references except the lens corpus, preserving directory structure.
+  if [[ -d "$skill_dir/references" ]]; then
+    while IFS= read -r -d '' ref; do
+      local rel="${ref#"$skill_dir"/references/}"
+      mkdir -p "$(dirname -- "$stage/references/$rel")"
+      cp "$ref" "$stage/references/$rel"
+    done < <(find "$skill_dir/references" -type f -not -path "$skill_dir/references/lenses/*" -print0)
+  fi
+
+  local count
+  count="$(find "$stage" -type f | wc -l | tr -d ' ')"
+
+  local zip_path="$PWD/$skill_name-devops-agent.zip"
+  rm -f "$zip_path"
+  ( cd "$stage" && zip -qr "$zip_path" . >/dev/null )
+  rm -rf "$stage"
+
+  echo "  Packaged: $zip_path ($count files)"
+  if [[ "$count" -gt 100 ]]; then
+    echo "  WARNING: $count files exceeds the DevOps Agent 100-file upload limit." >&2
+  fi
+}
+
+if [[ "$DEVOPS_AGENT_PACKAGE" == true ]]; then
+  echo "Packaging DevOps Agent-compatible skill zip(s)..."
+  if [[ ${#SKILLS[@]} -eq 0 ]]; then
+    for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+      skill_name="$(basename "$skill_dir")"
+      [[ "$skill_name" == "_shared" ]] && continue
+      SKILLS+=("$skill_name")
+    done
+  fi
+  for skill in "${SKILLS[@]}"; do
+    package_devops_agent "$skill"
+  done
+  echo ""
+  echo "Done. Upload the .zip via the DevOps Agent Operator Web App."
   exit 0
 fi
 


### PR DESCRIPTION
Fixes #102

> Independent of #126 — rebased onto `main`; this PR contains only the `--devops-agent` change.

## Problem
AWS DevOps Agent skill uploads enforce a **100-file-per-zip maximum**. The full `wa-review` skill directory is 970+ files (the lens corpus alone is 922), so a naïve zip fails validation:

> Zip validation failed: Zip contains 970 files, exceeds maximum of 100

The only prior workaround was a hand-written multi-line `zip` command in the README — easy to get wrong and drift out of sync.

## Why it matters
Without a supported packaging path, anyone deploying `wa-review` to a DevOps Agent Space has to reconstruct the exact file allowlist by hand; a mistake either breaks the upload (too many files) or ships a skill that can't do full-review dispatch (missing pillars).

## Fix (symptom → root cause → change)
- **Symptom:** the skill dir can't be uploaded as-is; no installer support for a compliant zip.
- **Root cause:** the lens corpus (`references/lenses/`, 922 files) dwarfs the runtime-critical files, and the installers had no packaging mode.
- **Change:** add a `--devops-agent` flag (`install.sh`) and `-DevOpsAgent` switch (`install.ps1`) that stage and zip a skill into `<skill>-devops-agent.zip` in the current directory. The allowlist rule is **"`SKILL.md` + `metadata.json` + everything under `references/` EXCEPT `references/lenses/`"** — which for `wa-review` is exactly the 16 files the issue specifies (manifest, wa-questions, 6 pillars, 6 pillar-playbooks). When a skill ships DevOps Agent variants (`SKILL-devops-agent.md` / `metadata-devops-agent.json`), those are packaged under the standard `SKILL.md` / `metadata.json` names the Agent Space expects. `--skill`/`-Skill` selects the skill (repeatable); omit it to package every skill.

The README's manual `zip` recipe is replaced with the flag (bash + PowerShell), keeping the 100-file rationale.

## Tests
No PS/bash test harness exists in-repo (CI runs `pytest` under `evals/`), so validated by execution:
- **bash** `--devops-agent --skill wa-review` → **exactly 16 files**; `SKILL.md`/`metadata.json` confirmed byte-identical to the `-devops-agent` variants (`cmp`).
- **PowerShell 7.4.6** `-DevOpsAgent -Skill wa-review` → parses clean; **exactly 16 files**; same manifest; variant used.
- **No `--skill`** (both): packages all 6 skills, each into its own zip (wa-review=16, others 2–3 files) — all under 100.
- **Unknown skill:** clean `ERROR: skill not found` on both.

## Manual verification
The generated zips were extracted and their manifests compared to the issue's 16-file spec (match). Actual upload to a live DevOps Agent Space is out of scope for this environment and should be smoke-tested by a maintainer with Agent Space access.

## Screenshots
N/A — installer/packaging change, no UI.
