### PR TITLE
fix(gemini-cli): repo-relative skill links so link-check can gate (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
         run: diff -rq skills/wa-review/references powers/wa-review/steering/references
 
   link-check:
-    # Advisory (non-blocking) for now: surfaces broken relative links in the log
-    # but does not gate. Blocked on adapters/gemini-cli/GEMINI.md, which uses
-    # repo-root-absolute links (/skills/.../SKILL.md) that render on GitHub but
-    # aren't resolvable by lychee --offline. Flip fail:true once those are fixed.
+    # Gating: fails the build on broken relative links in authored Markdown.
+    # (Generated crawler corpora are excluded below — their .md files carry
+    # intentional relative .html cross-links that resolve on the AWS docs site,
+    # not on disk.)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
             --exclude-path skills/example-skill/references
             --exclude-path powers/wa-review/steering/references
             "./**/*.md"
-          fail: false
+          fail: true
 
   secret-scan:
     # Enforces the intent behind the existing .gitleaksignore. CLI (not the action) avoids the org-license requirement.

--- a/adapters/gemini-cli/GEMINI.md
+++ b/adapters/gemini-cli/GEMINI.md
@@ -51,16 +51,15 @@ When delivering Well-Architected guidance:
 ## Skills
 
 Well-Architected skills are available as reusable playbooks in the `skills/` directory. If the user requests a specific audit or plan (e.g. WA review, security assessment, reliability improvement plan), locate and follow the step-by-step instructions in the corresponding skill directory:
-- [wa-review](file:///skills/wa-review/SKILL.md) (Full Well-Architected review)
-- [security-assessment](file:///skills/security-assessment/SKILL.md) (Security posture assessment)
-- [reliability-improvement-plan](file:///skills/reliability-improvement-plan/SKILL.md) (Reliability remediation plan)
-- [cost-optimization-review](file:///skills/cost-optimization-review/SKILL.md) (Cost optimization audit)
-- [performance-efficiency](file:///skills/performance-efficiency/SKILL.md) (Performance efficiency review)
-- [sustainability-optimization](file:///skills/sustainability-optimization/SKILL.md) (Sustainability optimization review)
-- [migration-readiness](file:///skills/migration-readiness/SKILL.md) (Migration readiness assessment)
-- [architecture-decision-record](file:///skills/architecture-decision-record/SKILL.md) (Architecture decision record template)
-- [wa-builder](file:///skills/wa-builder/SKILL.md) (Understand Well-Architected for your workload and generate visual artifacts: annotated diagrams, decision trees, roadmaps)
-- [wa-guardrails](file:///skills/wa-guardrails/SKILL.md) (Generate preventive guardrails: Config rules, SCPs, CI policy checks, alarms to keep a workload aligned with Well-Architected best practices over time)
+
+**Core skills:**
+- [wa-review](../../skills/wa-review/SKILL.md) — Full or pillar-scoped Well-Architected review (all 6 pillars supported as deep-dives)
+- [wa-builder](../../skills/wa-builder/SKILL.md) — Learn Well-Architected for your workload and generate visual artifacts: annotated diagrams, decision trees, roadmaps, ADRs
+- [wa-guardrails](../../skills/wa-guardrails/SKILL.md) — Generate preventive guardrails: Config rules, SCPs, CI policy checks, and alarms that keep a workload aligned with Well-Architected best practices over time
+- [wafr-facilitator](../../skills/wafr-facilitator/SKILL.md) — Prepare conversational Well-Architected Framework Review facilitation with customers
+- [migration-readiness](../../skills/migration-readiness/SKILL.md) — 7 Rs migration readiness assessment
+
+**Pillar-scoped variants** route to `wa-review` with a single-pillar focus — security assessment, reliability improvement plan, cost optimization review, performance efficiency review, sustainability optimization, and operational excellence — while an architecture decision record maps to `wa-builder`'s ADR mode.
 
 <!--
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
Fixes #121

## Problem
`adapters/gemini-cli/GEMINI.md` linked its skills with absolute `file://` URLs (`file:///skills/<name>/SKILL.md`). GitHub's web renderer tolerates them, but `lychee --offline` resolves them against the filesystem root and reports "file not found" — so the `link-check` CI job (added in #120) was left **advisory** (`fail: false`) rather than gating.

## Why it matters
While link-check can't gate, broken relative links can land on `main` unnoticed. This one file was the sole blocker to turning link-check into a real gate.

## Fix (symptom → root cause → change)
- **Symptom:** `lychee --offline` errors on the GEMINI.md skill links; CI can't gate.
- **Root cause:** two issues, not just link form —
  1. **Link form:** absolute `file:///skills/...` doesn't resolve offline.
  2. **Link targets:** six of the ten linked "skills" (`security-assessment`, `reliability-improvement-plan`, `cost-optimization-review`, `performance-efficiency`, `sustainability-optimization`, `architecture-decision-record`) are **not real skill directories** — per `adapters/claude-code/CLAUDE.md` they are pillar aliases that route to `wa-review` (and ADR → `wa-builder`). Relativizing them alone would still 404.
- **Change:** the Skills section now links only the **five real skill dirs** (`wa-review`, `wa-builder`, `wa-guardrails`, `wafr-facilitator`, `migration-readiness`) with repo-relative paths (`../../skills/<name>/SKILL.md`), and describes the pillar-scoped variants as aliases in prose — matching the CLAUDE.md model. With no unresolvable links left, `.github/workflows/ci.yml` flips the `link-check` job from `fail: false` to `fail: true`.

## Tests
Ran the exact CI lychee invocation offline (lychee 0.24.2) across all authored Markdown:
```
🔗 37 Unique ✅ 33 OK 🚫 0 Errors 👻 31 Excluded
```
0 errors repo-wide, so `fail: true` is safe.

## Manual verification
Confirmed the five linked `SKILL.md` targets exist under `skills/`; confirmed the six removed entries have no matching directory and are documented as pillar aliases in `adapters/claude-code/CLAUDE.md`.

## Screenshots
N/A — docs + CI config, no UI.
