### PR TITLE
feat(lenses): add mergers-and-acquisitions and maori-data lenses (#75, #76)

### DIFF
--- a/powers/wa-review/steering/references/lenses/maori-data/cost-optimization.md
+++ b/powers/wa-review/steering/references/lenses/maori-data/cost-optimization.md
@@ -1,0 +1,38 @@
+# Cost optimization
+
+**Pillar**: Cost Optimization  
+**Pages**: 1
+
+---
+
+# MD_CO 1 Understand costs associated with infrastructure options
+
+- **MD_CO01-BP01: How are you presenting the costs/benefit tradeoffs
+for infrastructure options?** Clearly present the cost to benefit trade-offs
+when looking at all infrastructure options. When designing technology solutions,
+organisations need to balance delivering functional and non-functional requirements with
+the cost associated with doing so. It is important that the cost to benefit ratio is
+assessed and understood. The assessment should take into account the strategic drivers for
+the organisation. Within the public sector, for example, value-for-money in terms of
+social, environmental, and public benefits is important. For some Māori customers,
+security, resilience, and sustainability may be key considerations.
+
+An example may be an organisation wanting to store data close to the source for
+latency reasons. An AWS Outpost can help meet those requirements. An AWS Outpost
+is a managed service that extends AWS infrastructure, services, APIs, and tools to
+customer premises. However, there are several considerations when using an AWS
+Outpost. An Outpost has a limited set of AWS services available compared to the 200+
+services available in an AWS Region. This consideration may impact how you design
+your architecture. An AWS Outpost is a physical device that needs to be built,
+shipped, and installed within a datacentre that meets certain physical requirements.
+This can be done with a third-party data centre, but there is a cost associated with
+renting space.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_cos-1-understand-cost.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/maori-data/operational-excellence.md
+++ b/powers/wa-review/steering/references/lenses/maori-data/operational-excellence.md
@@ -1,0 +1,221 @@
+# Operational excellence
+
+**Pillar**: Operational Excellence  
+**Pages**: 3
+
+---
+
+# MD_OPS 1: How do you incorporate Māori views into your technology governance and operations?
+
+Where appropriate, the Māori world view (te ao Māori) and Māori knowledge and
+understanding (mātauranga Māori) could be incorporated into an organisation's way of operating
+its technology in support of Māori customers. Sometimes this cannot be done as easily as
+performing operations as code, instead it may require active and ongoing collaboration with Māori.
+Understanding Māori interests and considerations relating to data collection, processing, and
+storage, as well as how those interests are evolving, helps you make informed technology
+decisions both in the interim and the long-term.
+
+- **MD_OPS01-BP01:**
+**Incorporate mātauranga Māori into your operational processes when it
+relates to Māori data.** There are several ways of doing this. Work directly
+with your Māori customer or accessible internal and external Māori advisers to help
+develop your organisation's understanding of te ao Māori.
+- **MD_OPS01-BP02:**
+**Consider governance and accountability over Māori data.**
+Consider incorporating specific accountabilities for Māori data into pre-existing roles in
+your organisation, such as Chief Information Officer (CIO), Chief Information Security
+Officer, or Chief Data Officer (CDO). Formalising these accountabilities and
+responsibilities into position descriptions can prioritise Māori data considerations at
+the executive level.
+- **MD_OPS01-BP03:**
+**Consider how you can incorporate international data management
+principles into your data governance framework**. Some examples of
+international data management principles include Findability, Accessibility,
+Interoperability, Reuse (FAIR), which were developed for scientific data management and
+stewardship.
+- **MD_OPS01-BP04:**
+**Consider how to supplement your knowledge for example through using
+Māori cultural advisers at the appropriate time**. Build your network of Māori
+advisers externally to your organisation, which you can engage with on particular
+technology projects. AWS has a growing list of advisers in the Amazon Partner Network.
+Working with external advisers also helps you develop your internal capabilities.
+- **MD_OPS01-BP05:**
+**Develop longer-term policies and procedures.** Consider how
+to gradually develop the internal competencies and capabilities in your organisation as
+you continue to work with Māori customers. This can help you set your organisation's or
+your customer's overall data policies and processes with respect to collecting, storing,
+processing, and handling Māori data. Raising awareness and understanding of this across
+your technology staff and suppliers can help inform design decisions for handling Māori
+data, but this may be a long-term process.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_ops-1-how-do-you-incorporate-māori-views-into-your-technology-governance-and-operations.html*
+
+---
+
+# MD_OPS 2: How can you design data collection with your Māori customer(s) in mind?
+
+Organisations collect and process data to support the delivery of products and services
+to customers, stakeholders, and citizens. Data collection occurs in many ways, including
+filling in a digital form on a website, sensors capturing environmental data like temperature
+or water flow rates, or a research team capturing data from participants in a university
+study. Organisations need to consider what data they are collecting, the purpose for
+collecting the data, and, in the case of personal information, to adhere to the New Zealand
+Privacy Act 2020. For additional considerations around the collection of personal information,
+see [Using AWS in the Context of New Zealand Privacy Considerations](https://d1.awsstatic.com/whitepapers/compliance/Using_AWS_in_the_context_of_New_Zealand_Privacy_Considerations.pdf).
+
+- **MD_OPS02-BP01:**
+**Consider adopting a privacy by design approach by designing and
+implementing mechanisms and processes that simplify compliance with the New Zealand
+Privacy Act 2020.** When collecting and handling personal information, make
+sure you comply with all applicable laws, such as the New Zealand Privacy Act 2020. You
+can design continuous and informed consent mechanisms that provide clear information to
+users about what personal information is being collected and for what purpose. Consider
+incorporating mechanisms that make it easier for users to revoke consent and to request
+access to, or correction of, their personal information. Maintain consent management over
+how you capture, store, and preserve personal information.
+- **MD_OPS02-BP02: Consider how you're communicating why you are
+collecting this data.** Make it clear to users why the data is being collected,
+how it is used, and how privacy is maintained on an ongoing basis. Customers can interact
+with your organisation multiple times, so communicating what data is collected, why it is
+collected, and how it is collected in the context of the interaction may help. Also
+consider when to communicate this. Some examples include:
+
+At the time a user registers or signs up to an organisation (for example, they
+sign up to a new bank, a new medical centre, or subscribe to a music streaming
+service).
+- At the time a user applies for a service from your organisation (for example,
+they apply for a home loan, book a medical exam, request a quote for home
+improvements, or apply for a government entitlement like a student loan).
+- At the time a user interacts with your organisation (for example, they lodge a
+complaint with a local council, submit an insurance claim, or request a change to a
+home loan).
+
+- **MD_OPS02-BP03: Consider important lineage and provenance of data
+that could be captured as additional data.** It may be helpful to capture and
+store lineage and provenance data, which could be included as metadata or a tag. This kind
+of additional data can provide additional context to the data, such as when it was
+collected, how it was collected and who was involved in the collection. Maintaining
+careful records of the data provenance can build trust in the integrity and authenticity
+of the data and from whom the data was derived. An example of this is a hapū's cultural
+archive which captures which whānau provided which cultural record. It could also apply to
+organisations conducting surveys of specific populations for the purpose of creating data
+sets or performing data analysis.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_ops-2-how-can-you-design-data-collection-with-your-māori-customers-in-mind.html*
+
+---
+
+# MD_OPS 3: How do you use or share Māori data back with Māori?
+
+Organisations use data in many different ways to design and deliver products and
+services. They can use it to gain insight and understanding of their organisation, their
+industry, and the wider world around them. Organisations should assess any legal and ethical
+implications when making decisions relating to how data will be used and shared.
+
+- **MD_OPS03-BP01: Collecting and separating Māori data
+appropriately**. Organisations can consider how to collect and separate data
+along different dimensions such as iwi and hapū or a Māori organisation. This may make data more relevant or
+useful to different groups or communities. This needs to be considered when designing your
+initial data collection plan to verify that the right data is collected and organised
+early. For example, a government agency may want to report on specific agency outcomes for
+Māori populations. If they captured an individual's hapū affiliations, they could report
+information at a hapū level. However, if they only captured an individual's record, then
+they can only report this at an individual level.
+- **MD_OPS03-BP02: Consider how your organisation could share Māori data
+back to Māori**. Data that your organisation holds could be used to better
+understand Māori communities and realise individual and collective benefits. Consider how
+you could identify useful data, and design ways to make data more accessible. Open data
+initiatives are one approach, but also remember the importance of complying with the
+Privacy Act 2020.
+- **MD_OPS03-BP03: Use tools to effectively and securely share data
+where there is a specific and appropriate purpose.** There are many approaches
+to sharing data. Consider tools to share data both publicly and privately, which fits the
+purpose for why that data is being shared and how it needs to be used. Share this data in culturally-appropriate ways, and avoid misappropriating that data or trying to create explanation around that data that isn't culturally-sensitive or informed. Seek advice from your Māori advisers if you are unsure how to do this. This includes open
+data portals or exchanges such as the AWS Open Data Registry, AWS Data Exchange, or private data
+portals hosted by your organisation. Consider solutions that allow data to be shared using
+different formats such as flat files, application programming interfaces (APIs), or
+interactive dashboards and visualisations to meet the needs of data consumers.
+- **MD_OPS03-BP04: Share data in ways that can be easily used by your
+various stakeholders**. Understand your Māori stakeholders, their interests in
+accessing and using the data you are sharing back with them, and how they use the data.
+This should drive your choice of format for that data. For example, graphs or
+visualisations published on your website can make data easy to find and understand, while
+data files such as comma-separated values files (CSV) or parquet are better for data
+analytics users. An API supports application-to-application integration. For example, a
+government agency may provide interactive graphs on their website so that anyone with a
+web browser can see graphs relating to key agency objectives. They may provide the data
+that sits behind the graphs in a CSV format so that people can download it and load it
+into a spreadsheet tool or analytics programme to build their own graphs or perform
+additional queries. They may also provide an open API so members of the public can
+retrieve the data and load into their own databases or analytics systems.
+- **MD_OPS03-BP05: Consider how your organisation could use federated
+data access methods.** Organisations often need to access data from other
+organisations to support a business process. Federated data approaches can allow
+organisations to access data from other organisations without the need to replicate or
+copy the data into your own systems. Federated data access models require appropriate
+mechanisms for making your organisations data discoverable and for securely sharing data.
+- **MD_OPS03-BP06: Define and implement appropriate authorisation
+mechanisms.** Design data access mechanisms that support both internal access
+and access for external third parties (for example, through federated data access or data
+sharing mechanism). Consider authorisation mechanisms including role-based access control
+(RBAC), attribute-based access control (ABAC), or policy-based access control (PBAC). The
+authorisation mechanism should provide ways to manage, grant, and revoke access and
+provide visibility into data access through auditing and logging. Establish appropriate
+governance processes to effectively manage the process for requesting, granting, and
+revoking access to data by verified, trusted, and approved external third parties.
+
+- **MD_OPS03-BP07: Incorporate responsible and ethical use of machine
+learning (ML) and artificial intelligence (AI) as a core part of your governance
+framework and development lifecycle.** ML and AI have transformational
+potential. It is already widely used for tasks such as transcription, translation, fraud
+detection, information security, search, and recommendation engines. At Amazon, we believe
+the design, development, and deployment of AI must respect the rule of law, human rights,
+and values of equity, privacy, and fairness. We are committed to developing fair and
+accurate AI services and providing customers with the tools and guidance needed to build
+applications responsibly. Developers and deployers of AI systems should ensure such
+systems are built based on principles of safety and responsibility by design. AWS builds
+AI with responsibility in mind at each stage of our comprehensive development process.
+Throughout design, development, deployment, and operations, we consider a range of factors
+including accuracy, fairness, appropriate usage, toxicity, security, safety, and privacy. Ask your Māori customers what particular ethical questions and principles they may want you to adopt as a part of your governance framework and development lifecycle. Regularly revisit and refine your AI ethics practices through ongoing dialogue and partnerships with Māori communities.
+- **MD_OPS03-BP08: Leverage vendor tools to provide AI
+transparency.** For example, AWS AI Service Cards deliver a form of
+transparency documentation that provide customers with a single place to find information
+on the intended use cases and limitations, responsible AI design choices, and deployment
+and performance optimisation best practices for our AI services. Amazon SageMaker AI Clarify detects
+and measures potential bias using a variety of metrics so developers can address potential
+bias and explain model predictions. Amazon's Responsible Use of Machine Learning Guide highlights key best practices and
+tooling that AI developers and deployers can use to mitigate risks across the lifecycle of
+an AI system.
+- **Other considerations:**
+
+**Discuss AI with stakeholders.** Artificial intelligence
+including generative AI and machine learning is a rapidly evolving area. Discuss the
+benefits and risks with your stakeholders. Your stakeholders may be internal to your
+organisation, external customers, or members of the public. Cross-functional expertise from technologists, ethicists, lawyers, domain experts, and external resources provides a holistic understanding and consideration of ethical, legal, and domain-specific factors. Customers should engage with Māori stakeholders early and continuously to understand their perspectives, concerns, and preferences regarding the use of certain data in AI/ML deployment and development. Employ Māori expertise in the design, development, and testing phases to verify cultural competence and alignment with tikanga.
+- **Consider potential inaccuracies.** Customers should consider potential inaccuracies in ML system results (especially concerning te reo Māori and Māori cultural concepts) and prepare a plan to address them, such as narrowing scope, introducing human oversight, or altering dependencies on the AI system. Customers should also consider incorporating appropriate testing of model outputs into the AI application creation process when model inputs or outputs are dealing with te reo Māori or Māori cultural concepts. Evaluation of outputs should be made by appropriately skilled people. To assess if an AI system operates as intended, it is important to use accurate and representative training data. AWS encourages specific policies and provides safeguards such as [Guardrails for Amazon Bedrock](https://aws.amazon.com/bedrock/guardrails/) to block harmful user inputs.
+- **Use case evaluation and testing.** Testing should
+include not just the AI system itself but also the overall process it is a part of,
+including decisions or actions that might be taken based on system output. Customers should consider evaluating models thoroughly on safety characteristics such as prompt stereotyping (like encoded biases for gender or socioeconomic status), factual knowledge, and toxicity. [FMEval](https://aws.amazon.com/blogs/machine-learning/evaluate-large-language-models-for-quality-and-responsibility/), an open source library is available in [Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) for developing these insights. [Model evaluation is also available in Amazon Bedrock](https://aws.amazon.com/blogs/aws/amazon-bedrock-model-evaluation-is-now-generally-available/) for large language models (LLMs). Model outputs can be evaluated by a pool of human evaluators, or through an automated process. Customers can test performance through techniques like [red teaming](https://www-cdn.anthropic.com/82564d4ec2451b2eed2e0796b7c658fc989f0c1a/Anthropic_RedTeaming.pdf) and reinforcement learning from human feedback (RLHF). Customers should also consider continually evaluating performance and responsibility metrics before deployment and use tools like [SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect data drift and prompt retraining if needed.
+- **Continuous improvement and validation.** Monitoring for
+potential bias and accuracy, and for models performing as expected across different
+segments, is an important part of this process.
+- **Ongoing education.** AI is a constantly-evolving
+landscape, and new techniques, technologies, laws, and social norms continue to be
+developed and refined over time. It is essential that all parties involved with
+building and using AI systems stay educated on these issues and account for them in
+the design, deployment, and operation of their systems. Successful AI adoption requires significant cultural and organisational changes, including defining the roles and responsibilities required for accountability, and customers should verify that they are allowing Māori to make informed decisions about participation.
+
+For further reading, refer to the [AWS Machine
+Learning lens](https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/machine-learning-lens.html).
+
+AWS continues to update this information and share additional guidance to customers on
+the use of AI/ML. Please reach out to the team at AWS for further updates.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_ops-3-how-do-you-use-or-share-māori-data.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/maori-data/performance-efficiency.md
+++ b/powers/wa-review/steering/references/lenses/maori-data/performance-efficiency.md
@@ -1,0 +1,56 @@
+# Performance efficiency
+
+**Pillar**: Performance Efficiency  
+**Pages**: 1
+
+---
+
+# Performance efficiency
+
+The [Performance Efficiency
+Pillar](https://docs.aws.amazon.com/wellarchitected/latest/performance-efficiency-pillar/welcome.html) addresses best practices for managing production environments. This document
+does not cover the design and management of non-production environments and processes, such as
+continuous integration or delivery. The Well-Architected Performance Efficiency Pillar provides
+an overview of design principles, best practices, and questions. If relevant, you can find
+guidance on implementation in the [Performance Efficiency
+Pillar whitepaper](https://docs.aws.amazon.com/wellarchitected/latest/performance-efficiency-pillar/welcome.html).
+
+The Performance Efficiency Pillar focuses on the efficient use of computing resources to
+meet requirements, and how to maintain efficiency as demand changes and technologies evolve.
+Following these design principles can help you achieve and maintain efficient workloads in the
+cloud.
+
+Design principles
+
+- **Democratise advanced technologies:** Make advanced technology
+implementation easier for your team by delegating certain tasks like the undifferentiated
+work to your cloud vendor. Rather than asking your IT team to learn about hosting and
+running a new technology, consider consuming the technology as a service. For example, NoSQL
+databases, media transcoding, and machine learning are all technologies that require
+specialised expertise. Learn and develop these expertise with [AWS Skill Builder](https://skillbuilder.aws/). In the cloud, these
+technologies become services that your team can consume, allowing your team to focus on
+product development rather than resource provisioning and management.
+- **Go global in minutes:** Deploying your workload in multiple
+AWS Regions around the world allows you to provide lower latency and a better experience
+for your customers at minimal cost.
+- **Use serverless architectures:** Serverless architectures
+remove the need for you to run and maintain physical servers for traditional compute
+activities. For example, serverless storage services can act as static websites (removing
+the need for web servers) and event services can host code. This removes the operational
+burden of managing physical servers, and can lower transactional costs because managed
+services operate at cloud scale.
+- **Experiment more often:** With virtual and automatable
+resources, you can quickly carry out comparative testing using different types of instances,
+storage, or configurations.
+- **Consider mechanical sympathy:** Use the technology approach
+that aligns best with your goals. For example, consider data access patterns when you select
+database or storage approaches.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/performance-efficiency.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/maori-data/reliability.md
+++ b/powers/wa-review/steering/references/lenses/maori-data/reliability.md
@@ -1,0 +1,57 @@
+# Reliability
+
+**Pillar**: Reliability  
+**Pages**: 1
+
+---
+
+# MD_REL 1 How do you safely retain data for future generations?
+
+Māori data is often considered taonga, and it is critical that this data is available for
+future generations. Whakapapa (genealogy) or mātauranga Māori (Māori knowledge) are examples
+where long-term retention and protection is important.
+
+- **MD_REL01-BP01: Design storage systems with multi-generational
+durability in mind**. Multi-generational durability focuses on the reliability
+of having access to that data across generations. This applies to the data that you are
+storing, but also associated metadata that provides context for that data. The
+Well-Architected Reliability Pillar provides guidance on best practices for architecting
+resilient workloads, backing up data, and planning for disasters. By understanding what
+kinds of data you are storing and the possible need for the long-term preservation of that
+data, you can choose appropriate architectural patterns and services such as Amazon S3, which
+creates six copies of your data and is designed to provide 99.999999999% (11 nines) of
+durability. In practice, 11 nines of durability means that if you stored ten million
+objects, you might expect to lose a single object every 10,000 years.
+- **MD_REL01-BP02: Consider how your organisational archive and
+retention processes apply to Māori data.** Many organisations have data
+retention and archiving processes that govern how long data is retained and how and where
+it is stored.
+- **MD_REL01-BP03: Configure your AWS account for long term
+continuity**. Within each of your AWS accounts, it is important to have
+accurate and up-to-date contact details, payment/credit card information, and multi-factor
+authentication (MFA) for users. Keeping your contact information up-to-date helps ensure
+that you receive important notifications from AWS on topics like security, billing, and
+operations. It is a best practice to use an email distribution list, rather than depending
+on an individual's email address. This can help avoid scenarios where important
+notifications from AWS are missed if an individual is on leave or has left the
+organisation.
+- **MD_REL01-BP04: Implement backup mechanisms**. The
+Reliability Pillar provides guidance on designing, implementing, and operating a backup
+solution for your data and applications. The nature of the Māori data being captured,
+processed, or stored influences the design of the backup solution. For example, an iwi
+register application or a digital archive application might call for multiple copies of
+backups to be stored in different locations, with different access controls due to the
+value of those datasets. While it may seem redundant, it's important to store backups
+across multiple different types of storage and in multiple different locations. This helps
+ensure there's always an available backup, no matter the circumstances. Where
+irreplaceable digital taonga is identified, it is important to consider offline
+replication in addition to the appropriate security and reliability controls.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_rel-1-how-do-you-safely-retain-data-for-future-generations.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/maori-data/security.md
+++ b/powers/wa-review/steering/references/lenses/maori-data/security.md
@@ -1,0 +1,184 @@
+# Security
+
+**Pillar**: Security  
+**Pages**: 4
+
+---
+
+# MD_SEC 1: How is Māori data protected?
+
+Systems designed to capture, store, or process Māori data should follow the same best
+practice as any other cloud solution in that they should be designed, built, and operated with
+security in mind. The Security Pillar of the Well-Architected Framework provides in-depth,
+best practice guidance for architecting secure workloads. The [Data protection](https://docs.aws.amazon.com/wellarchitected/latest/framework/sec-dataprot.html) best
+practice area in the Security Pillar provides best practices relating to data classification,
+protecting data at rest, and protecting data in transit. Data protection is just one aspect of
+securing your cloud architectures. Security should be applied at all layers through multiple
+controls using a defence-in-depth approach. In addition to the best practices contained in the
+Security Pillar, the following considerations may also apply:
+
+- **MD_SEC01-BP01: Design storage systems to handle data with different
+Māori data classifications.** If the data is considered tapu and that is
+feedback you have received from your customers, then it may be appropriate to apply
+additional controls and procedures. These may be required to support specific tikanga
+related to the handling of certain data. You may choose to store certain data separately
+from other data with different security requirements for access and processing. It is
+possible, for example, to store data in separate virtual private clouds (VPC), separate
+databases, or separate object storage buckets. This separation of datasets means you can
+apply independent security controls, such as different access permissions, different
+logging and auditing levels, and different backup approaches.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-1-how-is-māori-data-protected.html*
+
+---
+
+# MD_SEC 2: How do you design workload security for long-term safety?
+
+Certain Māori data may need to be available for generations to come. Consult with Māori
+customers and advisers about what data retention policies they recommend according to the
+different types of data. These data retention policies can be revisited in the future too.
+Regardless of how long you are intending to store this data, all data needs to be properly
+secured for the protection of taonga (treasure) for generations to come.
+
+Ransomware is a good example to consider. If you have one copy of your data and you are
+subject to a ransomware attack, you may not be able to recover your data. Consider how many
+backup copies may be required to protect yourself from this scenario. Design appropriate
+access controls to minimise the chance of accidental or malicious deletion or corruption of
+back-ups. While it may seem redundant, it's important to store backups across multiple
+different types of storage and in multiple different locations. With this strategy, there's
+always an available backup, no matter the circumstances. Where irreplaceable digital taonga is
+identified, it is important to consider offline replication in addition to the appropriate
+data protection and resilience controls.
+
+- **MD_SEC02-BP01: Understand data protection options available through
+your provider to protect data at the level of control your customer wants.**
+Customers control how they configure their environments and secure their content,
+including whether they encrypt their content (at rest and in transit), and what other
+security features and tools they use and how they use them. AWS does not change customer
+configuration settings, as these settings are determined and controlled by the customer.
+AWS customers have the ability to design their security architecture to meet
+their compliance needs. AWS provides the customer autonomy to decide when and how
+security measures are implemented in the cloud, in accordance with each customer's
+business needs. When choosing which option is best, you should understand the risks you
+are trying to mitigate, take into account both the benefits and costs of each solution,
+and choose a solution that meets your requirements. Choose a cloud provider that offers
+contractual restrictions on their access to your data and operational restrictions. AWS,
+for example, is one of those cloud providers who offers both.
+- **MD_SEC02-BP02: Understand what encryption options are available to
+protect your data at rest and in transit.** Encryption of data at rest is a
+recommended best practice for protecting your data from unauthorised access. AWS
+provides several options for data encryption. One option is to have AWS create and
+manage encryption keys for you through the AWS Key Management Service. Many AWS services integrate with
+AWS KMS to enable encryption of your data. Another option is to create your own encryption
+keys within AWS KMS. This provides you with more control over your keys. This includes
+control over the key material, the rotation policy, and the permissions that define who
+can use or manage the key. AWS KMS is designed so that no one, not even an AWS employee,
+can retrieve your plaintext KMS keys from the service.
+- **MD_SEC02-BP03: Make informed decisions about where data is
+stored**. Māori users of your system may prefer their data to be stored in New
+Zealand. AWS allows customers to control where their data is stored and processed, and
+your content won't be replicated or moved outside of your chosen AWS Region except as
+agreed by you. For customers in Aotearoa New Zealand, the options for storing data within
+New Zealand include the Auckland AWS Local Zone, an AWS Outpost, or the upcoming AWS
+Auckland region. Every commercial AWS region is designed, built, and operated in the
+same way and incorporates the same levels of security. When choosing an AWS
+infrastructure for your workload, take into account the possible trade-offs that may
+exist. For example, an AWS Region has a larger selection of AWS services and higher
+resiliency than an AWS Outpost. However, an AWS Outpost may provide more flexibility
+as to the location where the infrastructure can be placed. There are also costs and budget
+considerations to take into account. Some other considerations related to the location of
+data include:
+
+Do you need to make a distinction between where data is processed and where it is
+stored? For example, the data could be stored in a database in New Zealand but
+processed on an EC2 instance in another region (of your choice) as part of an analytics job.
+Alternatively, it could be captured using a web application running on servers in
+Sydney and then saved to a database located in New Zealand.
+- Do you need to duplicate data across locations to meet your customer requirements?
+For example, a data archiving solution could send backups to another AWS Region for
+resiliency and security reasons. An application like a digital archive solution could
+make use of Amazon CloudFront for content distribution to help reduce latency for end users
+when accessing the content. This would require copies of data to be stored at CloudFront
+edge locations, while the primary data is stored in the origin storage service such as
+Amazon S3 or a database.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-2-how-do-you-design-workload-security-for-long-term-safety.html*
+
+---
+
+# MD_SEC 3: How can you identify and classify Māori data?
+
+Organisations may wish to understand what Māori data they hold and have a method to
+classify Māori data to protect it with security controls and practices. Once the data has been
+classified and appropriate metadata is captured, you can govern and use that data in
+appropriate ways.
+
+- **MD_SEC03-BP01: Develop an understanding of what Māori data
+is**. Create an easy-to-understand definition of Māori data for your
+organisation. Having a definition of Māori data can help determine what additional
+considerations are relevant to your organisation or application. Piloting this and testing
+this with your customers facilitates a mutually-agreed upon definition, which is
+implementable for your organisation.
+- **MD_SEC03-BP02: Incorporate Māori data classification into your data
+governance framework**. If you already have a data classification framework
+within your organisation, you may wish to expand this to include a Māori data
+classification approach. A classification framework can help you determine what is Māori
+data, outline where and how the classification should be recorded, and define the security
+and access controls that are required for that data classification. For example, what
+additional data access controls may be required if the data is classified as tapu or noa?
+- **MD_SEC03-BP03: Record Māori data classifications as metadata and
+make it easily discoverable**. Use approaches such as metadata tagging and data
+cataloguing to store and manage your classification metadata. Tools such as business data
+catalogues should make it easier for your organisation to search for and discover datasets
+that contain Māori data in your organisation. In addition, you can add tags which record
+the purpose for which consent of that data was given. This may allow for easier review of
+consent and data access policies and up-to-date consent practices.
+- **MD_SEC03-BP04: Leverage technologies and techniques to help identify
+and classify existing Māori data**. Your organisation may already capture and
+store Māori data. Consider using available tools and techniques to review and classify
+your existing data. Once identified and classified, update your metadata and business data
+catalogues. This may involve assessing data across databases, object stores, file servers,
+document management systems, communication systems (like email), and analytics platforms.
+For example, search your AWS Glue Data Catalog table columns for terms like *iwi*
+or *hapū* or Māori organisation.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-3-how-can-you-identify-and-classify-māori-data.html*
+
+---
+
+# MD_SEC 4: How do you maintain privacy of personal Māori data?
+
+It is important that personal data is collected and processed lawfully, fairly, and
+transparently in relation to a person. When designing, building, and operating workloads that
+may capture, store, and process Māori personal data, privacy should be taken into account
+throughout the entire process. The application of privacy principles should align with your
+organisation's privacy framework and be guided by applicable privacy regulation such as the
+New Zealand Privacy Act 2020. For further information on how you are applying AWS services
+in conjunction with the New Zealand Privacy Act 2020, see [Using AWS in the Context of the New Zealand Privacy Considerations](https://d1.awsstatic.com/whitepapers/compliance/Using_AWS_in_the_context_of_New_Zealand_Privacy_Considerations.pdf).
+
+- **MD_SEC04-BP01: Use tools and techniques to adequately de-identify
+data.** This helps protect individual's privacy when producing data sets that
+may be shared or published. There are many techniques within data and analytics domains to
+help de-identify data. These include obfuscation (obscuring sensitive data), tokenisation
+(where a sensitive piece of data is replaced by a non-sensitive token where the token can
+map back to the original data), and anonymisation (such as removing sensitive data
+completely).
+- **MD_SEC04-BP02: Honour the consent you've received when using data
+for internal analytics**. If your organisation asked for consent when
+collecting data, that data should be used only for the purposes that you have received
+consent for. If your organisation asked for consent and did not receive it, exclude this
+data from analytics and AI/ML uses.
+- **MD_SEC04-BP03: Honour the consent you've received when sharing
+data**. Only share data with third parties if you have obtained requisite
+consent in accordance with applicable laws such as the New Zealand Privacy Act. Consider
+creating mechanisms to exclude that data from any data sharing processes if you have not
+obtained the required consents.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-4-how-do-you-maintain-privacy-of-personal-māori-data.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/maori-data/sustainability.md
+++ b/powers/wa-review/steering/references/lenses/maori-data/sustainability.md
@@ -1,0 +1,65 @@
+# Sustainability
+
+**Pillar**: Sustainability  
+**Pages**: 1
+
+---
+
+# MD_SUS 1 How do you design and operate systems to minimise potential impacts on the environment?
+
+- **MD_SUS01-BP01: Develop an understanding of the unique relationship
+between Māori and the land**. As tangata whenua (people of the land), Māori
+have deep connections to the land and the natural world. Whenua is seen as taonga that
+must be protected for future generations. It is important to understand the possible
+impacts your technology decisions may have on the environment. Understand your Māori
+customers in the context of their natural environment, their priorities, and their
+interests, and incorporate their perspectives into your technology when considering
+opportunities and environmental impact.
+- **MD_SUS01-BP02: Consider how your solution could positively impact
+the environment.**Technology is often used to improve processes by making them
+more efficient or effective. When designing products, consider how you can incorporate
+features that could have direct or indirect positive impacts on the environment. For
+example, if you are designing a farm management system that tracks nitrate usage on
+paddocks to maximise pasture growth, consider a feature that highlights potential risk of
+nitrates making their way into farm waterways. Similarly, you can reduce landfill waste by
+using machine learning in your manufacturing process to help determine the optimal use of
+resources.
+- **MD_SUS01-BP03: Consider where you might store and run your workload
+to make the most of the sustainability of the cloud.** A study by 451 Research
+shows that "moving IT workloads from on-premises data centres to the cloud would improve
+energy efficiency and reduce associated carbon emissions by nearly 80% on average" (among
+515 surveyed enterprises across Japan, South Korea, Singapore, Australia, and India). 451
+Research also estimates that emissions savings for organisations moving from on-premises
+data centers to cloud could increase to 93% if cloud data centers in APAC were powered by
+100% renewable energy. This advantage is attributable to the combination of more
+energy-efficient servers and much higher server utilisation. As New Zealand customers move
+their workloads from enterprise data centres to the AWS Cloud, the carbon footprint of
+these workloads is reduced due to lower energy consumption. Furthermore, the AWS Asia
+Pacific (Auckland) Region is planned to be powered by 100% renewable energy. This is part
+of Amazon's Climate Pledge whereby Amazon is on path towards powering its infrastructure
+operations by 100 percent renewable energy by 2025.
+- **MD_SUS01-BP04: Measure and report on carbon footprint.**
+AWS offers customers free use of the [Customer Carbon Footprint
+Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/) (CCFT). The CCFT provides the following features:
+
+Simple data visualisations to report on the emissions from your AWS usage
+following Greenhouse Gas (GHG) Protocol standards;
+- Analysis of the changes in your emissions over time as you migrate workloads to
+AWS;
+- Helps you re-architect applications, or deprecate unused resources; and
+- Forecasts how your emissions change across your sustainability journey as Amazon
+progresses toward powering operations with 100% renewable energy.
+
+You can also talk to your account executive about the range of tools available on the
+[AWS Marketplace](https://aws.amazon.com/marketplace), which can support tracking and
+reporting of your organisation's sustainability data. Such data provides necessary insight to
+achieve your organisation's sustainability goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sus-1-how-do-you-design-and-operate-systems-to-minimise-potential-impacts-on-the-environment.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MACOST01.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MACOST01.md
@@ -1,0 +1,59 @@
+# MACOST01 — Cost optimization
+
+**Pillar**: Cost Optimization  
+**Best Practices**: 6
+
+---
+
+## MACOST01-BP01 Perform pricing model analysis for the combined entities
+
+Analyze each component of the workload. Determine if the component and resources should be running for extended periods (for commitment discounts) or dynamic and short-running (for Spot or On-Demand Instances). Perform an analysis on the workload using the recommendations feature in AWS Cost Explorer.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP02 Optimize accounts through various means, such as EC2 instance types, Savings Plans, and Amazon S3 lifecycle
+
+Use AWS Trusted Advisor to examine current cost savings and possible additional savings.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP03 Discover and realize additional cost savings
+
+Explore means for additional cost savings, and use AWS Cost Explorer to evaluate costs. Choose an optimized savings plan for the combined entity, and work with AWS teams to use Reserve Instances or Savings Plans across companies if possible.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP04 Migrate to Regions based on cost
+
+Resource pricing can be different in each Region. Factoring in Region cost verifies that you are paying the lowest overall price for a workload.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP05 Use managed services for lower TCO
+
+Understand how proper use of managed services can lower TCO.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP06 Select third-party agreements with cost efficient terms
+
+Cost-efficient agreements and terms scale the cost of these services with the benefits they provide. Select agreements and pricing that scale when they provide additional benefits to your organization.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MACOST02.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MACOST02.md
@@ -1,0 +1,41 @@
+# MACOST02 — Cost optimization
+
+**Pillar**: Cost Optimization  
+**Best Practices**: 4
+
+---
+
+## MACOST02-BP01 Configure billing and cost management tools across both organizations
+
+Configure AWS Cost Explorer and AWS Budgets in line with your organization policies.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+## MACOST02-BP02 Combine both organizations information to cost and usage
+
+To roll your new AMS-managed AWS account bill into a payment for an existing AWS Organizations management account, set up consolidated billing, and link the accounts.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+## MACOST02-BP03 Allocate costs based on workload metrics
+
+Organize the workload's costs by metrics or business outcomes to measure workload cost efficiency. Implement a process to analyze the AWS Cost and Usage Report with Amazon Athena, which can provide insight and chargeback capability.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+## MACOST02-BP04 Configure a bill or chargeback strategy using custom usage tags
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MACOST03.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MACOST03.md
@@ -1,0 +1,51 @@
+# MACOST03 — Cost optimization
+
+**Pillar**: Cost Optimization  
+**Best Practices**: 5
+
+---
+
+## MACOST03-BP01 Perform data transfer modeling
+
+Gather organization requirements, and perform data transfer modeling of the workload and each of its components. This identifies the lowest cost point for its current data transfer requirements.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP02 Select components to optimize data transfer cost
+
+All components are selected, and architecture is designed to reduce data transfer costs. This includes using components such as wide-area-network (WAN) optimization and multi-Availability Zone (AZ) configurations.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP03 Implement services to reduce data transfer costs
+
+Implement services to reduce data transfer. For example, using a content delivery network (CDN) such as Amazon CloudFront to deliver content to users, caching layers using Amazon ElastiCache, or using AWS Direct Connect instead of VPN for connectivity to AWS.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP04 Delete redundant data stores using policies
+
+Manage the lifecycle of all your data, and automatically enforce deletion timelines to minimize the total storage requirements of your workload.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP05 Analyze data integration pattern of the combined organizations
+
+Data is a combined organizational asset. Collect, store, organize, and process valuable data, and make it available in a secure way to the people and applications that need it.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS01.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS01.md
@@ -1,0 +1,74 @@
+# MAOPS01 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 6
+
+---
+
+## MAOPS01-BP01 Workloads from both organizations have identified owners
+
+Strong governance and centralized control over scope of migration workloads facilitates
+a successful migration. Wide distribution makes migration more difficult (assuming the
+migration scope spans these distributed groups).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP02 Processes and procedures have identified owners
+
+Understand who has ownership of the definition of individual processes and procedures,
+why those specific process and procedures are used, and why that ownership exists. To better
+identify improvement opportunities, understand the reasons that specific processes and
+procedures are used.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP03 Operations activities have identified owners responsible for their performance
+
+Understand who has responsibility to perform specific activities on defined workloads
+and why that responsibility exists. Understanding who has responsibility to perform
+activities informs who conducts the activity, validates the result, and provides feedback to
+the owner of the activity.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP04 Create a Cloud Center of Excellence team
+
+Understand the responsibilities of your role and how you contribute to business
+outcomes, as this knowledge informs the prioritization of your tasks and why your role is
+important. This understanding helps team members recognize needs and respond appropriately.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP05 Mechanisms exist to request process additions, changes, and exceptions
+
+You are able to make requests to owners of processes, procedures, and resources. Make
+informed decisions to approve requests where they have been deemed viable and appropriate
+after an evaluation of benefits and risks.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP06 Both companies have identified the cloud skills and competencies to enable the resources
+
+Identify gaps between required skills and competencies and what is presently available
+in the organization. For existing staff, provide access to training courses of different
+types (both classroom-based and online courses). Encourage staff to obtain certification on
+cloud competencies to validate their knowledge.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS02.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS02.md
@@ -1,0 +1,49 @@
+# MAOPS02 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 4
+
+---
+
+## MAOPS02-BP01 Each company has identified their primary Region
+
+For many services, you can choose an AWS Region that specifies where your resources
+are managed. Regions are sets of AWS resources located in the same geographical area. You
+don't need to choose a Region for the AWS Management Console or for some services, such as AWS Identity and Access Management.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+## MAOPS02-BP02 Configure AWS Control Tower, AWS Config, and AWS CloudFormation
+
+AWS Control Tower offers the easiest way to set up and govern a secure, multi-account AWS
+environment. It establishes a landing zone that is based on best-practices blueprints, and
+it enables governance using guardrails you can choose from a pre-packaged list.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+## MAOPS02-BP03 Automate infrastructure as code (IaC) using Cloud Formation or Terraform
+
+AWS CloudFormation helps you model, provision, and manage AWS and third-party resources by
+treating infrastructure as code.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+## MAOPS02-BP04 Automate resource compliance using tools like AWS Config
+
+AWS Config is a config tool that helps you assess, audit, and evaluate the configurations
+and relationships of your resources.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS03.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS03.md
@@ -1,0 +1,68 @@
+# MAOPS03 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS03-BP01 Structure your organization following AWS best practices
+
+A well-architected multi-account strategy helps you innovate faster in AWS, while
+helping you meet your security and scalability needs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP02 Merge the management accounts of both organizations
+
+Consolidated billing is a feature of AWS Organizations. You can use the management account of
+your organization to consolidate and pay for all member accounts. In consolidated billing,
+management accounts can also access the billing information, account information, and
+account activity of member accounts in their organization. This information may be used for
+services such as AWS Cost Explorer, which can help management accounts improve their organization’s
+cost performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP03 Determine if it's appropriate to separate management accounts
+
+If there is a use case to keep OUs separate, you can certainly do that with multiple
+management accounts. There may be few reasons to keep Organizations separate:
+
+- AWS GovCloud (US) or commercial cloud
+- Differing financial needs, including taxation (Europe compared to the US)
+- Differing operating scope (Systems Manager)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP04 Merge logging, security, and infrastructure organizations
+
+The approach covered in this pattern is suitable for customers who have multiple
+AWS accounts with AWS Organizations and are now encountering challenges when using AWS Control Tower, a
+landing zone, or account vending machine services to set up baseline guardrails in their
+accounts.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP05 Define a backup strategy for each organization
+
+Use AWS Backup to create backup plans that define how to back up your AWS resources.
+The rules in the plan include a variety of settings, such as backup frequency, the time
+window during which the backup occurs, the AWS Region containing the resources to back up,
+and the vault in which to store the backup.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS04.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS04.md
@@ -1,0 +1,63 @@
+# MAOPS04 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS04-BP01 Standardize documented operational processes (like CI/CD and deployment)
+
+Organizations incur operational tech debt during mergers and acquisitions.
+Organizations should remove manual processes and focus on automation.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP02 Retire or consolidate redundant apps and data-stores
+
+Perform technical analysis during mergers and acquisitions. Otherwise, data and systems
+can be duplicated, or even potentially orphaned. Both organizations should agree on a
+consistent data model, consistent accesses, and compliance needs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP03 Have a process in place for customer migration (if necessary)
+
+Customer retention and migration is of utmost importance during mergers and
+acquisitions. It is critical to support existing customers with optimal costs and negligible
+impact. The AWS ISV Workload Migration Program (WMP) supports software partners that have
+a SaaS offering on AWS to drive and deliver workload migrations. Use funding, technical
+enablement, and go-to-market support to rapidly migrate customers to your SaaS offering.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP04 Understand third-party integrations and dependencies
+
+It might happen that companies merge or multiple platforms get developed over time and
+duplicate some of the same needed subsystems. Being service oriented and consolidating
+services reduces the amount of code to be maintained.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP05 Perform all customizations through configuration, and change them as self-serve or company-controlled feature flags
+
+Customizations that are done with configuration do not require a code recompile or
+reload. It is a way to get away from the legacy practice of making hard-coded customizations
+per individual customers or segments. Use feature flags that are temporary or permanent.
+These flags help during testing or canary release.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS05.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS05.md
@@ -1,0 +1,66 @@
+# MAOPS05 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS05-BP01 Configure AWS resource tags
+
+AWS resources can be tagged for a variety of purposes, from implementing a cost
+allocation strategy to supporting automation or authorizing access to AWS resources.
+Implementing a tagging strategy can be challenging for some organizations, owing to the
+number of stakeholder groups involved and considerations such as data sourcing and tag
+governance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP02 Group applications based on tags
+
+A tag is a label that you assign to an AWS resource. A tag consists of a key and a
+value, both of which you define. For example, if you have two EC2 instances, you might
+assign both a tag key of `Stack`. But the value of `Stack` might be
+`Testing` for one and `Production` for the other.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP03 Associate tags with each configured resource (during provisioning)
+
+AWS CloudFormation provides a common language for provisioning all the infrastructure resources
+in your AWS environment. For AWS resources using CloudFormation templates, you can use the CloudFormation
+Resource Tags property to apply tags to supported resource types upon creation. Managing the
+tags as well as the resources with IaC helps create consistency.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP04 Set up security based on tags
+
+Organizations have varying needs and obligations to meet regarding the appropriate
+handling of data storage and processing. Data classification is an important precursor for
+several use cases, such as access control, data retention, data analysis, and compliance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP05 Perform cost allocation based on tags
+
+The AWS-generated tag created by is a tag that AWS defines and applies to supported
+AWS resources for cost allocation purposes. User-defined tags are tags that you define,
+create, and apply to resources. After you have created and applied the user-defined tags,
+you can activate by using the AWS Cost Management Console for cost allocation tracking.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS06.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS06.md
@@ -1,0 +1,38 @@
+# MAOPS06 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 3
+
+---
+
+## MAOPS06-BP01 The seller has an extensive list of all IP and key innovations (and related documentation)
+
+Use industry domain knowledge, as well as patentable and other relevant code
+innovations, to create a platform offering that is truly unique and valuable to customers.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-6.html*
+
+---
+
+## MAOPS06-BP02 Document open-source software integrations
+
+Continually evolve your underlying code base to build up capabilities that use
+open-source software where appropriate.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-6.html*
+
+---
+
+## MAOPS06-BP03 Hold patents on key platform technologies
+
+Patents are a way to secure your rights to innovative technologies that keep you in a
+competitive position.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-6.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS07.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS07.md
@@ -1,0 +1,58 @@
+# MAOPS07 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS07-BP01 Document duplicate workloads and features
+
+Keep a centralized list of work that could be epic-level ideas down to more detailed
+work for features, bugs, technical debt, and innovative advances.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP02 Identify the impact of product features on customers from both companies
+
+A company should be looking beyond the current near-term features going in to
+strategically plan out longer term initiatives and how they can be ordered to create a
+compelling list of innovations.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP03 Document a combined-products strategy
+
+Identify products to be retired, maintained, or enhanced. Document customer impact and
+migration plan in case of product or workload decommission.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP04 Verify that teams understand critical customer requirements
+
+Increased decomposition for engineering tasks corresponds to increased probability of
+success. You can properly scope the effort in terms of cost, time, and resources needed, and
+define a definition for completion of work.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP05 Modify your existing roadmap to incorporate the new organization
+
+Define the new product roadmap that aligns with the combined companies’ goals.
+Determine customer impact based on product priorities.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS08.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS08.md
@@ -1,0 +1,40 @@
+# MAOPS08 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 3
+
+---
+
+## MAOPS08-BP01 Document mechanisms for both product teams to operate collaboratively
+
+Understanding deal rationale (for example, to acquire new capabilities or to capture
+market share). It's important for product teams from both companies to work closely to
+achieve the unified organization's goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-8.html*
+
+---
+
+## MAOPS08-BP02 Verify that key product teams have a post-integration product strategy in place
+
+Ensure product teams from both companies understand combined product strategy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-8.html*
+
+---
+
+## MAOPS08-BP03 Review, retire, and promote products and roadmaps based on customer focus
+
+Product managers speak to customers regularly. The teams collaborate on the analyzed
+findings, and experimentation at scale is performed using well-known mechanisms. Manage data
+and cloud-enabled offerings that deliver repeatable value to internal and external customers
+as products through their lifecycles.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-8.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS09.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAOPS09.md
@@ -1,0 +1,19 @@
+# MAOPS09 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 1
+
+---
+
+## MAOPS09-BP01 Create a Configuration Management Database (CMDB) or infrastructure repository
+
+Implement automated mechanisms to update data and maintain data accuracy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-9.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAPERF01.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAPERF01.md
@@ -1,0 +1,51 @@
+# MAPERF01 — Performance efficiency
+
+**Pillar**: Performance Efficiency  
+**Best Practices**: 5
+
+---
+
+## MAPERF01-BP01 Understand the available services and resources
+
+Explore the wide range of services and resources available in the cloud. Identify the relevant services and configuration options for your workload, and determine how to achieve optimal performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP02 Define a process for architectural choices
+
+Define a process to choose resources and services by using internal experience and knowledge of the cloud or external resources such as published use cases, relevant documentation, or whitepapers. You should define a process that encourages experimentation and benchmarking with any services that could be used in your workload.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP03 Factor cost requirements into decisions
+
+Workloads often have cost requirements for operation. Use internal cost controls to select resource types and sizes based on predicted resource need.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP04 Use guidance from your cloud provider or an appropriate partner
+
+Use cloud company resources, such as solutions architects, professional services, or an appropriate partner to guide your decisions. These resources can help review and improve your architecture for optimal performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP05 Benchmark workloads from both organization
+
+Benchmark the performance of an existing workload to understand how it performs in the cloud. Use the data collected from benchmarks to make architectural decisions.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAPERF02.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAPERF02.md
@@ -1,0 +1,43 @@
+# MAPERF02 — Performance efficiency
+
+**Pillar**: Performance Efficiency  
+**Best Practices**: 4
+
+---
+
+## MAPERF02-BP01 Scale current architecture and hosting through manual or automatic means
+
+Take progressive steps to achieve scaling.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+## MAPERF02-BP02 Remediate bottlenecks that prevent scaling, and use utomatic scaling or serverless resources when appropriate
+
+Serverless technologies feature automatic scaling, built-in high availability, and a pay-for-use billing model to increase agility. Serverless technologies reduce infrastructure management tasks like capacity provisioning. For more detail, see [Serverless on AWS](https://aws.amazon.com/serverless/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+## MAPERF02-BP03 Perform periodic static provisioning for peak usage in reaction to monitoring data
+
+Review historical data to understand peak usage days and time. Manually pre-provision resources based on historical data findings.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+## MAPERF02-BP04 Rearchitect to scale for new customers
+
+Cloud solutions architects should ideally build an architecture with the future in mind, meaning their solutions need to cater to current scale requirements as well as the anticipated growth of the solution. This growth can be either the organic growth of a solution, or it could be related to a merger and acquisition scenario where its size is increased dramatically within a short period of time.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAREL01.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAREL01.md
@@ -1,0 +1,43 @@
+# MAREL01 — Reliability
+
+**Pillar**: Reliability  
+**Best Practices**: 4
+
+---
+
+## MAREL01-BP01 Incorporate fault tolerance to achieve high availability as required for your industry vertical and customer expectations
+
+These are two important concepts in the concept of availability. *Fault tolerance* is the ability to withstand subsystem failure and maintain availability (working properly within an established SLA). To implement fault tolerance, workloads use spare (or redundant) subsystems. *Fault isolation* minimizes the scope of impact when a failure does occur. This is typically implemented with modularization. Workloads are broken down into small subsystems that fail independently and can be repaired in isolation.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+## MAREL01-BP02 Establish SLAs, including DR RTO and RPO for the combined organization
+
+Critical platforms require high availability. It is advised to achieve the maximum required availability at a reasonable cost that meets customer and business needs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+## MAREL01-BP03 Establish a deployment strategy for combined company
+
+AWS provides a number of tools to simplify and automate the provisioning of infrastructure and deployment of applications. Each deployment service offers different capabilities for managing applications. To build a successful deployment architecture, evaluate the available features of each service against the needs your application and organization.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+## MAREL01-BP04 Establish an SRE team and process for the combined organization.
+
+Site reliability engineering (SRE) is the practice of using software tools to automate IT infrastructure tasks such as system management and application monitoring. Organizations use SRE to keep their software applications reliable amidst frequent updates from development teams.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAREL02.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MAREL02.md
@@ -1,0 +1,27 @@
+# MAREL02 — Reliability
+
+**Pillar**: Reliability  
+**Best Practices**: 2
+
+---
+
+## MAREL02-BP01 Establish alternatives for each critical external service to switch over to if needed, or balance traffic across
+
+Amazon API Gateway can be used to front calls to backend external services and handle failover if problems are detected with the primary service.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-2.html*
+
+---
+
+## MAREL02-BP02 Have legal agreements in place guaranteeing the right of continued usage of all external services
+
+As an example, see [AWS Service Terms](https://aws.amazon.com/service-terms/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC01.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC01.md
@@ -1,0 +1,51 @@
+# MASEC01 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC01-BP01 Use a centralized identity provider
+
+At any given time, you can have only one directory or one SAML 2.0 identity provider connected to IAM Identity Center. But, you can change the identity source that is connected to a different one.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP02 Use a common authorization approach
+
+Companies may have a very different approach to authorization. Companies need to use a common authorization platform and develop consistent authorization policies for the combined systems.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP03 Use AWS temporary credentials
+
+You can use the AWS Security Token Service to create and provide trusted users with temporary security credentials that can control access to your AWS resources.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP04 Store and use secrets securely
+
+Use AWS Secrets Manager to replace hardcoded credentials in your code, including passwords, with an API call to Secrets Manager to retrieve the secret programmatically. The secret can't be compromised by someone examining your code because the secret no longer exists in the code.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP05 Create a common policy for auditing and rotating credentials
+
+Rotation is the process of periodically updating a secret. When you rotate a secret, you update the credentials in both the secret and the database or service. In Secrets Manager, you can set up automatic rotation for your secrets.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC02.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC02.md
@@ -1,0 +1,51 @@
+# MASEC02 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC02-BP01 Use an AWS-defined process to report vulnerabilities
+
+AWS takes security very seriously and investigates all reported vulnerabilities (for more detail, see [AWS Cloud Security](https://aws.amazon.com/security/)).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP02 Use AWS services with self-service within the existing management console
+
+On AWS, you can automate manual security tasks so you can shift your focus to scaling and innovating your business.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP03 Use third-party security tools when necessary due to integration with on-premises resources
+
+Amazon Security Lake is a fully-managed security data lake service. You can use Security Lake to automatically centralize security data from AWS and third-party sources into a data lake that's stored in your AWS account. Security Lake helps you analyze security data, so you can get a more complete understanding of your security posture across the entire organization. You can also use Security Lake to improve the protection of your workloads, applications, and data.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP04 Migrate to a common set of tools, including partner tools from marketplace
+
+The AWS Shared Responsibility Model (SRM) makes it easy to understand various choices for protecting unique AWS environment, and [access partner resources](https://aws.amazon.com/partners/featured/security/) that can help you implement end-to-end security quickly and easily.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP05 Create a common policy for auditing and rotating credentials
+
+For human identities, you should require users to change their passwords periodically and retire access keys in favor of temporary credentials. For machine identities, rely on temporary credentials using IAM roles. For situations where this is not possible, frequent auditing and rotating access keys is necessary.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC03.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC03.md
@@ -1,0 +1,51 @@
+# MASEC03 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC03-BP01 Standardize root email address (root account email access)
+
+When you first create an AWS account, you begin with a single sign-in identity that has complete access to all AWS services and resources in the account. This identity is called the AWS account root user and is accessed by signing in with the email address and password that you used to create the account. Ensure uninterrupted access to root email after a merger or acquisition.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP02 Define data access control mechanisms for combined systems
+
+Both organizations need a common set of privacy controls and access to data. AWS is built with comprehensive data protection in the cloud.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP03 Create a consistent mechanism for data classification and protection (in-transit and at rest)
+
+Before creating any workload, foundational practices that influence security should be in place. For example, data classification provides a way to categorize data based on levels of sensitivity, and encryption protects data by rendering it unintelligible to unauthorized access. These methods are important because they support objectives such as preventing mishandling or complying with regulatory obligations.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP04 Automate data backup process for combined systems
+
+A comprehensive backup strategy is an essential part of an organization’s data protection plan to withstand, recover from, and reduce any impact that might be sustained because of a security event. Create an extensive backup strategy that defines which data must be backed up, how often data must be backed up, and how backup and recovery tasks are monitored.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP05 Automate responses to data security events
+
+AWS encourages you to use automation to help quickly detect and respond to security events within your AWS environments. In addition to increasing the speed of detection and response, automation also helps you scale your security operations as you expand your workloads running on AWS. Do you have automation process defined on both organizations?
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC04.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC04.md
@@ -1,0 +1,43 @@
+# MASEC04 — Security
+
+**Pillar**: Security  
+**Best Practices**: 4
+
+---
+
+## MASEC04-BP01 The seller is using AWS services (marketplace) for data governance
+
+Data governance is a framework to build data quality checks, identify lineage (relation) between target and source datasets, and build a data catalog over existing data in data lakes and enterprise data warehouses.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+## MASEC04-BP02 Document consistent mechanisms for data classification
+
+Ensure organizations are using AWS-supported partner solutions.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+## MASEC04-BP03 Document processes to maintain data integrity within AWS services
+
+Regulatory requirements to maintain the integrity of data are typically implemented as part of a validated application. However, by implementing controls at the AWS service-level, you can facilitate data integrity even for actions performed outside the validated application.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+## MASEC04-BP04 Understand both the buyer's and seller's compliance needs
+
+AWS supports inheritance of many security standards and compliance certifications, including PCI-DSS, HIPAA/HITECH, FedRAMP, GDPR, FIPS 140-2, and NIST 800-171, which helps you satisfy necessary compliance requirements.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC05.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASEC05.md
@@ -1,0 +1,51 @@
+# MASEC05 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC05-BP01 Both organizations have documented network architecture
+
+Network documentation includes written charts, drawings, records, and instructions of networking procedures, layouts, and information on your installed production or development network.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP02 Define a strategy for overlapping Classless Inter-Domain Routing (CIDR)
+
+In order to plan your prefix summarization and create your routing design, you should understand the IP addressing scheme of the merging or divesting companies.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP03 Define a connectivity model for post-integration or divestiture
+
+The network connectivity layer holds an enterprise’s entire IT ecosystem together. Furthermore, creating the right connectivity model is a critical step toward planning your merger, acquisition, or divestiture.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP04 Define a strategy for inter-enterprise DNS resolution
+
+DNS is the typical way how users connect to applications and also how various components of an application may communicate with each other.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP05 Define a security strategy for data flowing between the two enterprises
+
+It is important to establish a secure communication between two enterprises for data transfer.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASUS01.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASUS01.md
@@ -1,0 +1,68 @@
+# MASUS01 — Sustainability
+
+**Pillar**: Sustainability  
+**Best Practices**: 5
+
+---
+
+## MASUS01-BP01 Perform due diligence
+
+Thoroughly investigate the acquired
+company's sustainability practices, including their
+environmental impact, social responsibility, and governance.
+Identify areas of alignment and improvement.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP02 Establish clear sustainability objectives
+
+Define the sustainability
+goals and targets that you want the acquired company to achieve.
+Ensure that these objectives align with your organization's
+sustainability strategy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP03 Integrate sustainability into the acquisition process
+
+Incorporate
+sustainability considerations into the due diligence process and
+valuation of the company. This could include assessing the
+company's carbon footprint, energy usage, supply chain
+practices, and community engagement.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP04 Communicate expectations
+
+Communicate your sustainability
+expectations and requirements to the acquired company's
+management and employees. Educate on the importance of
+sustainability and the required commitment to achieving your
+organization's goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP05 Provide resources and support
+
+Provide the acquired company with the
+necessary resources and support to achieve your sustainability
+objectives. Include training, funding for
+sustainability initiatives, or access to experts in the field.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASUS02.md
+++ b/powers/wa-review/steering/references/lenses/mergers-and-acquisitions/MASUS02.md
@@ -1,0 +1,74 @@
+# MASUS02 — Sustainability
+
+**Pillar**: Sustainability  
+**Best Practices**: 5
+
+---
+
+## MASUS02-BP01 Establish a sustainability committee
+
+Create a team of individuals from both
+organizations to oversee sustainability initiatives during the
+integration process. This committee should develop a plan for
+integrating sustainability into the new organization's
+operations and ensure that it remains a priority.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP02 Conduct a sustainability audit
+
+Before the acquisition, conduct a thorough
+audit of each organization's sustainability practices to
+identify areas of strength and weakness. This audit helps you
+understand the current state of sustainability within the
+organization and identifies opportunities for improvement.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP03 Communicate the importance of sustainability
+
+Communicate the importance of
+sustainability to all employees, stakeholders, and customers.
+Make sure everyone understands why sustainability is important
+and how it fits into the organization's long-term goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP04 Integrate sustainability into the integration plan
+
+Incorporate sustainability
+into the overall integration plan. This may involve developing
+new policies and procedures, identifying areas where
+sustainability can be improved, and setting goals and metrics
+for sustainability performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP05 Monitor and evaluate sustainability performance
+
+Regularly monitor and
+evaluate the organization's sustainability performance to ensure
+that progress is being made. This may involve collecting data on
+energy usage, waste generation, and other sustainability metrics
+and using this data to identify areas for improvement.
+
+For further details on sustainability, see
+[Sustainability
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/powers/wa-review/steering/wa-review.md
+++ b/powers/wa-review/steering/wa-review.md
@@ -336,6 +336,8 @@ Available lenses:
 - `references/lenses/streaming-media/` — media streaming, live/VOD delivery, encoding, content workflows
 - `references/lenses/iot/` — IoT devices, telemetry, edge computing, fleet provisioning, OTA updates
 - `references/lenses/government/` — public sector, privacy-by-design, compliance, real-time security
+- `references/lenses/mergers-and-acquisitions/` — M&A due diligence, multi-account/multicloud governance, integration, technical debt, post-acquisition cost & security
+- `references/lenses/maori-data/` — Māori data governance, data sovereignty, Te Ao Māori principles, indigenous data protection & retention
 
 ## Step 5: Risk Assessment
 

--- a/scripts/crawl-wa-framework.py
+++ b/scripts/crawl-wa-framework.py
@@ -62,6 +62,7 @@ import sys
 import time
 import urllib.request
 import urllib.error
+import urllib.parse
 from collections import defaultdict
 from pathlib import Path
 
@@ -238,6 +239,20 @@ def fetch(url: str, retries: int = 3) -> str | None:
     headers = {
         "User-Agent": "Mozilla/5.0 (compatible; WA-Skills-Crawler/1.0)"
     }
+    # Percent-encode any non-ASCII characters in the URL. Some lens pages have
+    # them in their path (e.g. the Māori Data lens: ".../md_ops-1-...māori...html"),
+    # and http.client can only put an ASCII request line on the wire — a raw
+    # non-ASCII URL raises UnicodeEncodeError before the request is even sent.
+    # safe="/%..." preserves path separators and any already-encoded octets so
+    # ASCII URLs pass through byte-for-byte unchanged.
+    split = urllib.parse.urlsplit(url)
+    url = urllib.parse.urlunsplit((
+        split.scheme,
+        split.netloc,
+        urllib.parse.quote(split.path, safe="/%~:@!$&'()*+,;="),
+        urllib.parse.quote(split.query, safe="/%~:@!$&'()*+,;=?"),
+        split.fragment,
+    ))
     for attempt in range(retries):
         try:
             req = urllib.request.Request(url, headers=headers)

--- a/scripts/crawl-wa-framework.py
+++ b/scripts/crawl-wa-framework.py
@@ -546,9 +546,27 @@ def discover_leaf_pages(toc_json: dict, pillar_sections: list[str] | None = None
         "Performance efficiency", "Cost optimization", "Sustainability",
     ]
 
+    def _normalize_pillar_text(s: str) -> str:
+        # Make pillar matching locale-agnostic. Some lenses deviate from the
+        # canonical US-English, unsuffixed pillar names the buckets are keyed on:
+        #   - British spelling: Māori lens uses "Cost optimisation" (vs
+        #     "Cost optimization"); without folding "optimis" -> "optimiz" that
+        #     whole pillar's leaves are silently dropped.
+        #   - trailing "pillar" suffix: government lens uses "Operational
+        #     excellence pillar".
+        # Fold case, reconcile the British "-isation" spelling, and drop a
+        # trailing " pillar" so a title matches regardless of these variations.
+        s = s.replace("\xa0", " ").strip().lower()
+        s = s.replace("optimis", "optimiz")
+        if s.endswith(" pillar"):
+            s = s[: -len(" pillar")]
+        return s
+
     def matches_pillar(title):
-        tl = title.lower()
-        return next((p for p in pillar_names if p.lower() in tl), None)
+        tl = _normalize_pillar_text(title)
+        return next(
+            (p for p in pillar_names if _normalize_pillar_text(p) in tl), None
+        )
 
     # A numbered-question branch title, e.g. "1 – Monitor the health..." or
     # "11 – Choose cost-effective compute and storage...". These sit between a

--- a/scripts/test_crawl_wa_framework.py
+++ b/scripts/test_crawl_wa_framework.py
@@ -1,0 +1,109 @@
+"""Regression tests for the topic-page crawler's pillar detection (issue #80).
+
+Stdlib unittest, no network, no AWS, no third-party deps. Uses small inline
+toc-contents.json fixtures that reproduce the structural variations found in
+real lens TOCs. Run with either:
+    python3 -m unittest scripts/test_crawl_wa_framework.py
+    cd scripts && python3 -m pytest test_crawl_wa_framework.py -q
+
+Focus: discover_leaf_pages must bucket leaves under the correct WA pillar even
+when a lens deviates from the canonical US-English, unsuffixed pillar names:
+  - British spelling ("Cost optimisation")  -- Māori lens
+  - trailing "pillar" suffix                -- government lens
+  - a pillar expressed as a single content page (pillar-as-leaf)
+  - generic scaffolding pages (Resources/Definitions/...) stay excluded
+American-spelling lenses must keep behaving exactly as before (no regression).
+"""
+
+import importlib.util
+import os
+import unittest
+
+# The crawler module's filename has hyphens, so import it by path.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "crawl-wa-framework.py")
+_spec = importlib.util.spec_from_file_location("crawl_wa_framework", _SCRIPT)
+cwf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cwf)
+
+
+def leaf(title, href):
+    return {"title": title, "href": href}
+
+
+def branch(title, children, href=""):
+    return {"title": title, "href": href, "contents": children}
+
+
+def sections(pages):
+    """Map section -> sorted list of captured hrefs."""
+    out = {}
+    for p in pages:
+        out.setdefault(p["section"], []).append(p["href"])
+    return {k: sorted(v) for k, v in out.items()}
+
+
+class TestPillarMatching(unittest.TestCase):
+    def test_british_spelling_cost_optimisation_is_captured(self):
+        """Māori lens uses 'Cost optimisation'; its leaf must bucket as
+        'Cost optimization' (issue #80 root cause #2) rather than being dropped."""
+        toc = {"contents": [
+            branch("Cost optimisation", [
+                leaf("MD_CO 1 Understand costs", "md_cos-1.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertIn("Cost optimization", secs)
+        self.assertEqual(secs["Cost optimization"], ["md_cos-1.html"])
+
+    def test_trailing_pillar_suffix_matches(self):
+        """government lens uses 'Operational excellence pillar' (suffix)."""
+        toc = {"contents": [
+            branch("Operational excellence pillar", [
+                leaf("GOVOPS 1 How do you...", "govops-1.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs.get("Operational excellence"), ["govops-1.html"])
+
+    def test_pillar_as_leaf(self):
+        """A pillar expressed as a single content page (no child BPs) is captured
+        under its own name (e.g. Māori 'Performance efficiency')."""
+        toc = {"contents": [
+            leaf("Performance efficiency", "performance-efficiency.html"),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs.get("Performance efficiency"),
+                         ["performance-efficiency.html"])
+
+    def test_generic_and_custom_pages_excluded(self):
+        """Generic scaffolding (Resources/Definitions) and non-pillar custom
+        sections (Te Ao Māori principles) are not captured."""
+        toc = {"contents": [
+            leaf("Definitions", "definitions.html"),
+            leaf("Te Ao Māori principles", "te-ao-maori.html"),
+            branch("Security", [
+                leaf("MD_SEC 1 How is data protected?", "md_sec-1.html"),
+                leaf("Resources", "md_sec-resources.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs, {"Security": ["md_sec-1.html"]})
+        all_hrefs = {h for hs in secs.values() for h in hs}
+        self.assertNotIn("definitions.html", all_hrefs)
+        self.assertNotIn("te-ao-maori.html", all_hrefs)
+        self.assertNotIn("md_sec-resources.html", all_hrefs)
+
+    def test_american_spelling_unchanged(self):
+        """Canonical US-English 'Cost optimization' still matches — the
+        normalization must be additive, never altering existing behavior."""
+        toc = {"contents": [
+            branch("Cost optimization", [
+                leaf("1 – Choose cost-effective resources", "co-1.html"),
+            ]),
+        ]}
+        secs = sections(cwf.discover_leaf_pages(toc))
+        self.assertEqual(secs.get("Cost optimization"), ["co-1.html"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/wa-review/SKILL.md
+++ b/skills/wa-review/SKILL.md
@@ -356,6 +356,8 @@ Available lenses:
 - `references/lenses/streaming-media/` — media streaming, live/VOD delivery, encoding, content workflows
 - `references/lenses/iot/` — IoT devices, telemetry, edge computing, fleet provisioning, OTA updates
 - `references/lenses/government/` — public sector, privacy-by-design, compliance, real-time security
+- `references/lenses/mergers-and-acquisitions/` — M&A due diligence, multi-account/multicloud governance, integration, technical debt, post-acquisition cost & security
+- `references/lenses/maori-data/` — Māori data governance, data sovereignty, Te Ao Māori principles, indigenous data protection & retention
 
 ## Step 5: Risk Assessment
 

--- a/skills/wa-review/references/lenses/maori-data/cost-optimization.md
+++ b/skills/wa-review/references/lenses/maori-data/cost-optimization.md
@@ -1,0 +1,38 @@
+# Cost optimization
+
+**Pillar**: Cost Optimization  
+**Pages**: 1
+
+---
+
+# MD_CO 1 Understand costs associated with infrastructure options
+
+- **MD_CO01-BP01: How are you presenting the costs/benefit tradeoffs
+for infrastructure options?** Clearly present the cost to benefit trade-offs
+when looking at all infrastructure options. When designing technology solutions,
+organisations need to balance delivering functional and non-functional requirements with
+the cost associated with doing so. It is important that the cost to benefit ratio is
+assessed and understood. The assessment should take into account the strategic drivers for
+the organisation. Within the public sector, for example, value-for-money in terms of
+social, environmental, and public benefits is important. For some Māori customers,
+security, resilience, and sustainability may be key considerations.
+
+An example may be an organisation wanting to store data close to the source for
+latency reasons. An AWS Outpost can help meet those requirements. An AWS Outpost
+is a managed service that extends AWS infrastructure, services, APIs, and tools to
+customer premises. However, there are several considerations when using an AWS
+Outpost. An Outpost has a limited set of AWS services available compared to the 200+
+services available in an AWS Region. This consideration may impact how you design
+your architecture. An AWS Outpost is a physical device that needs to be built,
+shipped, and installed within a datacentre that meets certain physical requirements.
+This can be done with a third-party data centre, but there is a cost associated with
+renting space.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_cos-1-understand-cost.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/maori-data/operational-excellence.md
+++ b/skills/wa-review/references/lenses/maori-data/operational-excellence.md
@@ -1,0 +1,221 @@
+# Operational excellence
+
+**Pillar**: Operational Excellence  
+**Pages**: 3
+
+---
+
+# MD_OPS 1: How do you incorporate Māori views into your technology governance and operations?
+
+Where appropriate, the Māori world view (te ao Māori) and Māori knowledge and
+understanding (mātauranga Māori) could be incorporated into an organisation's way of operating
+its technology in support of Māori customers. Sometimes this cannot be done as easily as
+performing operations as code, instead it may require active and ongoing collaboration with Māori.
+Understanding Māori interests and considerations relating to data collection, processing, and
+storage, as well as how those interests are evolving, helps you make informed technology
+decisions both in the interim and the long-term.
+
+- **MD_OPS01-BP01:**
+**Incorporate mātauranga Māori into your operational processes when it
+relates to Māori data.** There are several ways of doing this. Work directly
+with your Māori customer or accessible internal and external Māori advisers to help
+develop your organisation's understanding of te ao Māori.
+- **MD_OPS01-BP02:**
+**Consider governance and accountability over Māori data.**
+Consider incorporating specific accountabilities for Māori data into pre-existing roles in
+your organisation, such as Chief Information Officer (CIO), Chief Information Security
+Officer, or Chief Data Officer (CDO). Formalising these accountabilities and
+responsibilities into position descriptions can prioritise Māori data considerations at
+the executive level.
+- **MD_OPS01-BP03:**
+**Consider how you can incorporate international data management
+principles into your data governance framework**. Some examples of
+international data management principles include Findability, Accessibility,
+Interoperability, Reuse (FAIR), which were developed for scientific data management and
+stewardship.
+- **MD_OPS01-BP04:**
+**Consider how to supplement your knowledge for example through using
+Māori cultural advisers at the appropriate time**. Build your network of Māori
+advisers externally to your organisation, which you can engage with on particular
+technology projects. AWS has a growing list of advisers in the Amazon Partner Network.
+Working with external advisers also helps you develop your internal capabilities.
+- **MD_OPS01-BP05:**
+**Develop longer-term policies and procedures.** Consider how
+to gradually develop the internal competencies and capabilities in your organisation as
+you continue to work with Māori customers. This can help you set your organisation's or
+your customer's overall data policies and processes with respect to collecting, storing,
+processing, and handling Māori data. Raising awareness and understanding of this across
+your technology staff and suppliers can help inform design decisions for handling Māori
+data, but this may be a long-term process.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_ops-1-how-do-you-incorporate-māori-views-into-your-technology-governance-and-operations.html*
+
+---
+
+# MD_OPS 2: How can you design data collection with your Māori customer(s) in mind?
+
+Organisations collect and process data to support the delivery of products and services
+to customers, stakeholders, and citizens. Data collection occurs in many ways, including
+filling in a digital form on a website, sensors capturing environmental data like temperature
+or water flow rates, or a research team capturing data from participants in a university
+study. Organisations need to consider what data they are collecting, the purpose for
+collecting the data, and, in the case of personal information, to adhere to the New Zealand
+Privacy Act 2020. For additional considerations around the collection of personal information,
+see [Using AWS in the Context of New Zealand Privacy Considerations](https://d1.awsstatic.com/whitepapers/compliance/Using_AWS_in_the_context_of_New_Zealand_Privacy_Considerations.pdf).
+
+- **MD_OPS02-BP01:**
+**Consider adopting a privacy by design approach by designing and
+implementing mechanisms and processes that simplify compliance with the New Zealand
+Privacy Act 2020.** When collecting and handling personal information, make
+sure you comply with all applicable laws, such as the New Zealand Privacy Act 2020. You
+can design continuous and informed consent mechanisms that provide clear information to
+users about what personal information is being collected and for what purpose. Consider
+incorporating mechanisms that make it easier for users to revoke consent and to request
+access to, or correction of, their personal information. Maintain consent management over
+how you capture, store, and preserve personal information.
+- **MD_OPS02-BP02: Consider how you're communicating why you are
+collecting this data.** Make it clear to users why the data is being collected,
+how it is used, and how privacy is maintained on an ongoing basis. Customers can interact
+with your organisation multiple times, so communicating what data is collected, why it is
+collected, and how it is collected in the context of the interaction may help. Also
+consider when to communicate this. Some examples include:
+
+At the time a user registers or signs up to an organisation (for example, they
+sign up to a new bank, a new medical centre, or subscribe to a music streaming
+service).
+- At the time a user applies for a service from your organisation (for example,
+they apply for a home loan, book a medical exam, request a quote for home
+improvements, or apply for a government entitlement like a student loan).
+- At the time a user interacts with your organisation (for example, they lodge a
+complaint with a local council, submit an insurance claim, or request a change to a
+home loan).
+
+- **MD_OPS02-BP03: Consider important lineage and provenance of data
+that could be captured as additional data.** It may be helpful to capture and
+store lineage and provenance data, which could be included as metadata or a tag. This kind
+of additional data can provide additional context to the data, such as when it was
+collected, how it was collected and who was involved in the collection. Maintaining
+careful records of the data provenance can build trust in the integrity and authenticity
+of the data and from whom the data was derived. An example of this is a hapū's cultural
+archive which captures which whānau provided which cultural record. It could also apply to
+organisations conducting surveys of specific populations for the purpose of creating data
+sets or performing data analysis.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_ops-2-how-can-you-design-data-collection-with-your-māori-customers-in-mind.html*
+
+---
+
+# MD_OPS 3: How do you use or share Māori data back with Māori?
+
+Organisations use data in many different ways to design and deliver products and
+services. They can use it to gain insight and understanding of their organisation, their
+industry, and the wider world around them. Organisations should assess any legal and ethical
+implications when making decisions relating to how data will be used and shared.
+
+- **MD_OPS03-BP01: Collecting and separating Māori data
+appropriately**. Organisations can consider how to collect and separate data
+along different dimensions such as iwi and hapū or a Māori organisation. This may make data more relevant or
+useful to different groups or communities. This needs to be considered when designing your
+initial data collection plan to verify that the right data is collected and organised
+early. For example, a government agency may want to report on specific agency outcomes for
+Māori populations. If they captured an individual's hapū affiliations, they could report
+information at a hapū level. However, if they only captured an individual's record, then
+they can only report this at an individual level.
+- **MD_OPS03-BP02: Consider how your organisation could share Māori data
+back to Māori**. Data that your organisation holds could be used to better
+understand Māori communities and realise individual and collective benefits. Consider how
+you could identify useful data, and design ways to make data more accessible. Open data
+initiatives are one approach, but also remember the importance of complying with the
+Privacy Act 2020.
+- **MD_OPS03-BP03: Use tools to effectively and securely share data
+where there is a specific and appropriate purpose.** There are many approaches
+to sharing data. Consider tools to share data both publicly and privately, which fits the
+purpose for why that data is being shared and how it needs to be used. Share this data in culturally-appropriate ways, and avoid misappropriating that data or trying to create explanation around that data that isn't culturally-sensitive or informed. Seek advice from your Māori advisers if you are unsure how to do this. This includes open
+data portals or exchanges such as the AWS Open Data Registry, AWS Data Exchange, or private data
+portals hosted by your organisation. Consider solutions that allow data to be shared using
+different formats such as flat files, application programming interfaces (APIs), or
+interactive dashboards and visualisations to meet the needs of data consumers.
+- **MD_OPS03-BP04: Share data in ways that can be easily used by your
+various stakeholders**. Understand your Māori stakeholders, their interests in
+accessing and using the data you are sharing back with them, and how they use the data.
+This should drive your choice of format for that data. For example, graphs or
+visualisations published on your website can make data easy to find and understand, while
+data files such as comma-separated values files (CSV) or parquet are better for data
+analytics users. An API supports application-to-application integration. For example, a
+government agency may provide interactive graphs on their website so that anyone with a
+web browser can see graphs relating to key agency objectives. They may provide the data
+that sits behind the graphs in a CSV format so that people can download it and load it
+into a spreadsheet tool or analytics programme to build their own graphs or perform
+additional queries. They may also provide an open API so members of the public can
+retrieve the data and load into their own databases or analytics systems.
+- **MD_OPS03-BP05: Consider how your organisation could use federated
+data access methods.** Organisations often need to access data from other
+organisations to support a business process. Federated data approaches can allow
+organisations to access data from other organisations without the need to replicate or
+copy the data into your own systems. Federated data access models require appropriate
+mechanisms for making your organisations data discoverable and for securely sharing data.
+- **MD_OPS03-BP06: Define and implement appropriate authorisation
+mechanisms.** Design data access mechanisms that support both internal access
+and access for external third parties (for example, through federated data access or data
+sharing mechanism). Consider authorisation mechanisms including role-based access control
+(RBAC), attribute-based access control (ABAC), or policy-based access control (PBAC). The
+authorisation mechanism should provide ways to manage, grant, and revoke access and
+provide visibility into data access through auditing and logging. Establish appropriate
+governance processes to effectively manage the process for requesting, granting, and
+revoking access to data by verified, trusted, and approved external third parties.
+
+- **MD_OPS03-BP07: Incorporate responsible and ethical use of machine
+learning (ML) and artificial intelligence (AI) as a core part of your governance
+framework and development lifecycle.** ML and AI have transformational
+potential. It is already widely used for tasks such as transcription, translation, fraud
+detection, information security, search, and recommendation engines. At Amazon, we believe
+the design, development, and deployment of AI must respect the rule of law, human rights,
+and values of equity, privacy, and fairness. We are committed to developing fair and
+accurate AI services and providing customers with the tools and guidance needed to build
+applications responsibly. Developers and deployers of AI systems should ensure such
+systems are built based on principles of safety and responsibility by design. AWS builds
+AI with responsibility in mind at each stage of our comprehensive development process.
+Throughout design, development, deployment, and operations, we consider a range of factors
+including accuracy, fairness, appropriate usage, toxicity, security, safety, and privacy. Ask your Māori customers what particular ethical questions and principles they may want you to adopt as a part of your governance framework and development lifecycle. Regularly revisit and refine your AI ethics practices through ongoing dialogue and partnerships with Māori communities.
+- **MD_OPS03-BP08: Leverage vendor tools to provide AI
+transparency.** For example, AWS AI Service Cards deliver a form of
+transparency documentation that provide customers with a single place to find information
+on the intended use cases and limitations, responsible AI design choices, and deployment
+and performance optimisation best practices for our AI services. Amazon SageMaker AI Clarify detects
+and measures potential bias using a variety of metrics so developers can address potential
+bias and explain model predictions. Amazon's Responsible Use of Machine Learning Guide highlights key best practices and
+tooling that AI developers and deployers can use to mitigate risks across the lifecycle of
+an AI system.
+- **Other considerations:**
+
+**Discuss AI with stakeholders.** Artificial intelligence
+including generative AI and machine learning is a rapidly evolving area. Discuss the
+benefits and risks with your stakeholders. Your stakeholders may be internal to your
+organisation, external customers, or members of the public. Cross-functional expertise from technologists, ethicists, lawyers, domain experts, and external resources provides a holistic understanding and consideration of ethical, legal, and domain-specific factors. Customers should engage with Māori stakeholders early and continuously to understand their perspectives, concerns, and preferences regarding the use of certain data in AI/ML deployment and development. Employ Māori expertise in the design, development, and testing phases to verify cultural competence and alignment with tikanga.
+- **Consider potential inaccuracies.** Customers should consider potential inaccuracies in ML system results (especially concerning te reo Māori and Māori cultural concepts) and prepare a plan to address them, such as narrowing scope, introducing human oversight, or altering dependencies on the AI system. Customers should also consider incorporating appropriate testing of model outputs into the AI application creation process when model inputs or outputs are dealing with te reo Māori or Māori cultural concepts. Evaluation of outputs should be made by appropriately skilled people. To assess if an AI system operates as intended, it is important to use accurate and representative training data. AWS encourages specific policies and provides safeguards such as [Guardrails for Amazon Bedrock](https://aws.amazon.com/bedrock/guardrails/) to block harmful user inputs.
+- **Use case evaluation and testing.** Testing should
+include not just the AI system itself but also the overall process it is a part of,
+including decisions or actions that might be taken based on system output. Customers should consider evaluating models thoroughly on safety characteristics such as prompt stereotyping (like encoded biases for gender or socioeconomic status), factual knowledge, and toxicity. [FMEval](https://aws.amazon.com/blogs/machine-learning/evaluate-large-language-models-for-quality-and-responsibility/), an open source library is available in [Amazon SageMaker AI](https://aws.amazon.com/sagemaker/) for developing these insights. [Model evaluation is also available in Amazon Bedrock](https://aws.amazon.com/blogs/aws/amazon-bedrock-model-evaluation-is-now-generally-available/) for large language models (LLMs). Model outputs can be evaluated by a pool of human evaluators, or through an automated process. Customers can test performance through techniques like [red teaming](https://www-cdn.anthropic.com/82564d4ec2451b2eed2e0796b7c658fc989f0c1a/Anthropic_RedTeaming.pdf) and reinforcement learning from human feedback (RLHF). Customers should also consider continually evaluating performance and responsibility metrics before deployment and use tools like [SageMaker AI Model Monitor](https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html) to detect data drift and prompt retraining if needed.
+- **Continuous improvement and validation.** Monitoring for
+potential bias and accuracy, and for models performing as expected across different
+segments, is an important part of this process.
+- **Ongoing education.** AI is a constantly-evolving
+landscape, and new techniques, technologies, laws, and social norms continue to be
+developed and refined over time. It is essential that all parties involved with
+building and using AI systems stay educated on these issues and account for them in
+the design, deployment, and operation of their systems. Successful AI adoption requires significant cultural and organisational changes, including defining the roles and responsibilities required for accountability, and customers should verify that they are allowing Māori to make informed decisions about participation.
+
+For further reading, refer to the [AWS Machine
+Learning lens](https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/machine-learning-lens.html).
+
+AWS continues to update this information and share additional guidance to customers on
+the use of AI/ML. Please reach out to the team at AWS for further updates.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_ops-3-how-do-you-use-or-share-māori-data.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/maori-data/performance-efficiency.md
+++ b/skills/wa-review/references/lenses/maori-data/performance-efficiency.md
@@ -1,0 +1,56 @@
+# Performance efficiency
+
+**Pillar**: Performance Efficiency  
+**Pages**: 1
+
+---
+
+# Performance efficiency
+
+The [Performance Efficiency
+Pillar](https://docs.aws.amazon.com/wellarchitected/latest/performance-efficiency-pillar/welcome.html) addresses best practices for managing production environments. This document
+does not cover the design and management of non-production environments and processes, such as
+continuous integration or delivery. The Well-Architected Performance Efficiency Pillar provides
+an overview of design principles, best practices, and questions. If relevant, you can find
+guidance on implementation in the [Performance Efficiency
+Pillar whitepaper](https://docs.aws.amazon.com/wellarchitected/latest/performance-efficiency-pillar/welcome.html).
+
+The Performance Efficiency Pillar focuses on the efficient use of computing resources to
+meet requirements, and how to maintain efficiency as demand changes and technologies evolve.
+Following these design principles can help you achieve and maintain efficient workloads in the
+cloud.
+
+Design principles
+
+- **Democratise advanced technologies:** Make advanced technology
+implementation easier for your team by delegating certain tasks like the undifferentiated
+work to your cloud vendor. Rather than asking your IT team to learn about hosting and
+running a new technology, consider consuming the technology as a service. For example, NoSQL
+databases, media transcoding, and machine learning are all technologies that require
+specialised expertise. Learn and develop these expertise with [AWS Skill Builder](https://skillbuilder.aws/). In the cloud, these
+technologies become services that your team can consume, allowing your team to focus on
+product development rather than resource provisioning and management.
+- **Go global in minutes:** Deploying your workload in multiple
+AWS Regions around the world allows you to provide lower latency and a better experience
+for your customers at minimal cost.
+- **Use serverless architectures:** Serverless architectures
+remove the need for you to run and maintain physical servers for traditional compute
+activities. For example, serverless storage services can act as static websites (removing
+the need for web servers) and event services can host code. This removes the operational
+burden of managing physical servers, and can lower transactional costs because managed
+services operate at cloud scale.
+- **Experiment more often:** With virtual and automatable
+resources, you can quickly carry out comparative testing using different types of instances,
+storage, or configurations.
+- **Consider mechanical sympathy:** Use the technology approach
+that aligns best with your goals. For example, consider data access patterns when you select
+database or storage approaches.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/performance-efficiency.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/maori-data/reliability.md
+++ b/skills/wa-review/references/lenses/maori-data/reliability.md
@@ -1,0 +1,57 @@
+# Reliability
+
+**Pillar**: Reliability  
+**Pages**: 1
+
+---
+
+# MD_REL 1 How do you safely retain data for future generations?
+
+Māori data is often considered taonga, and it is critical that this data is available for
+future generations. Whakapapa (genealogy) or mātauranga Māori (Māori knowledge) are examples
+where long-term retention and protection is important.
+
+- **MD_REL01-BP01: Design storage systems with multi-generational
+durability in mind**. Multi-generational durability focuses on the reliability
+of having access to that data across generations. This applies to the data that you are
+storing, but also associated metadata that provides context for that data. The
+Well-Architected Reliability Pillar provides guidance on best practices for architecting
+resilient workloads, backing up data, and planning for disasters. By understanding what
+kinds of data you are storing and the possible need for the long-term preservation of that
+data, you can choose appropriate architectural patterns and services such as Amazon S3, which
+creates six copies of your data and is designed to provide 99.999999999% (11 nines) of
+durability. In practice, 11 nines of durability means that if you stored ten million
+objects, you might expect to lose a single object every 10,000 years.
+- **MD_REL01-BP02: Consider how your organisational archive and
+retention processes apply to Māori data.** Many organisations have data
+retention and archiving processes that govern how long data is retained and how and where
+it is stored.
+- **MD_REL01-BP03: Configure your AWS account for long term
+continuity**. Within each of your AWS accounts, it is important to have
+accurate and up-to-date contact details, payment/credit card information, and multi-factor
+authentication (MFA) for users. Keeping your contact information up-to-date helps ensure
+that you receive important notifications from AWS on topics like security, billing, and
+operations. It is a best practice to use an email distribution list, rather than depending
+on an individual's email address. This can help avoid scenarios where important
+notifications from AWS are missed if an individual is on leave or has left the
+organisation.
+- **MD_REL01-BP04: Implement backup mechanisms**. The
+Reliability Pillar provides guidance on designing, implementing, and operating a backup
+solution for your data and applications. The nature of the Māori data being captured,
+processed, or stored influences the design of the backup solution. For example, an iwi
+register application or a digital archive application might call for multiple copies of
+backups to be stored in different locations, with different access controls due to the
+value of those datasets. While it may seem redundant, it's important to store backups
+across multiple different types of storage and in multiple different locations. This helps
+ensure there's always an available backup, no matter the circumstances. Where
+irreplaceable digital taonga is identified, it is important to consider offline
+replication in addition to the appropriate security and reliability controls.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_rel-1-how-do-you-safely-retain-data-for-future-generations.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/maori-data/security.md
+++ b/skills/wa-review/references/lenses/maori-data/security.md
@@ -1,0 +1,184 @@
+# Security
+
+**Pillar**: Security  
+**Pages**: 4
+
+---
+
+# MD_SEC 1: How is Māori data protected?
+
+Systems designed to capture, store, or process Māori data should follow the same best
+practice as any other cloud solution in that they should be designed, built, and operated with
+security in mind. The Security Pillar of the Well-Architected Framework provides in-depth,
+best practice guidance for architecting secure workloads. The [Data protection](https://docs.aws.amazon.com/wellarchitected/latest/framework/sec-dataprot.html) best
+practice area in the Security Pillar provides best practices relating to data classification,
+protecting data at rest, and protecting data in transit. Data protection is just one aspect of
+securing your cloud architectures. Security should be applied at all layers through multiple
+controls using a defence-in-depth approach. In addition to the best practices contained in the
+Security Pillar, the following considerations may also apply:
+
+- **MD_SEC01-BP01: Design storage systems to handle data with different
+Māori data classifications.** If the data is considered tapu and that is
+feedback you have received from your customers, then it may be appropriate to apply
+additional controls and procedures. These may be required to support specific tikanga
+related to the handling of certain data. You may choose to store certain data separately
+from other data with different security requirements for access and processing. It is
+possible, for example, to store data in separate virtual private clouds (VPC), separate
+databases, or separate object storage buckets. This separation of datasets means you can
+apply independent security controls, such as different access permissions, different
+logging and auditing levels, and different backup approaches.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-1-how-is-māori-data-protected.html*
+
+---
+
+# MD_SEC 2: How do you design workload security for long-term safety?
+
+Certain Māori data may need to be available for generations to come. Consult with Māori
+customers and advisers about what data retention policies they recommend according to the
+different types of data. These data retention policies can be revisited in the future too.
+Regardless of how long you are intending to store this data, all data needs to be properly
+secured for the protection of taonga (treasure) for generations to come.
+
+Ransomware is a good example to consider. If you have one copy of your data and you are
+subject to a ransomware attack, you may not be able to recover your data. Consider how many
+backup copies may be required to protect yourself from this scenario. Design appropriate
+access controls to minimise the chance of accidental or malicious deletion or corruption of
+back-ups. While it may seem redundant, it's important to store backups across multiple
+different types of storage and in multiple different locations. With this strategy, there's
+always an available backup, no matter the circumstances. Where irreplaceable digital taonga is
+identified, it is important to consider offline replication in addition to the appropriate
+data protection and resilience controls.
+
+- **MD_SEC02-BP01: Understand data protection options available through
+your provider to protect data at the level of control your customer wants.**
+Customers control how they configure their environments and secure their content,
+including whether they encrypt their content (at rest and in transit), and what other
+security features and tools they use and how they use them. AWS does not change customer
+configuration settings, as these settings are determined and controlled by the customer.
+AWS customers have the ability to design their security architecture to meet
+their compliance needs. AWS provides the customer autonomy to decide when and how
+security measures are implemented in the cloud, in accordance with each customer's
+business needs. When choosing which option is best, you should understand the risks you
+are trying to mitigate, take into account both the benefits and costs of each solution,
+and choose a solution that meets your requirements. Choose a cloud provider that offers
+contractual restrictions on their access to your data and operational restrictions. AWS,
+for example, is one of those cloud providers who offers both.
+- **MD_SEC02-BP02: Understand what encryption options are available to
+protect your data at rest and in transit.** Encryption of data at rest is a
+recommended best practice for protecting your data from unauthorised access. AWS
+provides several options for data encryption. One option is to have AWS create and
+manage encryption keys for you through the AWS Key Management Service. Many AWS services integrate with
+AWS KMS to enable encryption of your data. Another option is to create your own encryption
+keys within AWS KMS. This provides you with more control over your keys. This includes
+control over the key material, the rotation policy, and the permissions that define who
+can use or manage the key. AWS KMS is designed so that no one, not even an AWS employee,
+can retrieve your plaintext KMS keys from the service.
+- **MD_SEC02-BP03: Make informed decisions about where data is
+stored**. Māori users of your system may prefer their data to be stored in New
+Zealand. AWS allows customers to control where their data is stored and processed, and
+your content won't be replicated or moved outside of your chosen AWS Region except as
+agreed by you. For customers in Aotearoa New Zealand, the options for storing data within
+New Zealand include the Auckland AWS Local Zone, an AWS Outpost, or the upcoming AWS
+Auckland region. Every commercial AWS region is designed, built, and operated in the
+same way and incorporates the same levels of security. When choosing an AWS
+infrastructure for your workload, take into account the possible trade-offs that may
+exist. For example, an AWS Region has a larger selection of AWS services and higher
+resiliency than an AWS Outpost. However, an AWS Outpost may provide more flexibility
+as to the location where the infrastructure can be placed. There are also costs and budget
+considerations to take into account. Some other considerations related to the location of
+data include:
+
+Do you need to make a distinction between where data is processed and where it is
+stored? For example, the data could be stored in a database in New Zealand but
+processed on an EC2 instance in another region (of your choice) as part of an analytics job.
+Alternatively, it could be captured using a web application running on servers in
+Sydney and then saved to a database located in New Zealand.
+- Do you need to duplicate data across locations to meet your customer requirements?
+For example, a data archiving solution could send backups to another AWS Region for
+resiliency and security reasons. An application like a digital archive solution could
+make use of Amazon CloudFront for content distribution to help reduce latency for end users
+when accessing the content. This would require copies of data to be stored at CloudFront
+edge locations, while the primary data is stored in the origin storage service such as
+Amazon S3 or a database.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-2-how-do-you-design-workload-security-for-long-term-safety.html*
+
+---
+
+# MD_SEC 3: How can you identify and classify Māori data?
+
+Organisations may wish to understand what Māori data they hold and have a method to
+classify Māori data to protect it with security controls and practices. Once the data has been
+classified and appropriate metadata is captured, you can govern and use that data in
+appropriate ways.
+
+- **MD_SEC03-BP01: Develop an understanding of what Māori data
+is**. Create an easy-to-understand definition of Māori data for your
+organisation. Having a definition of Māori data can help determine what additional
+considerations are relevant to your organisation or application. Piloting this and testing
+this with your customers facilitates a mutually-agreed upon definition, which is
+implementable for your organisation.
+- **MD_SEC03-BP02: Incorporate Māori data classification into your data
+governance framework**. If you already have a data classification framework
+within your organisation, you may wish to expand this to include a Māori data
+classification approach. A classification framework can help you determine what is Māori
+data, outline where and how the classification should be recorded, and define the security
+and access controls that are required for that data classification. For example, what
+additional data access controls may be required if the data is classified as tapu or noa?
+- **MD_SEC03-BP03: Record Māori data classifications as metadata and
+make it easily discoverable**. Use approaches such as metadata tagging and data
+cataloguing to store and manage your classification metadata. Tools such as business data
+catalogues should make it easier for your organisation to search for and discover datasets
+that contain Māori data in your organisation. In addition, you can add tags which record
+the purpose for which consent of that data was given. This may allow for easier review of
+consent and data access policies and up-to-date consent practices.
+- **MD_SEC03-BP04: Leverage technologies and techniques to help identify
+and classify existing Māori data**. Your organisation may already capture and
+store Māori data. Consider using available tools and techniques to review and classify
+your existing data. Once identified and classified, update your metadata and business data
+catalogues. This may involve assessing data across databases, object stores, file servers,
+document management systems, communication systems (like email), and analytics platforms.
+For example, search your AWS Glue Data Catalog table columns for terms like *iwi*
+or *hapū* or Māori organisation.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-3-how-can-you-identify-and-classify-māori-data.html*
+
+---
+
+# MD_SEC 4: How do you maintain privacy of personal Māori data?
+
+It is important that personal data is collected and processed lawfully, fairly, and
+transparently in relation to a person. When designing, building, and operating workloads that
+may capture, store, and process Māori personal data, privacy should be taken into account
+throughout the entire process. The application of privacy principles should align with your
+organisation's privacy framework and be guided by applicable privacy regulation such as the
+New Zealand Privacy Act 2020. For further information on how you are applying AWS services
+in conjunction with the New Zealand Privacy Act 2020, see [Using AWS in the Context of the New Zealand Privacy Considerations](https://d1.awsstatic.com/whitepapers/compliance/Using_AWS_in_the_context_of_New_Zealand_Privacy_Considerations.pdf).
+
+- **MD_SEC04-BP01: Use tools and techniques to adequately de-identify
+data.** This helps protect individual's privacy when producing data sets that
+may be shared or published. There are many techniques within data and analytics domains to
+help de-identify data. These include obfuscation (obscuring sensitive data), tokenisation
+(where a sensitive piece of data is replaced by a non-sensitive token where the token can
+map back to the original data), and anonymisation (such as removing sensitive data
+completely).
+- **MD_SEC04-BP02: Honour the consent you've received when using data
+for internal analytics**. If your organisation asked for consent when
+collecting data, that data should be used only for the purposes that you have received
+consent for. If your organisation asked for consent and did not receive it, exclude this
+data from analytics and AI/ML uses.
+- **MD_SEC04-BP03: Honour the consent you've received when sharing
+data**. Only share data with third parties if you have obtained requisite
+consent in accordance with applicable laws such as the New Zealand Privacy Act. Consider
+creating mechanisms to exclude that data from any data sharing processes if you have not
+obtained the required consents.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sec-4-how-do-you-maintain-privacy-of-personal-māori-data.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/maori-data/sustainability.md
+++ b/skills/wa-review/references/lenses/maori-data/sustainability.md
@@ -1,0 +1,65 @@
+# Sustainability
+
+**Pillar**: Sustainability  
+**Pages**: 1
+
+---
+
+# MD_SUS 1 How do you design and operate systems to minimise potential impacts on the environment?
+
+- **MD_SUS01-BP01: Develop an understanding of the unique relationship
+between Māori and the land**. As tangata whenua (people of the land), Māori
+have deep connections to the land and the natural world. Whenua is seen as taonga that
+must be protected for future generations. It is important to understand the possible
+impacts your technology decisions may have on the environment. Understand your Māori
+customers in the context of their natural environment, their priorities, and their
+interests, and incorporate their perspectives into your technology when considering
+opportunities and environmental impact.
+- **MD_SUS01-BP02: Consider how your solution could positively impact
+the environment.**Technology is often used to improve processes by making them
+more efficient or effective. When designing products, consider how you can incorporate
+features that could have direct or indirect positive impacts on the environment. For
+example, if you are designing a farm management system that tracks nitrate usage on
+paddocks to maximise pasture growth, consider a feature that highlights potential risk of
+nitrates making their way into farm waterways. Similarly, you can reduce landfill waste by
+using machine learning in your manufacturing process to help determine the optimal use of
+resources.
+- **MD_SUS01-BP03: Consider where you might store and run your workload
+to make the most of the sustainability of the cloud.** A study by 451 Research
+shows that "moving IT workloads from on-premises data centres to the cloud would improve
+energy efficiency and reduce associated carbon emissions by nearly 80% on average" (among
+515 surveyed enterprises across Japan, South Korea, Singapore, Australia, and India). 451
+Research also estimates that emissions savings for organisations moving from on-premises
+data centers to cloud could increase to 93% if cloud data centers in APAC were powered by
+100% renewable energy. This advantage is attributable to the combination of more
+energy-efficient servers and much higher server utilisation. As New Zealand customers move
+their workloads from enterprise data centres to the AWS Cloud, the carbon footprint of
+these workloads is reduced due to lower energy consumption. Furthermore, the AWS Asia
+Pacific (Auckland) Region is planned to be powered by 100% renewable energy. This is part
+of Amazon's Climate Pledge whereby Amazon is on path towards powering its infrastructure
+operations by 100 percent renewable energy by 2025.
+- **MD_SUS01-BP04: Measure and report on carbon footprint.**
+AWS offers customers free use of the [Customer Carbon Footprint
+Tool](https://aws.amazon.com/aws-cost-management/aws-customer-carbon-footprint-tool/) (CCFT). The CCFT provides the following features:
+
+Simple data visualisations to report on the emissions from your AWS usage
+following Greenhouse Gas (GHG) Protocol standards;
+- Analysis of the changes in your emissions over time as you migrate workloads to
+AWS;
+- Helps you re-architect applications, or deprecate unused resources; and
+- Forecasts how your emissions change across your sustainability journey as Amazon
+progresses toward powering operations with 100% renewable energy.
+
+You can also talk to your account executive about the range of tools available on the
+[AWS Marketplace](https://aws.amazon.com/marketplace), which can support tracking and
+reporting of your organisation's sustainability data. Such data provides necessary insight to
+achieve your organisation's sustainability goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/maori-data-lens/md_sus-1-how-do-you-design-and-operate-systems-to-minimise-potential-impacts-on-the-environment.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MACOST01.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MACOST01.md
@@ -1,0 +1,59 @@
+# MACOST01 — Cost optimization
+
+**Pillar**: Cost Optimization  
+**Best Practices**: 6
+
+---
+
+## MACOST01-BP01 Perform pricing model analysis for the combined entities
+
+Analyze each component of the workload. Determine if the component and resources should be running for extended periods (for commitment discounts) or dynamic and short-running (for Spot or On-Demand Instances). Perform an analysis on the workload using the recommendations feature in AWS Cost Explorer.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP02 Optimize accounts through various means, such as EC2 instance types, Savings Plans, and Amazon S3 lifecycle
+
+Use AWS Trusted Advisor to examine current cost savings and possible additional savings.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP03 Discover and realize additional cost savings
+
+Explore means for additional cost savings, and use AWS Cost Explorer to evaluate costs. Choose an optimized savings plan for the combined entity, and work with AWS teams to use Reserve Instances or Savings Plans across companies if possible.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP04 Migrate to Regions based on cost
+
+Resource pricing can be different in each Region. Factoring in Region cost verifies that you are paying the lowest overall price for a workload.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP05 Use managed services for lower TCO
+
+Understand how proper use of managed services can lower TCO.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+## MACOST01-BP06 Select third-party agreements with cost efficient terms
+
+Cost-efficient agreements and terms scale the cost of these services with the benefits they provide. Select agreements and pricing that scale when they provide additional benefits to your organization.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MACOST02.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MACOST02.md
@@ -1,0 +1,41 @@
+# MACOST02 — Cost optimization
+
+**Pillar**: Cost Optimization  
+**Best Practices**: 4
+
+---
+
+## MACOST02-BP01 Configure billing and cost management tools across both organizations
+
+Configure AWS Cost Explorer and AWS Budgets in line with your organization policies.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+## MACOST02-BP02 Combine both organizations information to cost and usage
+
+To roll your new AMS-managed AWS account bill into a payment for an existing AWS Organizations management account, set up consolidated billing, and link the accounts.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+## MACOST02-BP03 Allocate costs based on workload metrics
+
+Organize the workload's costs by metrics or business outcomes to measure workload cost efficiency. Implement a process to analyze the AWS Cost and Usage Report with Amazon Athena, which can provide insight and chargeback capability.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+## MACOST02-BP04 Configure a bill or chargeback strategy using custom usage tags
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MACOST03.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MACOST03.md
@@ -1,0 +1,51 @@
+# MACOST03 — Cost optimization
+
+**Pillar**: Cost Optimization  
+**Best Practices**: 5
+
+---
+
+## MACOST03-BP01 Perform data transfer modeling
+
+Gather organization requirements, and perform data transfer modeling of the workload and each of its components. This identifies the lowest cost point for its current data transfer requirements.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP02 Select components to optimize data transfer cost
+
+All components are selected, and architecture is designed to reduce data transfer costs. This includes using components such as wide-area-network (WAN) optimization and multi-Availability Zone (AZ) configurations.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP03 Implement services to reduce data transfer costs
+
+Implement services to reduce data transfer. For example, using a content delivery network (CDN) such as Amazon CloudFront to deliver content to users, caching layers using Amazon ElastiCache, or using AWS Direct Connect instead of VPN for connectivity to AWS.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP04 Delete redundant data stores using policies
+
+Manage the lifecycle of all your data, and automatically enforce deletion timelines to minimize the total storage requirements of your workload.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+## MACOST03-BP05 Analyze data integration pattern of the combined organizations
+
+Data is a combined organizational asset. Collect, store, organize, and process valuable data, and make it available in a secure way to the people and applications that need it.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/macost-3.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS01.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS01.md
@@ -1,0 +1,74 @@
+# MAOPS01 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 6
+
+---
+
+## MAOPS01-BP01 Workloads from both organizations have identified owners
+
+Strong governance and centralized control over scope of migration workloads facilitates
+a successful migration. Wide distribution makes migration more difficult (assuming the
+migration scope spans these distributed groups).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP02 Processes and procedures have identified owners
+
+Understand who has ownership of the definition of individual processes and procedures,
+why those specific process and procedures are used, and why that ownership exists. To better
+identify improvement opportunities, understand the reasons that specific processes and
+procedures are used.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP03 Operations activities have identified owners responsible for their performance
+
+Understand who has responsibility to perform specific activities on defined workloads
+and why that responsibility exists. Understanding who has responsibility to perform
+activities informs who conducts the activity, validates the result, and provides feedback to
+the owner of the activity.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP04 Create a Cloud Center of Excellence team
+
+Understand the responsibilities of your role and how you contribute to business
+outcomes, as this knowledge informs the prioritization of your tasks and why your role is
+important. This understanding helps team members recognize needs and respond appropriately.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP05 Mechanisms exist to request process additions, changes, and exceptions
+
+You are able to make requests to owners of processes, procedures, and resources. Make
+informed decisions to approve requests where they have been deemed viable and appropriate
+after an evaluation of benefits and risks.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+## MAOPS01-BP06 Both companies have identified the cloud skills and competencies to enable the resources
+
+Identify gaps between required skills and competencies and what is presently available
+in the organization. For existing staff, provide access to training courses of different
+types (both classroom-based and online courses). Encourage staff to obtain certification on
+cloud competencies to validate their knowledge.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS02.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS02.md
@@ -1,0 +1,49 @@
+# MAOPS02 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 4
+
+---
+
+## MAOPS02-BP01 Each company has identified their primary Region
+
+For many services, you can choose an AWS Region that specifies where your resources
+are managed. Regions are sets of AWS resources located in the same geographical area. You
+don't need to choose a Region for the AWS Management Console or for some services, such as AWS Identity and Access Management.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+## MAOPS02-BP02 Configure AWS Control Tower, AWS Config, and AWS CloudFormation
+
+AWS Control Tower offers the easiest way to set up and govern a secure, multi-account AWS
+environment. It establishes a landing zone that is based on best-practices blueprints, and
+it enables governance using guardrails you can choose from a pre-packaged list.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+## MAOPS02-BP03 Automate infrastructure as code (IaC) using Cloud Formation or Terraform
+
+AWS CloudFormation helps you model, provision, and manage AWS and third-party resources by
+treating infrastructure as code.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+## MAOPS02-BP04 Automate resource compliance using tools like AWS Config
+
+AWS Config is a config tool that helps you assess, audit, and evaluate the configurations
+and relationships of your resources.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS03.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS03.md
@@ -1,0 +1,68 @@
+# MAOPS03 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS03-BP01 Structure your organization following AWS best practices
+
+A well-architected multi-account strategy helps you innovate faster in AWS, while
+helping you meet your security and scalability needs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP02 Merge the management accounts of both organizations
+
+Consolidated billing is a feature of AWS Organizations. You can use the management account of
+your organization to consolidate and pay for all member accounts. In consolidated billing,
+management accounts can also access the billing information, account information, and
+account activity of member accounts in their organization. This information may be used for
+services such as AWS Cost Explorer, which can help management accounts improve their organization’s
+cost performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP03 Determine if it's appropriate to separate management accounts
+
+If there is a use case to keep OUs separate, you can certainly do that with multiple
+management accounts. There may be few reasons to keep Organizations separate:
+
+- AWS GovCloud (US) or commercial cloud
+- Differing financial needs, including taxation (Europe compared to the US)
+- Differing operating scope (Systems Manager)
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP04 Merge logging, security, and infrastructure organizations
+
+The approach covered in this pattern is suitable for customers who have multiple
+AWS accounts with AWS Organizations and are now encountering challenges when using AWS Control Tower, a
+landing zone, or account vending machine services to set up baseline guardrails in their
+accounts.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+## MAOPS03-BP05 Define a backup strategy for each organization
+
+Use AWS Backup to create backup plans that define how to back up your AWS resources.
+The rules in the plan include a variety of settings, such as backup frequency, the time
+window during which the backup occurs, the AWS Region containing the resources to back up,
+and the vault in which to store the backup.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-3.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS04.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS04.md
@@ -1,0 +1,63 @@
+# MAOPS04 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS04-BP01 Standardize documented operational processes (like CI/CD and deployment)
+
+Organizations incur operational tech debt during mergers and acquisitions.
+Organizations should remove manual processes and focus on automation.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP02 Retire or consolidate redundant apps and data-stores
+
+Perform technical analysis during mergers and acquisitions. Otherwise, data and systems
+can be duplicated, or even potentially orphaned. Both organizations should agree on a
+consistent data model, consistent accesses, and compliance needs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP03 Have a process in place for customer migration (if necessary)
+
+Customer retention and migration is of utmost importance during mergers and
+acquisitions. It is critical to support existing customers with optimal costs and negligible
+impact. The AWS ISV Workload Migration Program (WMP) supports software partners that have
+a SaaS offering on AWS to drive and deliver workload migrations. Use funding, technical
+enablement, and go-to-market support to rapidly migrate customers to your SaaS offering.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP04 Understand third-party integrations and dependencies
+
+It might happen that companies merge or multiple platforms get developed over time and
+duplicate some of the same needed subsystems. Being service oriented and consolidating
+services reduces the amount of code to be maintained.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+## MAOPS04-BP05 Perform all customizations through configuration, and change them as self-serve or company-controlled feature flags
+
+Customizations that are done with configuration do not require a code recompile or
+reload. It is a way to get away from the legacy practice of making hard-coded customizations
+per individual customers or segments. Use feature flags that are temporary or permanent.
+These flags help during testing or canary release.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-4.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS05.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS05.md
@@ -1,0 +1,66 @@
+# MAOPS05 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS05-BP01 Configure AWS resource tags
+
+AWS resources can be tagged for a variety of purposes, from implementing a cost
+allocation strategy to supporting automation or authorizing access to AWS resources.
+Implementing a tagging strategy can be challenging for some organizations, owing to the
+number of stakeholder groups involved and considerations such as data sourcing and tag
+governance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP02 Group applications based on tags
+
+A tag is a label that you assign to an AWS resource. A tag consists of a key and a
+value, both of which you define. For example, if you have two EC2 instances, you might
+assign both a tag key of `Stack`. But the value of `Stack` might be
+`Testing` for one and `Production` for the other.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP03 Associate tags with each configured resource (during provisioning)
+
+AWS CloudFormation provides a common language for provisioning all the infrastructure resources
+in your AWS environment. For AWS resources using CloudFormation templates, you can use the CloudFormation
+Resource Tags property to apply tags to supported resource types upon creation. Managing the
+tags as well as the resources with IaC helps create consistency.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP04 Set up security based on tags
+
+Organizations have varying needs and obligations to meet regarding the appropriate
+handling of data storage and processing. Data classification is an important precursor for
+several use cases, such as access control, data retention, data analysis, and compliance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+## MAOPS05-BP05 Perform cost allocation based on tags
+
+The AWS-generated tag created by is a tag that AWS defines and applies to supported
+AWS resources for cost allocation purposes. User-defined tags are tags that you define,
+create, and apply to resources. After you have created and applied the user-defined tags,
+you can activate by using the AWS Cost Management Console for cost allocation tracking.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-5.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS06.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS06.md
@@ -1,0 +1,38 @@
+# MAOPS06 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 3
+
+---
+
+## MAOPS06-BP01 The seller has an extensive list of all IP and key innovations (and related documentation)
+
+Use industry domain knowledge, as well as patentable and other relevant code
+innovations, to create a platform offering that is truly unique and valuable to customers.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-6.html*
+
+---
+
+## MAOPS06-BP02 Document open-source software integrations
+
+Continually evolve your underlying code base to build up capabilities that use
+open-source software where appropriate.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-6.html*
+
+---
+
+## MAOPS06-BP03 Hold patents on key platform technologies
+
+Patents are a way to secure your rights to innovative technologies that keep you in a
+competitive position.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-6.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS07.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS07.md
@@ -1,0 +1,58 @@
+# MAOPS07 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 5
+
+---
+
+## MAOPS07-BP01 Document duplicate workloads and features
+
+Keep a centralized list of work that could be epic-level ideas down to more detailed
+work for features, bugs, technical debt, and innovative advances.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP02 Identify the impact of product features on customers from both companies
+
+A company should be looking beyond the current near-term features going in to
+strategically plan out longer term initiatives and how they can be ordered to create a
+compelling list of innovations.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP03 Document a combined-products strategy
+
+Identify products to be retired, maintained, or enhanced. Document customer impact and
+migration plan in case of product or workload decommission.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP04 Verify that teams understand critical customer requirements
+
+Increased decomposition for engineering tasks corresponds to increased probability of
+success. You can properly scope the effort in terms of cost, time, and resources needed, and
+define a definition for completion of work.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+## MAOPS07-BP05 Modify your existing roadmap to incorporate the new organization
+
+Define the new product roadmap that aligns with the combined companies’ goals.
+Determine customer impact based on product priorities.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-7.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS08.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS08.md
@@ -1,0 +1,40 @@
+# MAOPS08 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 3
+
+---
+
+## MAOPS08-BP01 Document mechanisms for both product teams to operate collaboratively
+
+Understanding deal rationale (for example, to acquire new capabilities or to capture
+market share). It's important for product teams from both companies to work closely to
+achieve the unified organization's goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-8.html*
+
+---
+
+## MAOPS08-BP02 Verify that key product teams have a post-integration product strategy in place
+
+Ensure product teams from both companies understand combined product strategy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-8.html*
+
+---
+
+## MAOPS08-BP03 Review, retire, and promote products and roadmaps based on customer focus
+
+Product managers speak to customers regularly. The teams collaborate on the analyzed
+findings, and experimentation at scale is performed using well-known mechanisms. Manage data
+and cloud-enabled offerings that deliver repeatable value to internal and external customers
+as products through their lifecycles.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-8.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS09.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAOPS09.md
@@ -1,0 +1,19 @@
+# MAOPS09 — Operational excellence
+
+**Pillar**: Operational Excellence  
+**Best Practices**: 1
+
+---
+
+## MAOPS09-BP01 Create a Configuration Management Database (CMDB) or infrastructure repository
+
+Implement automated mechanisms to update data and maintain data accuracy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maops-9.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAPERF01.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAPERF01.md
@@ -1,0 +1,51 @@
+# MAPERF01 — Performance efficiency
+
+**Pillar**: Performance Efficiency  
+**Best Practices**: 5
+
+---
+
+## MAPERF01-BP01 Understand the available services and resources
+
+Explore the wide range of services and resources available in the cloud. Identify the relevant services and configuration options for your workload, and determine how to achieve optimal performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP02 Define a process for architectural choices
+
+Define a process to choose resources and services by using internal experience and knowledge of the cloud or external resources such as published use cases, relevant documentation, or whitepapers. You should define a process that encourages experimentation and benchmarking with any services that could be used in your workload.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP03 Factor cost requirements into decisions
+
+Workloads often have cost requirements for operation. Use internal cost controls to select resource types and sizes based on predicted resource need.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP04 Use guidance from your cloud provider or an appropriate partner
+
+Use cloud company resources, such as solutions architects, professional services, or an appropriate partner to guide your decisions. These resources can help review and improve your architecture for optimal performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+## MAPERF01-BP05 Benchmark workloads from both organization
+
+Benchmark the performance of an existing workload to understand how it performs in the cloud. Use the data collected from benchmarks to make architectural decisions.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAPERF02.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAPERF02.md
@@ -1,0 +1,43 @@
+# MAPERF02 — Performance efficiency
+
+**Pillar**: Performance Efficiency  
+**Best Practices**: 4
+
+---
+
+## MAPERF02-BP01 Scale current architecture and hosting through manual or automatic means
+
+Take progressive steps to achieve scaling.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+## MAPERF02-BP02 Remediate bottlenecks that prevent scaling, and use utomatic scaling or serverless resources when appropriate
+
+Serverless technologies feature automatic scaling, built-in high availability, and a pay-for-use billing model to increase agility. Serverless technologies reduce infrastructure management tasks like capacity provisioning. For more detail, see [Serverless on AWS](https://aws.amazon.com/serverless/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+## MAPERF02-BP03 Perform periodic static provisioning for peak usage in reaction to monitoring data
+
+Review historical data to understand peak usage days and time. Manually pre-provision resources based on historical data findings.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+## MAPERF02-BP04 Rearchitect to scale for new customers
+
+Cloud solutions architects should ideally build an architecture with the future in mind, meaning their solutions need to cater to current scale requirements as well as the anticipated growth of the solution. This growth can be either the organic growth of a solution, or it could be related to a merger and acquisition scenario where its size is increased dramatically within a short period of time.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/maperf-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAREL01.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAREL01.md
@@ -1,0 +1,43 @@
+# MAREL01 — Reliability
+
+**Pillar**: Reliability  
+**Best Practices**: 4
+
+---
+
+## MAREL01-BP01 Incorporate fault tolerance to achieve high availability as required for your industry vertical and customer expectations
+
+These are two important concepts in the concept of availability. *Fault tolerance* is the ability to withstand subsystem failure and maintain availability (working properly within an established SLA). To implement fault tolerance, workloads use spare (or redundant) subsystems. *Fault isolation* minimizes the scope of impact when a failure does occur. This is typically implemented with modularization. Workloads are broken down into small subsystems that fail independently and can be repaired in isolation.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+## MAREL01-BP02 Establish SLAs, including DR RTO and RPO for the combined organization
+
+Critical platforms require high availability. It is advised to achieve the maximum required availability at a reasonable cost that meets customer and business needs.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+## MAREL01-BP03 Establish a deployment strategy for combined company
+
+AWS provides a number of tools to simplify and automate the provisioning of infrastructure and deployment of applications. Each deployment service offers different capabilities for managing applications. To build a successful deployment architecture, evaluate the available features of each service against the needs your application and organization.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+## MAREL01-BP04 Establish an SRE team and process for the combined organization.
+
+Site reliability engineering (SRE) is the practice of using software tools to automate IT infrastructure tasks such as system management and application monitoring. Organizations use SRE to keep their software applications reliable amidst frequent updates from development teams.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MAREL02.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MAREL02.md
@@ -1,0 +1,27 @@
+# MAREL02 — Reliability
+
+**Pillar**: Reliability  
+**Best Practices**: 2
+
+---
+
+## MAREL02-BP01 Establish alternatives for each critical external service to switch over to if needed, or balance traffic across
+
+Amazon API Gateway can be used to front calls to backend external services and handle failover if problems are detected with the primary service.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-2.html*
+
+---
+
+## MAREL02-BP02 Have legal agreements in place guaranteeing the right of continued usage of all external services
+
+As an example, see [AWS Service Terms](https://aws.amazon.com/service-terms/).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/marel-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC01.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC01.md
@@ -1,0 +1,51 @@
+# MASEC01 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC01-BP01 Use a centralized identity provider
+
+At any given time, you can have only one directory or one SAML 2.0 identity provider connected to IAM Identity Center. But, you can change the identity source that is connected to a different one.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP02 Use a common authorization approach
+
+Companies may have a very different approach to authorization. Companies need to use a common authorization platform and develop consistent authorization policies for the combined systems.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP03 Use AWS temporary credentials
+
+You can use the AWS Security Token Service to create and provide trusted users with temporary security credentials that can control access to your AWS resources.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP04 Store and use secrets securely
+
+Use AWS Secrets Manager to replace hardcoded credentials in your code, including passwords, with an API call to Secrets Manager to retrieve the secret programmatically. The secret can't be compromised by someone examining your code because the secret no longer exists in the code.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+## MASEC01-BP05 Create a common policy for auditing and rotating credentials
+
+Rotation is the process of periodically updating a secret. When you rotate a secret, you update the credentials in both the secret and the database or service. In Secrets Manager, you can set up automatic rotation for your secrets.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC02.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC02.md
@@ -1,0 +1,51 @@
+# MASEC02 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC02-BP01 Use an AWS-defined process to report vulnerabilities
+
+AWS takes security very seriously and investigates all reported vulnerabilities (for more detail, see [AWS Cloud Security](https://aws.amazon.com/security/)).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP02 Use AWS services with self-service within the existing management console
+
+On AWS, you can automate manual security tasks so you can shift your focus to scaling and innovating your business.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP03 Use third-party security tools when necessary due to integration with on-premises resources
+
+Amazon Security Lake is a fully-managed security data lake service. You can use Security Lake to automatically centralize security data from AWS and third-party sources into a data lake that's stored in your AWS account. Security Lake helps you analyze security data, so you can get a more complete understanding of your security posture across the entire organization. You can also use Security Lake to improve the protection of your workloads, applications, and data.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP04 Migrate to a common set of tools, including partner tools from marketplace
+
+The AWS Shared Responsibility Model (SRM) makes it easy to understand various choices for protecting unique AWS environment, and [access partner resources](https://aws.amazon.com/partners/featured/security/) that can help you implement end-to-end security quickly and easily.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+## MASEC02-BP05 Create a common policy for auditing and rotating credentials
+
+For human identities, you should require users to change their passwords periodically and retire access keys in favor of temporary credentials. For machine identities, rely on temporary credentials using IAM roles. For situations where this is not possible, frequent auditing and rotating access keys is necessary.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC03.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC03.md
@@ -1,0 +1,51 @@
+# MASEC03 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC03-BP01 Standardize root email address (root account email access)
+
+When you first create an AWS account, you begin with a single sign-in identity that has complete access to all AWS services and resources in the account. This identity is called the AWS account root user and is accessed by signing in with the email address and password that you used to create the account. Ensure uninterrupted access to root email after a merger or acquisition.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP02 Define data access control mechanisms for combined systems
+
+Both organizations need a common set of privacy controls and access to data. AWS is built with comprehensive data protection in the cloud.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP03 Create a consistent mechanism for data classification and protection (in-transit and at rest)
+
+Before creating any workload, foundational practices that influence security should be in place. For example, data classification provides a way to categorize data based on levels of sensitivity, and encryption protects data by rendering it unintelligible to unauthorized access. These methods are important because they support objectives such as preventing mishandling or complying with regulatory obligations.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP04 Automate data backup process for combined systems
+
+A comprehensive backup strategy is an essential part of an organization’s data protection plan to withstand, recover from, and reduce any impact that might be sustained because of a security event. Create an extensive backup strategy that defines which data must be backed up, how often data must be backed up, and how backup and recovery tasks are monitored.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+## MASEC03-BP05 Automate responses to data security events
+
+AWS encourages you to use automation to help quickly detect and respond to security events within your AWS environments. In addition to increasing the speed of detection and response, automation also helps you scale your security operations as you expand your workloads running on AWS. Do you have automation process defined on both organizations?
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-3.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC04.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC04.md
@@ -1,0 +1,43 @@
+# MASEC04 — Security
+
+**Pillar**: Security  
+**Best Practices**: 4
+
+---
+
+## MASEC04-BP01 The seller is using AWS services (marketplace) for data governance
+
+Data governance is a framework to build data quality checks, identify lineage (relation) between target and source datasets, and build a data catalog over existing data in data lakes and enterprise data warehouses.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+## MASEC04-BP02 Document consistent mechanisms for data classification
+
+Ensure organizations are using AWS-supported partner solutions.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+## MASEC04-BP03 Document processes to maintain data integrity within AWS services
+
+Regulatory requirements to maintain the integrity of data are typically implemented as part of a validated application. However, by implementing controls at the AWS service-level, you can facilitate data integrity even for actions performed outside the validated application.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+## MASEC04-BP04 Understand both the buyer's and seller's compliance needs
+
+AWS supports inheritance of many security standards and compliance certifications, including PCI-DSS, HIPAA/HITECH, FedRAMP, GDPR, FIPS 140-2, and NIST 800-171, which helps you satisfy necessary compliance requirements.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-4.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC05.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MASEC05.md
@@ -1,0 +1,51 @@
+# MASEC05 — Security
+
+**Pillar**: Security  
+**Best Practices**: 5
+
+---
+
+## MASEC05-BP01 Both organizations have documented network architecture
+
+Network documentation includes written charts, drawings, records, and instructions of networking procedures, layouts, and information on your installed production or development network.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP02 Define a strategy for overlapping Classless Inter-Domain Routing (CIDR)
+
+In order to plan your prefix summarization and create your routing design, you should understand the IP addressing scheme of the merging or divesting companies.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP03 Define a connectivity model for post-integration or divestiture
+
+The network connectivity layer holds an enterprise’s entire IT ecosystem together. Furthermore, creating the right connectivity model is a critical step toward planning your merger, acquisition, or divestiture.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP04 Define a strategy for inter-enterprise DNS resolution
+
+DNS is the typical way how users connect to applications and also how various components of an application may communicate with each other.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+## MASEC05-BP05 Define a security strategy for data flowing between the two enterprises
+
+It is important to establish a secure communication between two enterprises for data transfer.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masec-5.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MASUS01.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MASUS01.md
@@ -1,0 +1,68 @@
+# MASUS01 — Sustainability
+
+**Pillar**: Sustainability  
+**Best Practices**: 5
+
+---
+
+## MASUS01-BP01 Perform due diligence
+
+Thoroughly investigate the acquired
+company's sustainability practices, including their
+environmental impact, social responsibility, and governance.
+Identify areas of alignment and improvement.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP02 Establish clear sustainability objectives
+
+Define the sustainability
+goals and targets that you want the acquired company to achieve.
+Ensure that these objectives align with your organization's
+sustainability strategy.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP03 Integrate sustainability into the acquisition process
+
+Incorporate
+sustainability considerations into the due diligence process and
+valuation of the company. This could include assessing the
+company's carbon footprint, energy usage, supply chain
+practices, and community engagement.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP04 Communicate expectations
+
+Communicate your sustainability
+expectations and requirements to the acquired company's
+management and employees. Educate on the importance of
+sustainability and the required commitment to achieving your
+organization's goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+## MASUS01-BP05 Provide resources and support
+
+Provide the acquired company with the
+necessary resources and support to achieve your sustainability
+objectives. Include training, funding for
+sustainability initiatives, or access to experts in the field.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-1.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->

--- a/skills/wa-review/references/lenses/mergers-and-acquisitions/MASUS02.md
+++ b/skills/wa-review/references/lenses/mergers-and-acquisitions/MASUS02.md
@@ -1,0 +1,74 @@
+# MASUS02 — Sustainability
+
+**Pillar**: Sustainability  
+**Best Practices**: 5
+
+---
+
+## MASUS02-BP01 Establish a sustainability committee
+
+Create a team of individuals from both
+organizations to oversee sustainability initiatives during the
+integration process. This committee should develop a plan for
+integrating sustainability into the new organization's
+operations and ensure that it remains a priority.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP02 Conduct a sustainability audit
+
+Before the acquisition, conduct a thorough
+audit of each organization's sustainability practices to
+identify areas of strength and weakness. This audit helps you
+understand the current state of sustainability within the
+organization and identifies opportunities for improvement.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP03 Communicate the importance of sustainability
+
+Communicate the importance of
+sustainability to all employees, stakeholders, and customers.
+Make sure everyone understands why sustainability is important
+and how it fits into the organization's long-term goals.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP04 Integrate sustainability into the integration plan
+
+Incorporate sustainability
+into the overall integration plan. This may involve developing
+new policies and procedures, identifying areas where
+sustainability can be improved, and setting goals and metrics
+for sustainability performance.
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+## MASUS02-BP05 Monitor and evaluate sustainability performance
+
+Regularly monitor and
+evaluate the organization's sustainability performance to ensure
+that progress is being made. This may involve collecting data on
+energy usage, waste generation, and other sustainability metrics
+and using this data to identify areas for improvement.
+
+For further details on sustainability, see
+[Sustainability
+Pillar - AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/sustainability-pillar/sustainability-pillar.html).
+
+*Source: https://docs.aws.amazon.com/wellarchitected/latest/mergers-and-acquisitions-lens/masus-2.html*
+
+---
+
+<!--
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+-->


### PR DESCRIPTION
Fixes #75
Fixes #76

> **Stacked on #125** (the #80 crawler fix). These lenses require that fix to crawl correctly, so this branch is based on it and its diff includes #125's commit until it merges. Merge #125 first and this rebases cleanly onto `main`.

## Problem
The **mergers-and-acquisitions** and **maori-data** Well-Architected lenses could not be added to the reference corpus: the crawler produced 0 (or incomplete) output for them. Two distinct crawler bugs were in the way:
1. **Pillar detection** (fixed in #80/#125) — Māori uses British "Cost optimisation", which the pillar matcher missed, dropping that pillar.
2. **Non-ASCII URLs** (fixed here) — Māori page paths contain a macron (e.g. `.../md_ops-1-...māori...html`). `http.client` can only send an ASCII request line, so a raw non-ASCII URL raised `UnicodeEncodeError` *before the request left the process* — the lens couldn't be fetched at all.

## Why it matters
Without these, anyone wanting an M&A or Māori-data review has no lens corpus, and the crawler fails silently/hard on the Māori lens. These were tracked as #75 and #76, both blocked on the crawler.

## Fix (symptom → root cause → change)
- **Crawler:** `fetch()` now percent-encodes non-ASCII characters in the URL (path + query) via `urllib.parse`. `safe=...` preserves separators and existing `%`-escapes, so ASCII URLs pass through byte-for-byte unchanged (all other lenses re-crawl identically).
- **Corpora** (generated with the fixed crawler, mirrored into the `powers/` steering tree):
  - `mergers-and-acquisitions/` — 23 question files, 101 best practices across all 6 pillars.
  - `maori-data/` — 6 pillar files, 11 pages; includes the **Cost optimisation** pillar the #80 fix recovered.
- **Registration:** both added to the "Available lenses" lists in `skills/wa-review/SKILL.md` and `powers/wa-review/steering/wa-review.md`.

## Tests
- `scripts/crawl-wa-framework.py` compiles; the crawler unit tests (`scripts/test_crawl_wa_framework.py`) pass (5/5).
- **drift-guard:** `diff -rq skills/wa-review/references powers/wa-review/steering/references` → identical (the mirror the CI drift-guard enforces).
- **link-check:** ran lychee 0.24.2 offline with the exact CI args — these files add **0 errors** (the lens `references/` trees are excluded by the workflow; the list entries are code spans, not links).

## Manual verification
Dry-ran both lenses first to confirm discovery: M&A shows all 6 pillars (27 pages); Māori now shows `[Cost optimization] MD_CO 1` (previously dropped). Spot-checked generated files for non-empty content and the MIT-0 footer. Live AWS-docs crawl output is inherently a snapshot; re-crawling requires the crawler fixes in this PR + #125.

## Screenshots
N/A — reference corpus + crawler change, no UI.
