### PR TITLE
ci(drift-guard): guard the well-architected.md steering mirror too (#118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,21 @@ jobs:
           uv run pytest -m "not eval" -q
 
   drift-guard:
-    # Closes the #118 gap: the skills/ reference tree and its powers/ mirror must stay byte-identical.
+    # The Kiro Power at powers/wa-review/ ships hand-copied mirrors of two things
+    # that MUST stay byte-identical to their source, or a stale copy silently
+    # ships (this is the #110/#118 drift class):
+    #   1. the whole skills/wa-review/references/ tree (pillars, playbooks, lenses,
+    #      manifest, wa-questions), and
+    #   2. the well-architected.md steering body.
+    # steering/wa-review.md is deliberately NOT mirrored — the Power's wa-review.md
+    # diverges by design — so it is intentionally excluded here.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: skills/ vs powers/ reference trees must match
         run: diff -rq skills/wa-review/references powers/wa-review/steering/references
+      - name: well-architected.md steering body must match its Power mirror
+        run: diff -q steering/well-architected.md powers/wa-review/steering/well-architected.md
 
   link-check:
     # Advisory (non-blocking) for now: surfaces broken relative links in the log


### PR DESCRIPTION
Fixes #118

## Problem
The `powers/wa-review/` Kiro Power ships **hand-copied** verbatim mirrors of source content. The CI `drift-guard` job already diffs the whole `skills/wa-review/references/` tree against its `powers/` mirror, but a second verbatim mirror was left unguarded: `powers/wa-review/steering/well-architected.md` is a byte-identical copy of `steering/well-architected.md` with nothing keeping them in sync. Any unmirrored edit to either side silently reintroduces the exact drift #110 was about.

## Why it matters
The trees are byte-identical today only because they were copied by hand. The next edit to one side that isn't manually mirrored ships a stale Power. Low severity (content is rarely edited), tracked as tech-debt so the guard #110 asked for isn't lost.

## Fix (symptom → root cause → change)
- **Symptom:** `well-architected.md` can drift between `steering/` and the Power with no CI catch.
- **Root cause:** the drift-guard covered `references/` but not the steering-body mirror.
- **Change:** add one step to the existing `drift-guard` job — `diff -q steering/well-architected.md powers/wa-review/steering/well-architected.md` — alongside the existing recursive references diff.

Per the maintainer's scoping note, `steering/wa-review.md` is **intentionally not mirrored** (the Power's `wa-review.md` diverges by design — confirmed **1201 differing lines**), so it is deliberately excluded to avoid a day-one failure. The job comment now documents exactly what is guarded and why `wa-review.md` is out of scope.

## Tests
Ran both guard commands against `main`:
- `diff -rq skills/wa-review/references powers/wa-review/steering/references` → exit 0
- `diff -q steering/well-architected.md powers/wa-review/steering/well-architected.md` → exit 0

So the broadened job is green on current content and will fail only on genuine future drift.

## Manual verification
Confirmed the mirror map: `references/` tree and `well-architected.md` are verbatim copies (guarded); `wa-review.md` diverges by design (excluded); `POWER.md` has no source mirror.

## Screenshots
N/A — CI workflow change.
