### PR TITLE
feat(playbooks): named anti-patterns with detection criteria in pillar playbooks

### DIFF
--- a/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/cost-optimization.md
+++ b/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/cost-optimization.md
@@ -82,6 +82,28 @@ Flag IMPROVEMENT OPPORTUNITY:
 - No AWS Budget or Cost Anomaly Detection
 - No lifecycle policies on temporary resources
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-COST-01: gp2 volumes where gp3 applies
+**Detect:** Terraform `aws_ebs_volume` / launch-template block devices / `aws_instance` `root_block_device` with `volume_type = "gp2"` (or unset where the default resolves to gp2); CloudFormation `VolumeType: gp2`; CDK `EbsDeviceVolumeType.GP2`. gp3 delivers the same or better baseline performance at ~20% lower cost, with IOPS/throughput configurable independently of size.
+**Maps to:** COST06-BP02 (related: SUS05 hardware efficiency, AP-PERF-01 in `performance-efficiency.md`)
+**Wrong:**
+```hcl
+resource "aws_ebs_volume" "data" {
+  size        = 500
+  volume_type = "gp2"
+}
+```
+**Right:**
+```hcl
+resource "aws_ebs_volume" "data" {
+  size        = 500
+  volume_type = "gp3"
+}
+```
+
 ## Cost-Specific Report Format
 
 When producing a pillar-scoped cost report, include:

--- a/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/operational-excellence.md
+++ b/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/operational-excellence.md
@@ -59,6 +59,36 @@ Flag:
 - No runbooks for critical components
 - Health checks that only verify HTTP 200 (no deep checks)
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-OPS-01: No CloudWatch alarms on critical resources
+**Detect:** The workload defines production compute, database, queue, or API resources (Lambda, ECS, RDS, ALB, SQS, API Gateway) but no `aws_cloudwatch_metric_alarm` (CloudFormation `AWS::CloudWatch::Alarm`, CDK `cloudwatch.Alarm`) covers their key health metrics (errors, latency, throttles, queue depth, CPU/memory) — or alarms exist with no `alarm_actions` wired to a notification channel.
+**Maps to:** OPS08-BP04
+**Wrong:**
+```hcl
+resource "aws_lambda_function" "checkout" {
+  # ...
+}
+# no aws_cloudwatch_metric_alarm references this function
+```
+**Right:**
+```hcl
+resource "aws_cloudwatch_metric_alarm" "checkout_errors" {
+  alarm_name          = "checkout-lambda-errors"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  dimensions          = { FunctionName = aws_lambda_function.checkout.function_name }
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  alarm_actions       = [aws_sns_topic.oncall.arn]
+}
+```
+
 ## Operational Excellence-Specific Report Format
 
 When producing a pillar-scoped operational excellence report, include:

--- a/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/performance-efficiency.md
+++ b/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/performance-efficiency.md
@@ -94,6 +94,40 @@ Flag:
 - Missing batch operations (individual PutItem instead of BatchWriteItem)
 - Unbounded data retrieval without pagination
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-PERF-01: No auto-scaling on stateless compute
+**Detect:** Terraform `aws_autoscaling_group` with `min_size == max_size` or no `aws_autoscaling_policy`; ECS services with a fixed `desired_count` and no `aws_appautoscaling_target`/`aws_appautoscaling_policy`; CloudFormation ASGs without scaling policies; CDK services without `autoScaleTaskCount` — on stateless compute serving variable load.
+**Maps to:** PERF02-BP05 (related: COST09, AP-COST-01 in `cost-optimization.md`)
+**Wrong:**
+```hcl
+resource "aws_autoscaling_group" "web" {
+  min_size         = 4
+  max_size         = 4
+  desired_capacity = 4
+}
+```
+**Right:**
+```hcl
+resource "aws_autoscaling_group" "web" {
+  min_size = 2
+  max_size = 10
+}
+
+resource "aws_autoscaling_policy" "web_cpu" {
+  autoscaling_group_name = aws_autoscaling_group.web.name
+  policy_type            = "TargetTrackingScaling"
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+    target_value = 60
+  }
+}
+```
+
 ## Performance-Specific Report Format
 
 When producing a pillar-scoped performance report, include:

--- a/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/reliability.md
+++ b/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/reliability.md
@@ -91,6 +91,75 @@ Flag HIGH RISK:
 - Database migrations that aren't backward-compatible
 - No pre-production environment mirroring production topology
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-REL-01: Single-AZ production database
+**Detect:** Terraform `aws_db_instance` without `multi_az = true`; CloudFormation `AWS::RDS::DBInstance` with `MultiAZ` absent or false; CDK `DatabaseInstance` without `multiAz: true` — for any workload of standard or higher business criticality. (Aurora clusters: fewer than 2 instances across AZs.)
+**Maps to:** REL10-BP01
+**Wrong:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine         = "postgres"
+  instance_class = "db.r6g.large"
+}
+```
+**Right:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine         = "postgres"
+  instance_class = "db.r6g.large"
+  multi_az       = true
+}
+```
+
+### AP-REL-02: No backup plan / retention policy
+**Detect:** `aws_db_instance` with `backup_retention_period = 0` (or unset); DynamoDB tables without `point_in_time_recovery`; stateful resources (EBS, EFS, RDS) not covered by an `aws_backup_plan` / `AWS::Backup::BackupPlan` selection; CloudFormation `AWS::RDS::DBInstance` with `BackupRetentionPeriod: 0`.
+**Maps to:** REL09-BP01 (related: REL09-BP03)
+**Wrong:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine                  = "postgres"
+  backup_retention_period = 0
+}
+```
+**Right:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine                  = "postgres"
+  backup_retention_period = 30
+}
+
+resource "aws_dynamodb_table" "sessions" {
+  # ...
+  point_in_time_recovery { enabled = true }
+}
+```
+
+### AP-REL-03: Async processing without DLQ / on-failure destination
+**Detect:** `aws_lambda_function` invoked asynchronously (SNS, S3, EventBridge triggers) with no `dead_letter_config` and no on-failure `aws_lambda_function_event_invoke_config` destination; `aws_lambda_event_source_mapping` from an SQS queue whose source queue has no `redrive_policy`; CloudFormation `AWS::Lambda::Function` without `DeadLetterConfig` on async paths; CDK functions without `deadLetterQueue` / `onFailure`.
+**Maps to:** REL04-BP02
+**Wrong:**
+```hcl
+resource "aws_lambda_function" "order_events" {
+  # invoked by EventBridge — failures are silently dropped after retries
+}
+```
+**Right:**
+```hcl
+resource "aws_sqs_queue" "order_events_dlq" {
+  message_retention_seconds = 1209600
+}
+
+resource "aws_lambda_function" "order_events" {
+  # ...
+  dead_letter_config {
+    target_arn = aws_sqs_queue.order_events_dlq.arn
+  }
+}
+```
+
 ## Reliability-Specific Report Format
 
 When producing a pillar-scoped reliability report, include:

--- a/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/security.md
+++ b/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/security.md
@@ -86,6 +86,102 @@ Flag HIGH RISK:
 - No container image scanning
 - SSH access where SSM Session Manager would suffice
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-SEC-01: Wildcard IAM action grants
+**Detect:** `"Action": "*"` or service-wide wildcards (`"Action": ["s3:*", ...]`) combined with `"Resource": "*"` in any IAM policy document — Terraform `aws_iam_policy` / `aws_iam_role_policy`, CloudFormation `AWS::IAM::Policy` or inline role policies, CDK `iam.PolicyStatement` with `actions: ["*"]`.
+**Maps to:** SEC03-BP02
+**Wrong:**
+```hcl
+resource "aws_iam_role_policy" "app" {
+  role = aws_iam_role.app.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = "*", Resource = "*" }]
+  })
+}
+```
+**Right:**
+```hcl
+resource "aws_iam_role_policy" "app" {
+  role = aws_iam_role.app.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:PutObject"]
+      Resource = "${aws_s3_bucket.uploads.arn}/*"
+    }]
+  })
+}
+```
+
+### AP-SEC-02: Public S3 bucket / missing Block Public Access
+**Detect:** No `aws_s3_bucket_public_access_block` for a bucket (or any of its four flags false); CloudFormation `AWS::S3::Bucket` without `PublicAccessBlockConfiguration`; CDK `Bucket` with `blockPublicAccess` unset or weakened; bucket ACLs `public-read`/`public-read-write`; bucket policies with `"Principal": "*"` and no restricting condition.
+**Maps to:** SEC08-BP04 (related: SEC03-BP07)
+**Wrong:**
+```hcl
+resource "aws_s3_bucket" "uploads" {
+  bucket = "app-uploads"
+}
+# no aws_s3_bucket_public_access_block anywhere in the module
+```
+**Right:**
+```hcl
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket                  = aws_s3_bucket.uploads.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+### AP-SEC-03: Unencrypted data at rest (S3, EBS, RDS)
+**Detect:** Terraform `aws_db_instance` without `storage_encrypted = true`; `aws_ebs_volume` or launch-template block devices without `encrypted = true`; no `aws_s3_bucket_server_side_encryption_configuration` for a bucket; CloudFormation `AWS::RDS::DBInstance` without `StorageEncrypted: true` or `AWS::EC2::Volume` without `Encrypted: true`; CDK storage constructs with encryption explicitly disabled or left to an unencrypted default.
+**Maps to:** SEC08-BP02
+**Wrong:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine         = "postgres"
+  instance_class = "db.t3.medium"
+}
+```
+**Right:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.data.arn
+}
+```
+
+### AP-SEC-04: Hardcoded credentials or secrets in code
+**Detect:** String literals assigned to names matching `password|secret|api[_-]?key|token` in application code or IaC; secrets passed as plaintext Lambda/ECS environment variables; committed `.env` files; connection strings with embedded credentials.
+**Maps to:** SEC02-BP03
+**Wrong:**
+```hcl
+resource "aws_lambda_function" "api" {
+  # ...
+  environment {
+    variables = { DB_PASSWORD = "p@ssw0rd123" }
+  }
+}
+```
+**Right:**
+```hcl
+resource "aws_lambda_function" "api" {
+  # ...
+  environment {
+    variables = { DB_SECRET_ARN = aws_secretsmanager_secret.db.arn }
+  }
+}
+# function code resolves the secret at runtime via secretsmanager:GetSecretValue
+```
+
 ## Security-Specific Report Format
 
 When producing a pillar-scoped security report, include:

--- a/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/sustainability.md
+++ b/powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/sustainability.md
@@ -85,6 +85,13 @@ Flag:
 - Older generation instances (m4 instead of m7g, t2 instead of t4g)
 - Resources in high-carbon regions without latency justification
 
+## Named Anti-Patterns
+
+The starter anti-pattern set is weighted toward Security and Reliability, and sustainability-relevant entries live in the playbook of their primary pillar. When reviewing this pillar, explicitly check for these cross-pillar patterns and cite their IDs when they match:
+
+- **AP-COST-01: gp2 volumes where gp3 applies** (`cost-optimization.md`) — gp3 delivers the same baseline performance on more efficient infrastructure at lower cost; maps here to SUS05 (hardware and services selection).
+- **AP-PERF-01: No auto-scaling on stateless compute** (`performance-efficiency.md`) — fixed-size fleets hold idle capacity powered on around the clock; maps here to SUS02 (align cloud resources to demand).
+
 ## Sustainability-Specific Report Format
 
 When producing a pillar-scoped sustainability report, include:

--- a/skills/aws-well-architected-framework-review/references/pillar-playbooks/cost-optimization.md
+++ b/skills/aws-well-architected-framework-review/references/pillar-playbooks/cost-optimization.md
@@ -82,6 +82,28 @@ Flag IMPROVEMENT OPPORTUNITY:
 - No AWS Budget or Cost Anomaly Detection
 - No lifecycle policies on temporary resources
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-COST-01: gp2 volumes where gp3 applies
+**Detect:** Terraform `aws_ebs_volume` / launch-template block devices / `aws_instance` `root_block_device` with `volume_type = "gp2"` (or unset where the default resolves to gp2); CloudFormation `VolumeType: gp2`; CDK `EbsDeviceVolumeType.GP2`. gp3 delivers the same or better baseline performance at ~20% lower cost, with IOPS/throughput configurable independently of size.
+**Maps to:** COST06-BP02 (related: SUS05 hardware efficiency, AP-PERF-01 in `performance-efficiency.md`)
+**Wrong:**
+```hcl
+resource "aws_ebs_volume" "data" {
+  size        = 500
+  volume_type = "gp2"
+}
+```
+**Right:**
+```hcl
+resource "aws_ebs_volume" "data" {
+  size        = 500
+  volume_type = "gp3"
+}
+```
+
 ## Cost-Specific Report Format
 
 When producing a pillar-scoped cost report, include:

--- a/skills/aws-well-architected-framework-review/references/pillar-playbooks/operational-excellence.md
+++ b/skills/aws-well-architected-framework-review/references/pillar-playbooks/operational-excellence.md
@@ -59,6 +59,36 @@ Flag:
 - No runbooks for critical components
 - Health checks that only verify HTTP 200 (no deep checks)
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-OPS-01: No CloudWatch alarms on critical resources
+**Detect:** The workload defines production compute, database, queue, or API resources (Lambda, ECS, RDS, ALB, SQS, API Gateway) but no `aws_cloudwatch_metric_alarm` (CloudFormation `AWS::CloudWatch::Alarm`, CDK `cloudwatch.Alarm`) covers their key health metrics (errors, latency, throttles, queue depth, CPU/memory) — or alarms exist with no `alarm_actions` wired to a notification channel.
+**Maps to:** OPS08-BP04
+**Wrong:**
+```hcl
+resource "aws_lambda_function" "checkout" {
+  # ...
+}
+# no aws_cloudwatch_metric_alarm references this function
+```
+**Right:**
+```hcl
+resource "aws_cloudwatch_metric_alarm" "checkout_errors" {
+  alarm_name          = "checkout-lambda-errors"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  dimensions          = { FunctionName = aws_lambda_function.checkout.function_name }
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  alarm_actions       = [aws_sns_topic.oncall.arn]
+}
+```
+
 ## Operational Excellence-Specific Report Format
 
 When producing a pillar-scoped operational excellence report, include:

--- a/skills/aws-well-architected-framework-review/references/pillar-playbooks/performance-efficiency.md
+++ b/skills/aws-well-architected-framework-review/references/pillar-playbooks/performance-efficiency.md
@@ -94,6 +94,40 @@ Flag:
 - Missing batch operations (individual PutItem instead of BatchWriteItem)
 - Unbounded data retrieval without pagination
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-PERF-01: No auto-scaling on stateless compute
+**Detect:** Terraform `aws_autoscaling_group` with `min_size == max_size` or no `aws_autoscaling_policy`; ECS services with a fixed `desired_count` and no `aws_appautoscaling_target`/`aws_appautoscaling_policy`; CloudFormation ASGs without scaling policies; CDK services without `autoScaleTaskCount` — on stateless compute serving variable load.
+**Maps to:** PERF02-BP05 (related: COST09, AP-COST-01 in `cost-optimization.md`)
+**Wrong:**
+```hcl
+resource "aws_autoscaling_group" "web" {
+  min_size         = 4
+  max_size         = 4
+  desired_capacity = 4
+}
+```
+**Right:**
+```hcl
+resource "aws_autoscaling_group" "web" {
+  min_size = 2
+  max_size = 10
+}
+
+resource "aws_autoscaling_policy" "web_cpu" {
+  autoscaling_group_name = aws_autoscaling_group.web.name
+  policy_type            = "TargetTrackingScaling"
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+    target_value = 60
+  }
+}
+```
+
 ## Performance-Specific Report Format
 
 When producing a pillar-scoped performance report, include:

--- a/skills/aws-well-architected-framework-review/references/pillar-playbooks/reliability.md
+++ b/skills/aws-well-architected-framework-review/references/pillar-playbooks/reliability.md
@@ -91,6 +91,75 @@ Flag HIGH RISK:
 - Database migrations that aren't backward-compatible
 - No pre-production environment mirroring production topology
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-REL-01: Single-AZ production database
+**Detect:** Terraform `aws_db_instance` without `multi_az = true`; CloudFormation `AWS::RDS::DBInstance` with `MultiAZ` absent or false; CDK `DatabaseInstance` without `multiAz: true` — for any workload of standard or higher business criticality. (Aurora clusters: fewer than 2 instances across AZs.)
+**Maps to:** REL10-BP01
+**Wrong:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine         = "postgres"
+  instance_class = "db.r6g.large"
+}
+```
+**Right:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine         = "postgres"
+  instance_class = "db.r6g.large"
+  multi_az       = true
+}
+```
+
+### AP-REL-02: No backup plan / retention policy
+**Detect:** `aws_db_instance` with `backup_retention_period = 0` (or unset); DynamoDB tables without `point_in_time_recovery`; stateful resources (EBS, EFS, RDS) not covered by an `aws_backup_plan` / `AWS::Backup::BackupPlan` selection; CloudFormation `AWS::RDS::DBInstance` with `BackupRetentionPeriod: 0`.
+**Maps to:** REL09-BP01 (related: REL09-BP03)
+**Wrong:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine                  = "postgres"
+  backup_retention_period = 0
+}
+```
+**Right:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine                  = "postgres"
+  backup_retention_period = 30
+}
+
+resource "aws_dynamodb_table" "sessions" {
+  # ...
+  point_in_time_recovery { enabled = true }
+}
+```
+
+### AP-REL-03: Async processing without DLQ / on-failure destination
+**Detect:** `aws_lambda_function` invoked asynchronously (SNS, S3, EventBridge triggers) with no `dead_letter_config` and no on-failure `aws_lambda_function_event_invoke_config` destination; `aws_lambda_event_source_mapping` from an SQS queue whose source queue has no `redrive_policy`; CloudFormation `AWS::Lambda::Function` without `DeadLetterConfig` on async paths; CDK functions without `deadLetterQueue` / `onFailure`.
+**Maps to:** REL04-BP02
+**Wrong:**
+```hcl
+resource "aws_lambda_function" "order_events" {
+  # invoked by EventBridge — failures are silently dropped after retries
+}
+```
+**Right:**
+```hcl
+resource "aws_sqs_queue" "order_events_dlq" {
+  message_retention_seconds = 1209600
+}
+
+resource "aws_lambda_function" "order_events" {
+  # ...
+  dead_letter_config {
+    target_arn = aws_sqs_queue.order_events_dlq.arn
+  }
+}
+```
+
 ## Reliability-Specific Report Format
 
 When producing a pillar-scoped reliability report, include:

--- a/skills/aws-well-architected-framework-review/references/pillar-playbooks/security.md
+++ b/skills/aws-well-architected-framework-review/references/pillar-playbooks/security.md
@@ -86,6 +86,102 @@ Flag HIGH RISK:
 - No container image scanning
 - SSH access where SSM Session Manager would suffice
 
+## Named Anti-Patterns
+
+High-frequency Well-Architected failures codified as named patterns. Check every detection heuristic explicitly during discovery. When one matches, cite the anti-pattern ID alongside the BP ID in the finding, and base the remediation on the Right example (adapted to the workload's IaC dialect and actual resource names).
+
+### AP-SEC-01: Wildcard IAM action grants
+**Detect:** `"Action": "*"` or service-wide wildcards (`"Action": ["s3:*", ...]`) combined with `"Resource": "*"` in any IAM policy document — Terraform `aws_iam_policy` / `aws_iam_role_policy`, CloudFormation `AWS::IAM::Policy` or inline role policies, CDK `iam.PolicyStatement` with `actions: ["*"]`.
+**Maps to:** SEC03-BP02
+**Wrong:**
+```hcl
+resource "aws_iam_role_policy" "app" {
+  role = aws_iam_role.app.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = "*", Resource = "*" }]
+  })
+}
+```
+**Right:**
+```hcl
+resource "aws_iam_role_policy" "app" {
+  role = aws_iam_role.app.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:PutObject"]
+      Resource = "${aws_s3_bucket.uploads.arn}/*"
+    }]
+  })
+}
+```
+
+### AP-SEC-02: Public S3 bucket / missing Block Public Access
+**Detect:** No `aws_s3_bucket_public_access_block` for a bucket (or any of its four flags false); CloudFormation `AWS::S3::Bucket` without `PublicAccessBlockConfiguration`; CDK `Bucket` with `blockPublicAccess` unset or weakened; bucket ACLs `public-read`/`public-read-write`; bucket policies with `"Principal": "*"` and no restricting condition.
+**Maps to:** SEC08-BP04 (related: SEC03-BP07)
+**Wrong:**
+```hcl
+resource "aws_s3_bucket" "uploads" {
+  bucket = "app-uploads"
+}
+# no aws_s3_bucket_public_access_block anywhere in the module
+```
+**Right:**
+```hcl
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket                  = aws_s3_bucket.uploads.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+### AP-SEC-03: Unencrypted data at rest (S3, EBS, RDS)
+**Detect:** Terraform `aws_db_instance` without `storage_encrypted = true`; `aws_ebs_volume` or launch-template block devices without `encrypted = true`; no `aws_s3_bucket_server_side_encryption_configuration` for a bucket; CloudFormation `AWS::RDS::DBInstance` without `StorageEncrypted: true` or `AWS::EC2::Volume` without `Encrypted: true`; CDK storage constructs with encryption explicitly disabled or left to an unencrypted default.
+**Maps to:** SEC08-BP02
+**Wrong:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine         = "postgres"
+  instance_class = "db.t3.medium"
+}
+```
+**Right:**
+```hcl
+resource "aws_db_instance" "orders" {
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.data.arn
+}
+```
+
+### AP-SEC-04: Hardcoded credentials or secrets in code
+**Detect:** String literals assigned to names matching `password|secret|api[_-]?key|token` in application code or IaC; secrets passed as plaintext Lambda/ECS environment variables; committed `.env` files; connection strings with embedded credentials.
+**Maps to:** SEC02-BP03
+**Wrong:**
+```hcl
+resource "aws_lambda_function" "api" {
+  # ...
+  environment {
+    variables = { DB_PASSWORD = "p@ssw0rd123" }
+  }
+}
+```
+**Right:**
+```hcl
+resource "aws_lambda_function" "api" {
+  # ...
+  environment {
+    variables = { DB_SECRET_ARN = aws_secretsmanager_secret.db.arn }
+  }
+}
+# function code resolves the secret at runtime via secretsmanager:GetSecretValue
+```
+
 ## Security-Specific Report Format
 
 When producing a pillar-scoped security report, include:

--- a/skills/aws-well-architected-framework-review/references/pillar-playbooks/sustainability.md
+++ b/skills/aws-well-architected-framework-review/references/pillar-playbooks/sustainability.md
@@ -85,6 +85,13 @@ Flag:
 - Older generation instances (m4 instead of m7g, t2 instead of t4g)
 - Resources in high-carbon regions without latency justification
 
+## Named Anti-Patterns
+
+The starter anti-pattern set is weighted toward Security and Reliability, and sustainability-relevant entries live in the playbook of their primary pillar. When reviewing this pillar, explicitly check for these cross-pillar patterns and cite their IDs when they match:
+
+- **AP-COST-01: gp2 volumes where gp3 applies** (`cost-optimization.md`) — gp3 delivers the same baseline performance on more efficient infrastructure at lower cost; maps here to SUS05 (hardware and services selection).
+- **AP-PERF-01: No auto-scaling on stateless compute** (`performance-efficiency.md`) — fixed-size fleets hold idle capacity powered on around the clock; maps here to SUS02 (align cloud resources to demand).
+
 ## Sustainability-Specific Report Format
 
 When producing a pillar-scoped sustainability report, include:


### PR DESCRIPTION
Closes #133

## What changed

Adds a **Named Anti-Patterns** section to each of the 6 pillar playbooks under `skills/aws-well-architected-framework-review/references/pillar-playbooks/`, codifying the 10 highest-frequency WA failures from the issue's starter set. Each entry follows the proposed format:

- Stable ID (`AP-SEC-01` …) so findings can cite the pattern alongside the BP ID
- **Detect** — explicit heuristic with concrete Terraform / CloudFormation / CDK markers
- **Maps to** — canonical BP ID (verified against `references/manifest.md`), plus cross-pillar relations
- **Wrong / Right** — minimal Terraform pair, to be adapted to the workload's dialect and actual resource names

Distribution by primary pillar: SEC×4 (wildcard IAM → SEC03-BP02, public S3/BPA → SEC08-BP04, unencrypted at rest → SEC08-BP02, hardcoded secrets → SEC02-BP03), REL×3 (single-AZ RDS → REL10-BP01, no backups → REL09-BP01, async without DLQ → REL04-BP02), COST×1 (gp2→gp3 → COST06-BP02), PERF×1 (no auto-scaling → PERF02-BP05), OPS×1 (no alarms → OPS08-BP04).

Since each pillar subagent loads only its own playbook, the sustainability playbook gets explicit cross-references to AP-COST-01 and AP-PERF-01 (mapping them to SUS05/SUS02) rather than duplicated entries — same for the COST↔PERF relations.

## Drift guard

`powers/aws-well-architected-framework-review/steering/references/pillar-playbooks/` mirrored byte-identically in the same commit; verified locally with the CI drift-guard diff.

## Pillars

All six (starter set weighted toward Security and Reliability, per the issue).

## Notes

- Content-only change — no SKILL.md structural edits, as scoped in the issue.
- The wrong/right pairs are written to be directly reusable by the #134 **Fix:** block proposal.