### PR TITLE
feat(aws-well-architected-framework-review): inline IaC remediation snippets for High/Medium findings

### DIFF
--- a/adapters/antigravity/rules/aws-well-architected-framework-review.md
+++ b/adapters/antigravity/rules/aws-well-architected-framework-review.md
@@ -117,8 +117,8 @@ Structure:
 - Executive Summary (date, workload, criticality, lens, findings count, overall maturity 1-5)
 - Architecture Overview (PlantUML diagram)
 - Pillar Scorecard (table: pillar, score 1-5, key strength, key gap)
-- Critical and High Risk Findings (ID, pillar, title, evidence file:line, impact, recommendation, effort, AWS services)
-- Medium Risk Findings (condensed)
+- Critical and High Risk Findings (ID, pillar, title, evidence file:line, impact, recommendation, fix — ready-to-copy snippet in the workload's IaC dialect, AWS CLI when no IaC, report-only, effort, AWS services)
+- Medium Risk Findings (condensed, each with its fix snippet)
 - Low Risk Findings (summary table)
 - Cross-Pillar Trade-offs
 - Prioritized Remediation Plan (Quick Wins < 1 week, Foundation 1-4 weeks, Strategic 1-3 months)

--- a/adapters/claude-code/commands/aws-well-architected-framework-review.md
+++ b/adapters/claude-code/commands/aws-well-architected-framework-review.md
@@ -158,10 +158,10 @@ Output a structured report:
 | Sustainability | {score} | {strength} | {gap} |
 
 ## Critical and High Risk Findings
-{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, effort, AWS services}
+{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, **Fix:** block — a minimal ready-to-copy snippet in the workload's IaC dialect (AWS CLI when no IaC), using the actual resource names from the evidence; shown in the report only, never applied — effort, AWS services}
 
 ## Medium Risk Findings
-{Same format, condensed}
+{Same format, condensed — each finding still carries its **Fix:** block}
 
 ## Low Risk Findings
 {Summary table: ID | Pillar | Title | Recommendation}

--- a/adapters/cursor/rules/aws-well-architected-framework-review.md
+++ b/adapters/cursor/rules/aws-well-architected-framework-review.md
@@ -117,8 +117,8 @@ Structure:
 - Executive Summary (date, workload, criticality, lens, findings count, overall maturity 1-5)
 - Architecture Overview (PlantUML diagram)
 - Pillar Scorecard (table: pillar, score 1-5, key strength, key gap)
-- Critical and High Risk Findings (ID, pillar, title, evidence file:line, impact, recommendation, effort, AWS services)
-- Medium Risk Findings (condensed)
+- Critical and High Risk Findings (ID, pillar, title, evidence file:line, impact, recommendation, fix — ready-to-copy snippet in the workload's IaC dialect, AWS CLI when no IaC, report-only, effort, AWS services)
+- Medium Risk Findings (condensed, each with its fix snippet)
 - Low Risk Findings (summary table)
 - Cross-Pillar Trade-offs
 - Prioritized Remediation Plan (Quick Wins < 1 week, Foundation 1-4 weeks, Strategic 1-3 months)

--- a/powers/aws-well-architected-framework-review/steering/aws-well-architected-framework-review.md
+++ b/powers/aws-well-architected-framework-review/steering/aws-well-architected-framework-review.md
@@ -436,10 +436,10 @@ Empirical measurement shows this section is where recall reaches the user. Skipp
 {After writing this table, count the rows and confirm the count matches the sum of subagent rows. If not, you dropped citations — go back and add them.}
 
 ## Critical and High Risk Findings
-{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, effort, AWS services. This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
+{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, **Fix:** block — a minimal ready-to-copy snippet in the workload's IaC dialect (AWS CLI when no IaC), using the actual resource names from the evidence; shown in the report only, never applied — effort, AWS services. This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
 
 ## Medium Risk Findings
-{Same format, condensed. Also references ledger rows.}
+{Same format, condensed — each finding still carries its **Fix:** block. Also references ledger rows.}
 
 ## Low Risk Findings
 {Summary table: ID | Pillar | Title | Recommendation. Also references ledger rows.}

--- a/skills/aws-well-architected-framework-review/SKILL-devops-agent.md
+++ b/skills/aws-well-architected-framework-review/SKILL-devops-agent.md
@@ -110,6 +110,11 @@ For each infrastructure component, document:
 - Resilience configs (multi-AZ, backups, scaling)
 - Cost-relevant configs (instance types, capacity mode)
 
+Record the workload's **primary IaC dialect** (CDK, CloudFormation, Terraform, or
+SAM) — Step 6 emits a per-finding **Fix:** block in this dialect. When the
+workload has no IaC (on-premises or legacy), fix blocks fall back to AWS CLI
+commands or explicit configuration guidance.
+
 Create an architecture diagram in PlantUML showing major components, data flows,
 and trust boundaries.
 
@@ -369,11 +374,11 @@ paraphrase. Target row count: 250-307.
 subagent rows. If not, you dropped citations — go back and add them.}
 
 ## Critical and High Risk Findings
-{For each: ID, pillar, title, description, evidence, impact, recommendation, effort, AWS services.
+{For each: ID, pillar, title, description, evidence, impact, recommendation, **Fix:** block (see "Fix blocks" below), effort, AWS services.
  This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
 
 ## Medium Risk Findings
-{Same format, condensed.}
+{Same format, condensed — each finding still carries its **Fix:** block.}
 
 ## Low Risk Findings
 {Summary table: ID | Pillar | Title | Recommendation}
@@ -410,6 +415,24 @@ subagent rows. If not, you dropped citations — go back and add them.}
 ## Next Steps
 {Top 5 concrete actions from the "Do First" quadrant}
 ```
+
+### Fix blocks — ready-to-copy remediation snippets
+
+Every 🔴 Critical/High and 🟡 Medium finding in the report MUST include a **Fix:**
+block — a minimal, ready-to-copy remediation snippet:
+
+- **Language-matched.** Use the primary IaC dialect recorded in Step 2
+  (CDK / CloudFormation / Terraform / SAM); fall back to AWS CLI commands or
+  explicit configuration guidance when the workload has no IaC.
+- **Evidence-grounded.** Use the actual resource names and identifiers from the
+  finding's evidence — not generic placeholders — whenever the source is available.
+- **Minimal.** Only the lines needed to close the gap; elide unchanged
+  surrounding configuration with a comment.
+- **Report-only.** The fix appears in the report for the team to review and
+  apply. Do NOT apply it to the workload's codebase and do NOT emit it as a
+  diff/patch (repo design principle: review and guidance, not code mutation).
+- **Reuse anti-pattern examples.** When a finding matches a named anti-pattern
+  from the pillar playbooks, start from that entry's Right example.
 
 ## Calibration Guidance
 

--- a/skills/aws-well-architected-framework-review/SKILL-sequential.md
+++ b/skills/aws-well-architected-framework-review/SKILL-sequential.md
@@ -55,6 +55,8 @@ For each infrastructure component, document:
 - Resilience configs (multi-AZ, backups, scaling)
 - Cost-relevant configs (instance types, capacity mode)
 
+Record the workload's **primary IaC dialect** (CDK, CloudFormation, Terraform, or SAM) — Step 6 emits a per-finding **Fix:** block in this dialect. When the workload has no IaC, note that fix blocks will fall back to AWS CLI commands.
+
 You MUST create an architecture diagram in PlantUML showing:
 - All major components and their relationships
 - Data flows and external dependencies
@@ -465,10 +467,10 @@ Empirical measurement shows this section is where recall reaches the user. Skipp
 {After writing this table, count the rows and confirm the count matches the sum of per-pillar rows. If not, you dropped citations — go back and add them.}
 
 ## Critical and High Risk Findings
-{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, effort, AWS services. This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
+{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, **Fix:** block (see "Fix blocks" below), effort, AWS services. This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
 
 ## Medium Risk Findings
-{Same format, condensed. Also references ledger rows.}
+{Same format, condensed — each finding still carries its **Fix:** block. Also references ledger rows.}
 
 ## Low Risk Findings
 {Summary table: ID | Pillar | Title | Recommendation. Also references ledger rows.}
@@ -537,6 +539,28 @@ For each solution in "Do First" and "Plan":
 
 ## Next Steps
 {Top 5 concrete actions from the "Do First" quadrant — the team should start this week}
+```
+
+### Fix blocks — ready-to-copy remediation snippets
+
+Every 🔴 Critical/High and 🟡 Medium finding in the report MUST include a **Fix:** block — a minimal, ready-to-copy remediation snippet the user can apply themselves:
+
+- **Language-matched.** Emit the snippet in the primary IaC dialect recorded in Step 2 (CDK / CloudFormation / Terraform / SAM). When the workload has no IaC (e.g., a verbal review), fall back to equivalent AWS CLI commands.
+- **Evidence-grounded.** Use the actual resource names and identifiers from the finding's evidence — not generic placeholders — whenever the source is available.
+- **Minimal.** Only the lines needed to close the gap; elide unchanged surrounding configuration with a comment.
+- **Report-only.** The fix appears in the report for the user to review and apply. Do NOT apply it to the user's codebase and do NOT emit it as a diff/patch (repo design principle: review and guidance, not code mutation). The JSON artifact's `recommendation` field (Step 6b) stays prose-only; fix blocks live in the markdown report.
+- **Reuse anti-pattern examples.** When a finding matches a named anti-pattern from the pillar playbooks, start from that entry's Right example.
+- **Scope.** Applies to full and pillar-scoped reports. Score mode and quick review stay snippet-free, and the Full BP Ledger table stays snippet-free — fixes belong in the findings sections.
+
+Example (finding SEC08-BP02, Terraform workload, evidence `infra/rds.tf:12`):
+
+**Fix:**
+```hcl
+# infra/rds.tf — aws_db_instance.orders (line 12)
+resource "aws_db_instance" "orders" {
+  # ...existing configuration...
+  storage_encrypted = true
+}
 ```
 
 ## Step 6b: Emit structured output (`aws-well-architected-framework-review.json`)

--- a/skills/aws-well-architected-framework-review/SKILL.md
+++ b/skills/aws-well-architected-framework-review/SKILL.md
@@ -46,6 +46,8 @@ For each infrastructure component, document:
 - Resilience configs (multi-AZ, backups, scaling)
 - Cost-relevant configs (instance types, capacity mode)
 
+Record the workload's **primary IaC dialect** (CDK, CloudFormation, Terraform, or SAM) — Step 6 emits a per-finding **Fix:** block in this dialect. When the workload has no IaC, note that fix blocks will fall back to AWS CLI commands.
+
 You MUST create an architecture diagram in PlantUML showing:
 - All major components and their relationships
 - Data flows and external dependencies
@@ -456,10 +458,10 @@ Empirical measurement shows this section is where recall reaches the user. Skipp
 {After writing this table, count the rows and confirm the count matches the sum of subagent rows. If not, you dropped citations — go back and add them.}
 
 ## Critical and High Risk Findings
-{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, effort, AWS services. This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
+{For each: ID, pillar, title, description, evidence (file:line), impact assessment, recommendation, **Fix:** block (see "Fix blocks" below), effort, AWS services. This section EXPANDS on rows in the Full BP Ledger — it does NOT replace them.}
 
 ## Medium Risk Findings
-{Same format, condensed. Also references ledger rows.}
+{Same format, condensed — each finding still carries its **Fix:** block. Also references ledger rows.}
 
 ## Low Risk Findings
 {Summary table: ID | Pillar | Title | Recommendation. Also references ledger rows.}
@@ -528,6 +530,28 @@ For each solution in "Do First" and "Plan":
 
 ## Next Steps
 {Top 5 concrete actions from the "Do First" quadrant — the team should start this week}
+```
+
+### Fix blocks — ready-to-copy remediation snippets
+
+Every 🔴 Critical/High and 🟡 Medium finding in the report MUST include a **Fix:** block — a minimal, ready-to-copy remediation snippet the user can apply themselves:
+
+- **Language-matched.** Emit the snippet in the primary IaC dialect recorded in Step 2 (CDK / CloudFormation / Terraform / SAM). When the workload has no IaC (e.g., a verbal review), fall back to equivalent AWS CLI commands.
+- **Evidence-grounded.** Use the actual resource names and identifiers from the finding's evidence — not generic placeholders — whenever the source is available.
+- **Minimal.** Only the lines needed to close the gap; elide unchanged surrounding configuration with a comment.
+- **Report-only.** The fix appears in the report for the user to review and apply. Do NOT apply it to the user's codebase and do NOT emit it as a diff/patch (repo design principle: review and guidance, not code mutation). The JSON artifact's `recommendation` field (Step 6b) stays prose-only; fix blocks live in the markdown report.
+- **Reuse anti-pattern examples.** When a finding matches a named anti-pattern from the pillar playbooks, start from that entry's Right example.
+- **Scope.** Applies to full and pillar-scoped reports. Score mode and quick review stay snippet-free, and the Full BP Ledger table stays snippet-free — fixes belong in the findings sections.
+
+Example (finding SEC08-BP02, Terraform workload, evidence `infra/rds.tf:12`):
+
+**Fix:**
+```hcl
+# infra/rds.tf — aws_db_instance.orders (line 12)
+resource "aws_db_instance" "orders" {
+  # ...existing configuration...
+  storage_encrypted = true
+}
 ```
 
 ## Step 6b: Emit structured output (`aws-well-architected-framework-review.json`)

--- a/skills/aws-well-architected-framework-review/evals/evals.json
+++ b/skills/aws-well-architected-framework-review/evals/evals.json
@@ -71,7 +71,8 @@
         "BP IDs cited: SEC04 (detective controls/GuardDuty), SEC05 (network protection/WAF), REL10 (fault isolation/single-AZ RDS), and DLQ gap referenced as REL06 or REL07",
         "Risk assessment: no WAF = Medium, no GuardDuty = Medium, single-AZ RDS = High, no DLQ = High",
         "Eisenhower prioritization covers only the scoped findings",
-        "Pillar scorecard shows only Security and Reliability scores (not all 6)"
+        "Pillar scorecard shows only Security and Reliability scores (not all 6)",
+        "High Risk findings each include a Fix: block with a concrete remediation snippet (AWS CLI or IaC, since only a verbal description was provided) referencing the named resources (e.g., the metadata RDS instance, the SQS queue)"
       ]
     },
     {
@@ -104,6 +105,20 @@
         "Score mode is activated — output format is scorecard, not full review",
         "Depth filter is respected — only Critical and High findings shown",
         "All 6 pillars receive a score even though findings are filtered"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Review the Security and Reliability pillars of this Terraform workload:\n\n```hcl\nresource \"aws_s3_bucket\" \"uploads\" {\n  bucket = \"acme-uploads\"\n}\n\nresource \"aws_db_instance\" \"orders\" {\n  engine                  = \"postgres\"\n  instance_class          = \"db.t3.medium\"\n  backup_retention_period = 0\n}\n\nresource \"aws_iam_role_policy\" \"app\" {\n  role   = aws_iam_role.app.id\n  policy = jsonencode({\n    Version   = \"2012-10-17\"\n    Statement = [{ Effect = \"Allow\", Action = \"*\", Resource = \"*\" }]\n  })\n}\n```",
+      "expected_output": "A pillar-scoped Security + Reliability review whose High/Medium findings each include a ready-to-copy Fix: block written in Terraform (the workload's IaC dialect), referencing the actual resource names from the input.",
+      "assertions": [
+        "Every High Risk finding includes a Fix: block containing a syntactically plausible Terraform (HCL) snippet — not CloudFormation, CDK, or bare CLI",
+        "Fix blocks reference the actual resource identifiers from the input (aws_s3_bucket.uploads / acme-uploads, aws_db_instance.orders, aws_iam_role_policy.app), not generic placeholders",
+        "The wildcard IAM policy is flagged (SEC03) with a fix narrowing Action and Resource to least privilege",
+        "The disabled backup retention is flagged (REL09) with a fix setting backup_retention_period to a value greater than 0",
+        "The bucket's missing public-access block or missing encryption at rest is flagged (SEC08) with a corresponding Terraform fix resource",
+        "Fix snippets are presented in the report only — the response does not claim to have modified or applied changes to the user's files",
+        "The review stays scoped to Security and Reliability — no findings for the other four pillars"
       ]
     }
   ]

--- a/steering/aws-well-architected-framework-review.md
+++ b/steering/aws-well-architected-framework-review.md
@@ -629,10 +629,10 @@ Compile all analyses into a comprehensive report.
 | Sustainability | {score} | {strength} | {gap} |
 
 ## Critical and High Risk Findings
-{For each finding: ID, pillar, title, description, evidence (file:line), impact, recommendation, effort, AWS services}
+{For each finding: ID, pillar, title, description, evidence (file:line), impact, recommendation, **Fix:** block — a minimal ready-to-copy snippet in the workload's IaC dialect (AWS CLI when no IaC), using the actual resource names from the evidence; shown in the report only, never applied — effort, AWS services}
 
 ## Medium Risk Findings
-{Same format, condensed}
+{Same format, condensed — each finding still carries its **Fix:** block}
 
 ## Low Risk Findings
 {Summary table only}


### PR DESCRIPTION
Closes #134

## What changed

Adds a required **Fix:** block to every 🔴 Critical/High and 🟡 Medium finding in the review report — a minimal, ready-to-copy remediation snippet.

### Rules (new `Fix blocks` subsection in Step 6)

- **Language-matched** — Step 2 discovery now records the workload's primary IaC dialect (CDK / CloudFormation / Terraform / SAM); Step 6 emits fixes in that dialect, falling back to AWS CLI when no IaC exists.
- **Evidence-grounded** — fixes use the actual resource names/identifiers from the finding's evidence, not generic placeholders.
- **Minimal** — only the lines needed to close the gap.
- **Report-only** — never applied to the user's codebase, never a diff/patch (design principle: *review and guidance, not code mutation*). The JSON artifact's `recommendation` field stays prose-only.
- **Anti-pattern reuse** — when a finding matches a named anti-pattern (#133 / #136), the entry's *Right* example is the fix skeleton.
- Score mode / quick review / the Full BP Ledger table stay snippet-free.

### Surfaces kept in sync

`SKILL.md`, `SKILL-sequential.md`, `SKILL-devops-agent.md` (CLI/config-guidance fallback for on-prem workloads), `steering/aws-well-architected-framework-review.md` **and** its Kiro Power copy, plus the claude-code / cursor / antigravity adapter report templates — all five files carrying the findings field-list were extended identically.

### Evals

- New case 7: a Terraform workload with a public bucket, `backup_retention_period = 0`, and a wildcard IAM policy — asserts High findings carry syntactically plausible **HCL** fixes referencing `aws_s3_bucket.uploads`, `aws_db_instance.orders`, `aws_iam_role_policy.app`, and that the response never claims to have modified the user's files.
- Case 4 gains a CLI-fallback fix-block assertion (verbal workload, no IaC).
- `uv run pytest -m "not eval" -q` → 72 passed.

## Pillars

All six (report plumbing).

## Notes

- Skill frontmatter `version` left untouched to avoid conflicts with the other in-flight PRs — bump on merge as part of the release.
- Playbook seeding (issue step 2) lands via #136; the wrong/right pairs there are directly reusable as fix skeletons, as anticipated in the issue.