### PR TITLE
feat(aws-well-architected-framework-review): optional confirmation-gated tracking-issue output mode

### DIFF
--- a/skills/aws-well-architected-framework-review/SKILL-sequential.md
+++ b/skills/aws-well-architected-framework-review/SKILL-sequential.md
@@ -632,6 +632,32 @@ After delivering the report, offer:
 > - Generate automated checks (Config rules, custom metrics) for ongoing compliance?
 > - Set up a continuous WA gate: commit `aws-well-architected-framework-review.json` as a baseline and run `tools/wa-ci` in CI?
 > - Produce a WA Tool import for tracking in the AWS console?
+> - File the 🔴/🟡 findings as tracking issues with a summary epic? (Step 7b — offer only when an issue tracker CLI is available)
+
+## Step 7b: File findings as tracking issues (optional — confirmation-gated)
+
+An optional output mode that turns report findings into tracked work so the report does not go stale. **Never run it automatically** — it is gated behind one explicit user confirmation per review, and the default is no (design principle: keep the user in control).
+
+**Tracker detection.** Before offering, check that an issue tracker is actually reachable: `gh` CLI first (`gh auth status` succeeds and the workload repo has a GitHub remote); another tracker only if the runtime exposes an equivalent tool. If none is available, skip silently — do not offer — and add one line to the report footer: `Tracking-issue filing skipped — no issue tracker CLI available.`
+
+**Ask once** (only when a tracker is available), as part of the Step 7 offer:
+
+> Shall I file these findings as tracking issues? I would create one issue per 🔴 Critical/High and 🟡 Medium finding, plus one summary epic with a prioritized checklist. Low and Cannot Determine items stay in the report only. (default: no)
+
+**If — and only if — the user confirms**, create:
+
+1. **One issue per 🔴 Critical/High and 🟡 Medium finding**
+   - Title: `[WA][<PILLAR>] <finding title>` (e.g., `[WA][SEC] Uploads bucket lacks Block Public Access`)
+   - Body: severity, BP ID in canonical `SEC01-BP02` format (or the lens + finding title when the lens exposes no BP ID), the evidence citation (file:line), and the remediation next step from the report — including its **Fix:** block when present.
+2. **One summary epic**
+   - Title: `[WA] Well-Architected review — {workload name} ({date})`
+   - Body: the pillar scorecard table plus a checklist linking every finding issue (`- [ ] #<n> …`), grouped by Eisenhower quadrant (Do First → Plan → Delegate → Defer).
+
+**Rules:**
+- Issues are review artifacts, not code changes — bodies carry guidance and fix snippets to copy, never applied diffs.
+- Do not add labels, assignees, or milestones unless the user asks — leave triage to the team.
+- Do not file Low or Cannot Determine rows (tracker noise); they remain in the report.
+- When done, list the created issue URLs and note the epic as the tracking entry point.
 
 ## Calibration Guidance
 

--- a/skills/aws-well-architected-framework-review/SKILL.md
+++ b/skills/aws-well-architected-framework-review/SKILL.md
@@ -623,6 +623,32 @@ After delivering the report, offer:
 > - Generate automated checks (Config rules, custom metrics) for ongoing compliance?
 > - Set up a continuous WA gate: commit `aws-well-architected-framework-review.json` as a baseline and run `tools/wa-ci` in CI?
 > - Produce a WA Tool import for tracking in the AWS console?
+> - File the 🔴/🟡 findings as tracking issues with a summary epic? (Step 7b — offer only when an issue tracker CLI is available)
+
+## Step 7b: File findings as tracking issues (optional — confirmation-gated)
+
+An optional output mode that turns report findings into tracked work so the report does not go stale. **Never run it automatically** — it is gated behind one explicit user confirmation per review, and the default is no (design principle: keep the user in control).
+
+**Tracker detection.** Before offering, check that an issue tracker is actually reachable: `gh` CLI first (`gh auth status` succeeds and the workload repo has a GitHub remote); another tracker only if the runtime exposes an equivalent tool. If none is available, skip silently — do not offer — and add one line to the report footer: `Tracking-issue filing skipped — no issue tracker CLI available.`
+
+**Ask once** (only when a tracker is available), as part of the Step 7 offer:
+
+> Shall I file these findings as tracking issues? I would create one issue per 🔴 Critical/High and 🟡 Medium finding, plus one summary epic with a prioritized checklist. Low and Cannot Determine items stay in the report only. (default: no)
+
+**If — and only if — the user confirms**, create:
+
+1. **One issue per 🔴 Critical/High and 🟡 Medium finding**
+   - Title: `[WA][<PILLAR>] <finding title>` (e.g., `[WA][SEC] Uploads bucket lacks Block Public Access`)
+   - Body: severity, BP ID in canonical `SEC01-BP02` format (or the lens + finding title when the lens exposes no BP ID), the evidence citation (file:line), and the remediation next step from the report — including its **Fix:** block when present.
+2. **One summary epic**
+   - Title: `[WA] Well-Architected review — {workload name} ({date})`
+   - Body: the pillar scorecard table plus a checklist linking every finding issue (`- [ ] #<n> …`), grouped by Eisenhower quadrant (Do First → Plan → Delegate → Defer).
+
+**Rules:**
+- Issues are review artifacts, not code changes — bodies carry guidance and fix snippets to copy, never applied diffs.
+- Do not add labels, assignees, or milestones unless the user asks — leave triage to the team.
+- Do not file Low or Cannot Determine rows (tracker noise); they remain in the report.
+- When done, list the created issue URLs and note the epic as the tracking entry point.
 
 ## Calibration Guidance
 


### PR DESCRIPTION
Closes #135

## What changed

Adds **Step 7b: File findings as tracking issues (optional — confirmation-gated)** to `SKILL.md` and `SKILL-sequential.md`, plus a matching bullet in the Step 7 follow-up offer.

### Behavior (as proposed in the issue)

1. After report delivery, ask the user **once** — default is **no**. Never automatic.
2. On yes, using the detected tracker (`gh` CLI first; other trackers only if the runtime exposes them):
   - One issue per 🔴 Critical/High and 🟡 Medium finding — title `[WA][<PILLAR>] <finding>`, body with severity, canonical BP ID (`SEC01-BP02` format, or lens + title when the lens exposes no BP ID), evidence citation, and the remediation next step (including the finding's **Fix:** block when present, once #137 lands).
   - One summary epic — pillar scorecard table + checklist linking the finding issues, grouped by Eisenhower quadrant.
3. If no tracker is available: skip silently, note it in the report footer.

### Design constraints honored

- **Confirmation-gated, never automatic** — one explicit ask per review; keeps the user in control.
- **Artifacts, not mutations** — issue bodies carry guidance/snippets to copy, never applied diffs.
- **Runtime-dependent, graceful degradation** — detection before offering; footer note when unavailable; **omitted entirely from `SKILL-devops-agent.md`** per the issue (that variant is autonomous with no interactive checkpoints).
- Low / Cannot Determine rows are deliberately not filed, to avoid tracker noise.

## Pillars

All six (output plumbing, not pillar content).

## Notes

- Skill frontmatter `version` left untouched to avoid conflicts with the other in-flight PRs (#136, #137) — bump on merge.
- `uv run pytest -m "not eval" -q` → 72 passed (no eval harness changes in this PR).