### PR TITLE
fix(evals): keep the OpenAI-compatible API key out of logged error strings (CodeQL alert #1)

### DIFF
--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -90,13 +90,21 @@ def _openai_compatible_request(endpoint: str, body: dict, api_key: str, timeout:
     """Send a bearer-authenticated request to an OpenAI-compatible endpoint."""
     import requests as req
 
-    response = req.post(
-        endpoint,
-        json=body,
-        headers={"Authorization": f"Bearer {api_key}"},
-        timeout=timeout,
-    )
-    response.raise_for_status()
+    try:
+        response = req.post(
+            endpoint,
+            json=body,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+    except req.RequestException as e:
+        # requests exceptions can embed the prepared request, whose
+        # Authorization header carries the API key, and callers log str(e).
+        # Re-raise with a message built only from non-sensitive parts.
+        status = getattr(getattr(e, "response", None), "status_code", None)
+        detail = f" (HTTP {status})" if status else ""
+        raise RuntimeError(f"{type(e).__name__} calling {endpoint}{detail}") from None
     return response.json()
 
 


### PR DESCRIPTION
Remediates [code-scanning alert #1](https://github.com/aws-samples/sample-well-architected-skills-and-steering/security/code-scanning/1) — `py/clear-text-logging-sensitive-data` (high), open on `main` since 2026-08-05.

## The flow

`api_key = os.getenv(...)` (`evals/benchmark.py:117`) → `Authorization: Bearer` header inside `_openai_compatible_request` → a `requests` exception raised from `req.post` can embed the prepared request (a malformed key literally appears in `InvalidHeader` messages) → `str(e)` is stored in `result['error']` → printed by the runner at line 640.

## The fix

Catch `requests.RequestException` at the request boundary and re-raise a `RuntimeError` whose message is built **only from non-sensitive parts**: exception type name, endpoint URL, and HTTP status code. `from None` drops the original exception so no traceback/context can carry the header either. Non-request exceptions (e.g. JSON decode) are unaffected, and callers keep the same `except Exception` contract — error strings still say what failed and where, just never the credential.

`uv run pytest -m "not eval" -q` → 72 passed.

The CodeQL analysis on this PR should confirm the alert closes; the sibling `_mantle_request` path signs with SigV4 headers via the same `requests` library — if CodeQL later flags it, the same boundary pattern applies.