### PR TITLE
feat(plugins): adopt Agent Plugins 1.0.0 (add root plugin.json) (#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ evals/                              Automated evaluation runner (Bedrock)
   benchmark_config.yaml               Models, prompt, and grading criteria
   pyproject.toml                      Dependencies (use uv sync)
 
+plugin.json                         Agent Plugins 1.0.0 manifest (portable plugin package)
 install.sh                          One-command setup (macOS/Linux)
 install.ps1                         One-command setup (Windows PowerShell)
 ```
@@ -155,6 +156,17 @@ curl -sL .../bootstrap.sh | bash -s -- --tool kiro
 # Windows (PowerShell)
 & ([scriptblock]::Create((irm .../bootstrap.ps1))) -Tool kiro
 ```
+
+#### Via Agent Plugins
+
+This repo is a conformant [Agent Plugins 1.0.0](https://agent-plugins.org/) package: the root [`plugin.json`](plugin.json) manifest wraps the `skills/` core (each `skills/*/SKILL.md` already carries valid [Agent Skills](https://agentskills.io/) frontmatter) into a single portable plugin. Clients that ship a native Agent Plugins loader can install directly from the repository:
+
+```bash
+# Point your Agent Plugins-compatible client at the repository
+https://github.com/aws-samples/sample-well-architected-skills-and-steering
+```
+
+This path is **additive** and does not replace the adapters or install scripts. The plugin is intentionally MCP-free (`mcp.json` is optional in the spec) because the skills read static pillar files rather than calling a server. Kiro-specific behavior (`powers/` and the Kiro agent config) is homed under the `extensions["dev.kiro"]` namespace, keeping the portable core clean. Tool-specific steering and rules translations (`.cursor/rules/`, `.windsurfrules`, `CLAUDE.md`, `.clinerules`, `GEMINI.md`, Copilot instructions) remain in `adapters/`, since they target formats outside the Agent Plugins ecosystem.
 
 ### Install script (from local clone)
 

--- a/llms.txt
+++ b/llms.txt
@@ -57,6 +57,7 @@ powers/         → Kiro Powers (bundled installable units with contextual activ
 assets/         → Reference material (best practices, metrics, patterns)
 adapters/       → Tool-specific packaging (Claude Code, Cursor, Kiro, OpenClaw, etc.)
 evals/          → Automated evaluation runner (Amazon Bedrock)
+plugin.json     → Agent Plugins 1.0.0 manifest (portable plugin package)
 install.sh      → Setup script for macOS/Linux
 install.ps1     → Setup script for Windows
 ```

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "aws-well-architected",
+  "version": "6.4.0",
+  "description": "Well-Architected skills and steering for AI coding agents: full and pillar-scoped Well-Architected reviews, guardrails, migration readiness, and guided build assistance across all 6 pillars.",
+  "author": {
+    "name": "AWS",
+    "url": "https://github.com/aws-samples"
+  },
+  "homepage": "https://github.com/aws-samples/sample-well-architected-skills-and-steering",
+  "repository": "https://github.com/aws-samples/sample-well-architected-skills-and-steering",
+  "license": "MIT-0",
+  "keywords": [
+    "aws",
+    "well-architected",
+    "operational-excellence",
+    "security",
+    "reliability",
+    "performance-efficiency",
+    "cost-optimization",
+    "sustainability"
+  ],
+  "extensions": {
+    "dev.kiro": {
+      "powers": "./powers",
+      "agent": "./adapters/kiro-cli/agents/well-architected.json"
+    }
+  }
+}


### PR DESCRIPTION
Closes #143.

## What
Adds a conformant [Agent Plugins 1.0.0](https://agent-plugins.org/) manifest (`plugin.json`) at the repo root, making this repository a first-class portable plugin layered on top of the [Agent Skills](https://agentskills.io/) frontmatter every `skills/*/SKILL.md` already carries.

## Why
This repo's premise is "one source of truth, many tools." Agent Plugins is the vendor-neutral interoperability floor for exactly that, and its steering committee includes AWS, so being an early conformant example is on-mission for an `aws-samples` repo. We were already ~90% conformant; the only missing piece was the root manifest.

## Design
Fully **additive** per the issue's accepted approach. Adapters, install scripts, and the deliberate no-MCP design are unchanged:
- The `adapters/` layer is **not** replaced. Those targets (`.cursor/rules/`, `.windsurfrules`, `CLAUDE.md`, `.clinerules`, `GEMINI.md`, Copilot instructions) are steering/rules translations for formats **outside** the Agent Plugins ecosystem, which standardizes only the `skills/` core for conformant clients.
- `mcp.json` is omitted (optional in the spec) since the skills read static pillar files rather than calling a server.
- Kiro-specific behavior (`powers/` and the Kiro agent config) is homed under `extensions["dev.kiro"]`, keeping the portable core clean (issue's optional item 3).

## On the version field
The issue's example used `2.3.0`, but that is the `aws-well-architected-framework-review` **skill's** version, not the repo's. `plugin.json` describes the whole bundle, and this repo's only repo-level version signal is its git tags (`vX.Y.Z`, currently `v6.3.1`). Since this manifest ships as an additive feature, by the repo's own tag convention (feat = minor bump) it lands as **`6.4.0`**. Please adjust if this release is cut differently.

Follow-up suggestion: add a small CI drift-guard (this repo already uses that pattern) asserting `plugin.json` `version` matches the latest release tag, so it cannot silently drift.

## Changes
- `plugin.json` (new): required `$schema` + `name`, plus recommended `version`, `description`, `author`, `homepage`, `repository`, `license` (MIT-0), `keywords`, and the `extensions["dev.kiro"]` namespace. Validated against the 1.0.0 schema (name pattern, `$schema` const, extension values are objects).
- `README.md`: new "Via Agent Plugins" install path; `plugin.json` listed in the repo structure.
- `llms.txt`: `plugin.json` listed in the architecture tree.

No skill content, adapters, or installers changed.